### PR TITLE
Changes to Minié ball ammo

### DIFF
--- a/Recipe/c_recipes.json
+++ b/Recipe/c_recipes.json
@@ -1458,20 +1458,19 @@
     "result": "flintlock_ammo_mine",
     "type": "recipe",
     "category": "CC_AMMO",
-    "subcategory": "CSC_AMMO_BULLETS",
+    "subcategory": "CSC_AMMO_RIFLE",
     "skill_used": "fabrication",
     "difficulty": 3,
     "skills_required": [ "gun", 1 ],
-    "time": 50000,
-    "reversible": false,
-    "autolearn": false,
+    "time": 800,
+    "batch_time_factors": [ 50, 10 ],
     "book_learn": [ [ "manual_rifle", 2 ], [ "manual_pistol", 2 ], [ "recipe_bullets", 2 ], [ "recipe_surv", 2 ] ],
-    "qualities": [ { "id": "CUT", "level": 1, "amount": 1 } ],
-    "tools": [ [ [ "soldering_iron", 25 ], [ "toolset", 25 ] ] ],
+    "charges": 1,
+    "using": [ [ "ammo_bullet", 15 ] ],
+    "qualities": [ { "id": "CUT", "level": 1 } ],
     "components": [
-      [ [ "gunpowder", 600 ], [ "chem_black_powder", 1200 ] ],
-      [ [ "lead", 400 ], [ "gold_small", 400 ], [ "silver_small", 400 ], [ "tin", 400 ], [ "bismuth", 400 ], [ "solder_wire", 400 ] ],
-      [ [ "bag_plastic", 1 ], [ "paper", 10 ] ]
+      [ [ "chem_black_powder", 5 ], [ "gunpowder", 5 ] ],
+      [ [ "paper", 1 ] ]
     ]
   },
   {

--- a/Weapons/c_ammo.json
+++ b/Weapons/c_ammo.json
@@ -1,24 +1,14 @@
 [
   {
     "id": "flintlock_ammo_mine",
+    "copy-from": "flintlock_ammo",
     "type": "AMMO",
-    "name": "Paper Minie ball cartridge",
+    "name": "paper Minie ball cartridge",
     "//": "meant as a companion to the Survivor's Flintlock Sniper.",
     "description": "A paper cartridge containing black powder and a Minie ball.  A paper enclosed version of the historic projectile of the USA Civil war. The Minie ball is still as deadly and accurate as ever.",
-    "weight": 86,
-    "volume": 2,
+    "weight": 55,
     "price": 5000,
-    "to_hit": 0,
-    "bashing": 1,
-    "material": [ "steel", "powder" ],
-    "symbol": "=",
-    "color": "white",
-    "count": 25,
-    "ammo_type": "flintlock",
-    "range": 25,
-    "damage": 50,
-    "dispersion": 100,
-    "recoil": 350,
-    "effects": [ "COOKOFF" ]
+    "proportional": { "dispersion": 0.89 },
+    "relative": { "recoil": 300, "range": 19 }
   }
 ]


### PR DESCRIPTION
* Makes it actually more accurate, as intended. Also gave it more recoil, though this doesn't do much for game balance given most flintlock guns in the game are single-shot.
* Implemented copy-from to futureproof stuff.
* Changed recipe to be consistent with how current flintlock ammo is set up. Also made it use more lead, based off some poking around trying to get data on Minié ball loads along with trying to figure out what the hell the in-game flintlock even is (my money's on a .69, more likely to be a musket than a rifle) using weaponized math.