### PR TITLE
Change material of heavy suit

### DIFF
--- a/Surv_help/c_armor.json
+++ b/Surv_help/c_armor.json
@@ -286,7 +286,7 @@
     "price": 400000,
     "to_hit": -3,
     "bashing": 5,
-    "material": [ "kevlar", "leather" ],
+    "material": [ "kevlar", "steel" ],
     "symbol": "[",
     "color": "dark_gray",
     "covers": [ "HEAD", "TORSO", "ARMS", "HANDS", "LEGS", "FEET" ],


### PR DESCRIPTION
Something I forgot in last PR, per @BorkBorkGoesTheCode's suggestion. Reasonably certain kevlar/steel is his recommended materials to use in the heavy military suit, though unsure what the final thickness should be.