### PR TITLE
Major Dialogue Enhancements

### DIFF
--- a/Npc/TALK_BFF.json
+++ b/Npc/TALK_BFF.json
@@ -3,12 +3,12 @@
     "id": "TALK_BFF",
     "type": "talk_topic",
     "dynamic_line": {
-      "u_male": "Holy shit man, you are still alive?! I am glad, I thought I was going to have to deal with all this alone. We got this place far away and are safe for now. Its now you and me like old times!",
-      "u_female": "Holy shit girl, you are still alive?! I am glad, I thought I was going to have to deal with all this alone. We got this place far away and are safe for now. Its now you and me like old times!"
+      "u_male": "Holy shit man, you are still alive?! I'm glad, I thought I was going to have to deal with all this alone. We got this place far away and are safe for now. It's now you and me, just like old times!",
+      "u_female": "Holy shit girl, you are still alive?! I'm glad, I thought I was going to have to deal with all this alone. We got this place far away and are safe for now. It's now you and me, just like old times!"
     },
     "responses": [
       {
-        "text": "Glad to see you too buddy, let us go now!",
+        "text": "Glad to see you too buddy, let's go now!",
         "trial": { "type": "NONE" },
         "success": {
           "effect": "follow",

--- a/Npc/TALK_BHUNTER.json
+++ b/Npc/TALK_BHUNTER.json
@@ -10,20 +10,16 @@
     "responses": [
       {
         "text": "Yeah, I am one of them.",
-        "topic": "TALK_BHUNTER_IAM_BIO"
+        "topic": "TALK_BHUNTER_IAM_BIO",
+        "condition": { "u_has_any_trait": [ "BIO_WEAPON_ALPHA", "BIO_WEAPON_BETA", "BIO_WEAPON_GAMMA", "BIO_WEAPON_DELTA", "BIO_WEAPON_FAILED", "SUPER_SOLDIER_MARKER" ] }
       },
       {
         "text": "Bio-Weapon?",
-        "trial": { "type": "NONE" },
-        "success": {
-          "opinion": {
-            "trust": 0,
-            "fear": -1,
-            "value": -1,
-            "anger": 0
-          },
-          "topic": "TALK_BHUNTER_ASK_BIO"
-        }
+        "topic": "TALK_BHUNTER_ASK_BIO"
+      },
+      {
+        "text": "What's going on out here?",
+        "topic": "TALK_BHUNTER_ASK_SITUATION"
       },
       {
         "text": "What are you doing here?",
@@ -44,6 +40,65 @@
     ]
   },
   {
+    "id": "TALK_BHUNTER_ASK_SITUATION",
+    "type": "talk_topic",
+    "dynamic_line": "Not good.  I had another person with me when I arrived, and he was guarding the vehicle when those things showed up.  Luckily they seemed reluctant to barge into the bunker, and things are getting hectic out there as it seems my buddy took a couple of them out before he bit it, and they started getting back up...",
+    "responses": [
+      {
+        "text": "What are those things?",
+        "topic": "TALK_BHUNTER_THINGS"
+      },
+      {
+        "text": "I see.",
+        "topic": "TALK_BHUNTER"
+      }
+    ]
+  },
+  {
+    "id": "TALK_BHUNTER_THINGS",
+    "type": "talk_topic",
+    "dynamic_line": {
+      "u_has_any_trait": [ "BIO_WEAPON_FAILED" ],
+      "yes": "Bio-Weapons.  At least they were supposed to be.  In fact, you look like you're in the same shape as them, though you're not trying to kill me at least.  Can I trust you?",
+      "no": "Bio-Weapons.  At least they were supposed to be.  I don't know what went wrong or who's ordering them around, but they seem hell-bent on destroying everything connected to the project."
+    },
+    "responses": [
+      {
+        "text": "I'm not one of them.  You can trust me.",
+        "condition": { "u_has_any_trait": [ "BIO_WEAPON_FAILED" ] },
+        "topic": "TALK_BHUNTER"
+      },
+      {
+        "text": "I don't want to end up like those things.  I don't want to become a monster, please...",
+        "trial": { "type": "NONE" },
+        "success": {
+          "opinion": {
+            "fear": -1,
+            "trust": 1
+          },
+        "topic": "TALK_BHUNTER_THINGS_FAILED"
+        },
+        "condition": { "u_has_any_trait": [ "BIO_WEAPON_FAILED" ] }
+      },
+      {
+        "text": "I see.",
+        "condition": { "not": { "u_has_any_trait": [ "BIO_WEAPON_FAILED" ] } },
+        "topic": "TALK_BHUNTER"
+      }
+    ]
+  },
+  {
+    "id": "TALK_BHUNTER_THINGS_FAILED",
+    "type": "talk_topic",
+    "dynamic_line": "It's alright.  I'm not going to hurt you.  I'll trust you, and you can trust me as well.",
+    "responses": [
+      {
+        "text": "Thank you.",
+        "topic": "TALK_BHUNTER"
+      }
+    ]
+  },
+  {
     "id": "TALK_BHUNTER_IAM_BIO",
     "type": "talk_topic",
     "dynamic_line": {
@@ -53,8 +108,94 @@
     },
     "responses": [
       {
-        "text": "I'll keep that in mind...",
+        "text": "I can prove it.  Project Mesektet, First Series, external designation RD-Z-01.",
+        "topic": "TALK_BHUNTER_CONFIRM_BIO",
+        "condition": { "u_has_any_trait": [ "BIO_WEAPON_ALPHA", "BIO_WEAPON_BETA", "BIO_WEAPON_GAMMA", "BIO_WEAPON_DELTA" ] }
+      },
+      {
+        "text": "You don't recognize this aug configuration, Hunter?",
+        "topic": "TALK_BHUNTER_CONFIRM_OUST",
+        "condition": { "u_has_any_trait": [ "SUPER_SOLDIER_MARKER" ] }
+      },
+      {
+        "text": "Look at me again, and tell me I'm lying.",
+        "condition": { "u_has_any_trait": [ "BIO_WEAPON_FAILED" ] },
+        "trial": { "type": "NONE" },
+        "success": {
+          "opinion": {
+            "fear": 1
+          },
+          "topic": "TALK_BHUNTER_CONFIRM_FAILED"
+        }
+      },
+      {
+        "text": "I'm not wearing mine.",
+        "topic": "TALK_BHUNTER_NOBADGE",
+        "condition": { "not": { "u_is_wearing": "badge_bio_weapon" } }
+      },
+      {
+        "text": "...",
         "topic": "TALK_BHUNTER"
+      }
+    ]
+  },
+  {
+    "id": "TALK_BHUNTER_CONFIRM_BIO",
+    "type": "talk_topic",
+    "dynamic_line": "Project... you're right.  Between that and your augmentations, it's hard to deny the evidence right in front of me.  Sorry I doubted you.",
+    "responses": [
+      {
+        "text": "It's fine.",
+        "trial": { "type": "NONE" },
+        "success": {
+          "opinion": {
+            "trust": 1,
+            "fear": -1,
+            "value": 1,
+            "anger": -1
+          },
+          "topic": "TALK_BHUNTER"
+        }
+      }
+    ]
+  },
+  {
+    "id": "TALK_BHUNTER_CONFIRM_FAILED",
+    "type": "talk_topic",
+    "dynamic_line": "Alright, you're right.  Looks like they really did a number on you.  I'm sorry they did this to you.",
+    "responses": [
+      {
+        "text": "...",
+        "topic": "TALK_BHUNTER"
+      }
+    ]
+  },
+  {
+    "id": "TALK_BHUNTER_CONFIRM_OUST",
+    "type": "talk_topic",
+    "dynamic_line": "Shit.  Seems it's harder to hide than I thought.  They sent me to investigate what happened to these installations, re-establish contact with any remaining personnel or bio-weapons that haven't gone rogue, then see what can be done from there.  I don't know what your last orders were or why you're here, but maybe we have a common goal.",
+    "responses": [
+      {
+        "text": "We'll see.",
+        "topic": "TALK_BHUNTER"
+      }
+    ]
+  },
+  {
+    "id": "TALK_BHUNTER_NOBADGE",
+    "type": "talk_topic",
+    "dynamic_line": "I'd say you're full of shit, but looking at you, those are some heavy-duty augs.  I don't know if you decided not to wear it, or if you lost yours, but either way I appreciate your honestly.",
+    "responses": [
+      {
+        "text": "Thank you.",
+        "trial": { "type": "NONE" },
+        "success": {
+          "opinion": {
+            "trust": 1,
+            "value": 1
+          },
+          "topic": "TALK_BHUNTER"
+        }
       }
     ]
   },
@@ -120,7 +261,55 @@
     "dynamic_line": "I used to be a computer hacker before the world went to hell.  After it did, when I wasn't looking for food and gear or fighting for my life, I was following leads to this place.  The military weren't all that good at keeping their secrets.",
     "responses": [
       {
+        "text": "You seem rather well-equiped for a mere hacker.",
+        "condition": { "u_has_intelligence": 11 },
+        "trial": {
+          "type": "PERSUADE",
+          "difficulty": 3
+        },
+        "success": {
+          "topic": "TALK_BHUNTER_ADMIT",
+          "opinion": {
+            "trust": 1
+          }
+        },
+        "failure": {
+          "topic": "TALK_BHUNTER_DENY",
+          "opinion": {
+            "trust": -1,
+            "anger": 1
+          }
+        }
+      },
+      {
+        "text": "Right. Research Directive Z-12 ring a bell to you, Hunter?",
+        "topic": "TALK_BHUNTER_CONFIRM_OUST",
+        "condition": { "u_has_any_trait": [ "SUPER_SOLDIER_MARKER" ] }
+      },
+      {
         "text": "I see.",
+        "topic": "TALK_BHUNTER"
+      }
+    ]
+  },
+  {
+    "id": "TALK_BHUNTER_ADMIT",
+    "type": "talk_topic",
+    "dynamic_line": "You're right.  I'd rather not talk too much about the details, but I'm on a mission to find out what happened and get in touch with anyone still alive.",
+    "responses": [
+      {
+        "text": "Got it.",
+        "topic": "TALK_BHUNTER"
+      }
+    ]
+  },
+  {
+    "id": "TALK_BHUNTER_DENY",
+    "type": "talk_topic",
+    "dynamic_line": "Scavenged the kit along the way.  I wouldn't still be alive if I wasn't both resourceful and lucky.",
+    "responses": [
+      {
+        "text": "...",
         "topic": "TALK_BHUNTER"
       }
     ]
@@ -146,6 +335,21 @@
     "dynamic_line": "I came here to see if I could find anything on the Bio-Weapons. How about yourself?",
     "responses": [
       {
+        "text": "I don't have any orders, and don't remember much from before I woke up.  Had anything in mind?",
+        "topic": "TALK_MISSION_OFFER",
+        "condition": { "u_has_any_trait": [ "BIO_WEAPON_ALPHA", "BIO_WEAPON_BETA", "BIO_WEAPON_GAMMA", "BIO_WEAPON_DELTA" ] }
+      },
+      {
+        "text": "Sounds like a good start, don't have any other standing orders to follow.  What have you got for me?",
+        "topic": "TALK_MISSION_OFFER",
+        "condition": { "u_has_any_trait": [ "SUPER_SOLDIER_MARKER" ] }
+      },
+      {
+        "text": "I don't know what to do with myself.  What do you need done?",
+        "topic": "TALK_MISSION_OFFER",
+        "condition": { "u_has_any_trait": [ "BIO_WEAPON_FAILED" ] }
+      },
+      {
         "text": "I have no idea.",
         "topic": "TALK_BHUNTER"
       }
@@ -161,31 +365,5 @@
         "topic": "TALK_BHUNTER"
       }
     ]
-  },
-  {
-    "id": "TALK_BHUNTER_ASK_QUEST",
-    "type": "talk_topic",
-    "dynamic_line": {
-      "u_is_wearing": "badge_bio_weapon",
-      "yes": "Sure!  Not just anybody gets to wear that badge.  Fake or not, you're a good fighter from what I've seen.  It'll be easier with somebody to watch my back.  Also, there is something that I want to ask later if you have time.",
-      "no": "Well, I'm running low on supplies and the fact that you made it here proves you can handle yourself.  Also, there is something that I want to ask later if you have time."
-    },
-    "responses": [
-      {
-        "text": "Let's go, then.",
-        "trial": { "type": "NONE" },
-        "success": {
-          "effect": "follow",
-          "opinion": {
-            "trust": 8,
-            "fear": 0,
-            "value": 8,
-            "anger": -2
-          },
-          "topic": "TALK_DONE"
-        }
-      }
-    ],
-    "//": "This Talk topic is no longer used"
   }
 ]

--- a/Npc/TALK_BIO_1.json
+++ b/Npc/TALK_BIO_1.json
@@ -36,7 +36,27 @@
     },
     "responses": [
       {
+        "text": "I'm in the same boat, it seems.",
+        "topic": "TALK_BIO_1_IAM_BIO",
+        "condition": { "u_has_any_trait": [ "BIO_WEAPON_ALPHA", "BIO_WEAPON_BETA", "BIO_WEAPON_GAMMA", "BIO_WEAPON_DELTA", "BIO_WEAPON_FAILED", "SUPER_SOLDIER_MARKER" ] }
+      },
+      {
         "text": "Well, damn.",
+        "topic": "TALK_BIO_1"
+      }
+    ]
+  },
+  {
+    "type": "talk_topic",
+    "id": "TALK_BIO_1_IAM_BIO",
+    "dynamic_line": {
+      "u_is_wearing": "badge_bio_weapon",
+      "yes": "Looks about right.  Can be hard to tell for sure if that's your badge or not, but they contracted the work out to all sorts of weirdos, and they made all sorts of crazy shit. They could slap the Bio-Weapon label on a zombie swinging around a sword and it still wouldn't be the strangest thing out there.",
+      "no": "I'm not sure whether to believe you or not, without the badge and all.  But whatever, no telling whether you lost yours or maybe you decided on not advertising it for everyone to see.  Given those bastards cranked out everything from super soldiers to a giant cat Bio-Weapon to fucking Apophis, nothing would suprise me at this point."
+    },
+    "responses": [
+      {
+        "text": "...",
         "topic": "TALK_BIO_1"
       }
     ]
@@ -49,50 +69,6 @@
       {
         "text": "Must be tough...",
         "topic": "TALK_BIO_1"
-      }
-    ]
-  },
-  {
-    "type": "talk_topic",
-    "//": "This Talk topic is no lobger used",
-    "id": "TALK_BIO_1_JOIN",
-    "dynamic_line": {
-      "u_is_wearing": "badge_bio_weapon",
-      "yes": "I am listening...",
-      "no": "An offer, huh?  Well, might as well hear it."
-    },
-    "responses": [
-      {
-        "text": "Why don't you join me?  There are plenty of things out there to be killed.  You wouldn't have to hide anymore.  And we could go after Apophis...",
-        "topic": "TALK_BIO_1_JOIN2"
-      }
-    ]
-  },
-  {
-    "type": "talk_topic",
-    "//": "This Talk topic is no lobger used",
-    "id": "TALK_BIO_1_JOIN2",
-    "dynamic_line": {
-      "u_is_wearing": "badge_bio_weapon",
-      "yes": "Heh, guess that badge of yours isn't just for show.  You really think we can take Apophis...?  I really want to leave this place.  Alright, you've got yourself a deal!",
-      "no": "So you know about Apophis, then?  Hm... well, if I go with you, I get to have some fun again.  Sure, I'll tag along..."
-    },
-    "responses": [
-      {
-        "text": "Things are going to be different from now on.",
-        "trial": {
-          "type": "NONE"
-        },
-        "success": {
-          "topic": "TALK_DONE",
-          "effect": "follow"
-        },
-        "opinion": {
-          "trust": 8,
-          "fear": 0,
-          "value": 8,
-          "anger": -2
-        }
       }
     ]
   }

--- a/Npc/TALK_BIO_2.json
+++ b/Npc/TALK_BIO_2.json
@@ -36,7 +36,63 @@
     },
     "responses": [
       {
+        "text": "Same here.",
+        "topic": "TALK_BIO_2_IAM_BIO",
+        "condition": { "u_has_any_trait": [ "BIO_WEAPON_ALPHA", "BIO_WEAPON_BETA", "BIO_WEAPON_GAMMA", "BIO_WEAPON_DELTA" ] }
+      },
+      {
         "text": "I see.",
+        "topic": "TALK_BIO_2"
+      }
+    ]
+  },
+  {
+    "id": "TALK_BIO_2_IAM_BIO",
+    "type": "talk_topic",
+    "dynamic_line": {
+      "u_is_wearing": "badge_bio_weapon",
+      "yes": "Huh.  Surprised there are any more of us out there.  First Series even, I bet.  My pal and I were part of Series Seven.  Far as I know, most of the ones between yours and mine have probably been wiped out or joined Apophis.",
+      "no": "I find it hard to believe that.  Without one of these badges, how am I supposed to tell you aren't just some well-kitted-out scavenger?"
+    },
+    "responses": [
+      {
+        "text": "What do you know about the other Bio-Weapons?",
+        "condition": { "u_is_wearing": "badge_bio_weapon" },
+        "topic": "TALK_BIO_2_INFO"
+      },
+      {
+        "text": "Project Mesektet, First Series.  Sound familiar?",
+        "topic": "TALK_BIO_2_CONFIRM_BIO",
+        "condition": { "not": { "u_is_wearing": "badge_bio_weapon" } }
+      },
+      {
+        "text": "Nevermind then.",
+        "topic": "TALK_BIO_2"
+      }
+    ]
+  },
+  {
+    "id": "TALK_BIO_2_CONFIRM_BIO",
+    "type": "talk_topic",
+    "dynamic_line": "Huh.  Guess you are one of them after all..  Seventh Series here, along with my friend over there.  No idea if any from Series 2 to 6 are left.",
+    "responses": [
+      {
+        "text": "Know anything about the others?",
+        "topic": "TALK_BIO_2_INFO"
+      },
+      {
+        "text": "Right.",
+        "topic": "TALK_BIO_2"
+      }
+    ]
+  },
+  {
+    "id": "TALK_BIO_2_INFO",
+    "type": "talk_topic",
+    "dynamic_line": "Not much.  They made us in batches, a different bunch of eggheads contracted out for each Series.  Your bunch was the most well-known, pioneered the concepts that influenced all the others.  All the others varied in quality considerably.  Ours was the seventh batch, last bunch of full-on Bio-Weapons made.  Think there were another five afterward, Super Soldiers, Bio-Weapon Hunters, etc.  Then the last one was Apophis.  Figures, lucky number thirteen...",
+    "responses": [
+      {
+        "text": "...",
         "topic": "TALK_BIO_2"
       }
     ]
@@ -51,47 +107,5 @@
         "topic": "TALK_BIO_2"
       }
     ]
-  },
-  {
-    "id": "TALK_BIO_2_JOIN",
-    "type": "talk_topic",
-    "dynamic_line": {
-      "u_is_wearing": "badge_bio_weapon",
-      "yes": "I... are you sure?  I can help with combat, but I might just be a burden overall... besides, we can't make it until we deal with the reason we're stuck here in the first place.",
-      "no": "I'd like to, but I'm not sure I could survive out there.  I know how to fight, but what about water and food?  And we wouldn't be safe, not until..."
-    },
-    "responses": [
-      {
-        "text": "Listen.  I can help you out, I survived out there this far, so I know what I'm doing. Just lend me a hand against the undead and I'll take care of the rest.  And as for Apophis, we'll take it down, eventually.  Besides, wouldn't it be better than staying here, doing nothing?",
-        "topic": "TALK_BIO_2_JOIN2"
-      }
-    ],
-    "//": "This Talk topic is no lobger used"
-  },
-  {
-    "id": "TALK_BIO_2_JOIN2",
-    "type": "talk_topic",
-    "dynamic_line": {
-      "u_is_wearing": "badge_bio_weapon",
-      "yes": "...You know what?  I am tired of being stuck here.  You're right, together we can survive out there and Apophis is going down!",
-      "no": "...You're right, I can't just hide here forever.  I'm coming with you.  You obviously know what you're talking about, so I can rely on your help.  Let's hope we kill that thing one day!"
-    },
-    "responses": [
-      {
-        "text": "That's the spirit!",
-        "trial": { "type": "NONE" },
-        "success": {
-          "effect": "follow",
-          "opinion": {
-            "trust": 8,
-            "fear": 0,
-            "value": 8,
-            "anger": -2
-          },
-          "topic": "TALK_DONE"
-        }
-      }
-    ],
-    "//": "This Talk topic is no longer used"
   }
 ]

--- a/Npc/TALK_MSCI.json
+++ b/Npc/TALK_MSCI.json
@@ -52,7 +52,7 @@
   {
     "id": "TALK_MSCI_BIO_WHO",
     "type": "talk_topic",
-    "dynamic_line": "That would be Sigma and Lambda.  They are very confused.  They awoke with their memory gone and they knew they were 'different'.  I found them and they helped to scavenge and build this place.  They were built for combat;  I can tell they're bored out of their minds...",
+    "dynamic_line": "That would be Sigma and Lambda.  They are very confused.  They awoke with their memory gone and only knew they were 'different'.  I found them and they helped to scavenge and build this place.  They were built for combat;  I can tell they're bored out of their minds...",
     "responses": [
       {
         "text": "I'll keep on eye out for them.",
@@ -91,8 +91,38 @@
     "type": "talk_topic",
     "dynamic_line": {
       "u_is_wearing": "badge_bio_weapon",
-      "yes": "You have that badge, you should know how powerful those things are.  Apophis could take them all at once.  Have you seen a Zombie Hulk?  They wouldn't even scratch it.  Worse still, there are some rejects from Bio-Weapon program that have sided with him. This is why we are hiding here.",
+      "yes": "You have that badge, you should know how powerful those things are.  Apophis could take them all at once.  Have you seen a zombie hulk?  They couldn't even scratch it.  Worse still, there are some rejects from Bio-Weapon program that have sided with him. This is why we are hiding here.",
       "no": "Ha!  You really have no idea, do you?  Have you ever fought a Bio-Weapon?  How about those failed versions?  Tough, right?  They have nothing on Apophis.  It's incredibly durable thanks to its armor and its heavy weaponry is a step above other Bio-Weapons.  Apophis is far more dangerous than any ordinary enemy."
+    },
+    "responses": [
+      {
+        "text": "I'm one of the originals it seems.  It's going to come after me anyway, so why not fight it?",
+        "topic": "TALK_MSCI_APOPHIS_ORIGINAL",
+        "condition": { "u_has_any_trait": [ "BIO_WEAPON_ALPHA", "BIO_WEAPON_BETA", "BIO_WEAPON_GAMMA", "BIO_WEAPON_DELTA" ] }
+      },
+      {
+        "text": "Failure or not, I'm not one of those monsters.  There has to be something I can do.",
+        "topic": "TALK_MSCI_APOPHIS_FAILED",
+        "condition": { "u_has_any_trait": [ "BIO_WEAPON_FAILED" ] }
+      },
+      {
+        "text": "Dealing with this mess is what I was created for.",
+        "topic": "TALK_MSCI_APOPHIS_SOLDIER",
+        "condition": { "u_has_any_trait": [ "SUPER_SOLDIER_MARKER" ] }
+      },
+      {
+        "text": "...",
+        "topic": "TALK_MSCI"
+      }
+    ]
+  },
+  {
+    "id": "TALK_MSCI_APOPHIS_ORIGINAL",
+    "type": "talk_topic",
+    "dynamic_line": {
+      "u_is_wearing": "badge_bio_weapon",
+      "yes": "That you may be, but while you've been stuck in stasis, the other research teams had been poring over every last scrap of data they could get out of your production.  Even if it was two steps forward, one step back, Apophis is the culmination of all that research.  I know you might be eager to fight, but we need to prepare ourselves.",
+      "no": "Hmm, maybe I was wrong about judging you based on your lack of a badge.  If you are who you claim to be, then know this.  Apophis is the culmination of all the research that came from your creation.  I know you might be eager to fight, but we need to be ready."
     },
     "responses": [
       {
@@ -102,70 +132,34 @@
     ]
   },
   {
-    "id": "TALK_MSCI_ASK_DO",
+    "id": "TALK_MSCI_APOPHIS_FAILED",
     "type": "talk_topic",
     "dynamic_line": {
       "u_is_wearing": "badge_bio_weapon",
-      "yes": "Well.  Only one thing comes to mind.  You were a part of the program, too, so you might have a chance.  There is a map in the locker.  It has the coordinates to the laboratory Apophis uses as its base.  I want you to take it down, rid the world of Apophis!  Take Lambda and Sigma with you, if you want.  That lab has a lot of valuable equipment left inside - if you manage to kill that thing, it's all yours.  ...I wish we could do it ourselves, but between the portal breakthroughs, the bombs and  the undead, the chance has been lost.",
-      "no": "Help?  Well... there is one thing.  If you feel up for it, grab the map from the locker;  it marks the lab where Apophis resides.  If you think you can kill the damn thing, anything left inside is yours.  Take Lambda and Sigma with you, if you want.  I don't really expect you to take the offer, but since you've asked..."
+      "yes": "I know you're eager to prove yourself, but that doesn't require throwing your life away.  That thing is tailor-made to kill Bio-Weapons and anyone else that gets in his way.  You don't have to prove yourself just because others have joined him.  I know I can trust you.",
+      "no": "Huh.  Maybe that's why you're not wearing the badge.  I think I can trust you.  I wish the others had been given the same chance you have now, and that Apophis hadn't gotten to them first.  But if you take him on unprepared, you'll just be throwing your life away needlessly."
     },
     "responses": [
       {
-        "text": "I'll take care of this.",
-        "trial": { "type": "NONE" },
-        "success": {
-          "opinion": {
-            "trust": 1,
-            "fear": 2,
-            "value": 3,
-            "anger": 0
-          },
-          "topic": "TALK_MSCI_THANKS"
-        }
-      },
-      {
-        "text": "It seems like too much for me...",
-        "trial": { "type": "NONE" },
-        "success": {
-          "opinion": {
-            "trust": 0,
-            "fear": -2,
-            "value": -2,
-            "anger": 0
-          },
-          "topic": "TALK_MSCI_NOTHANKS"
-        }
+        "text": "...",
+        "topic": "TALK_MSCI"
       }
-    ],
-    "//": "This Talk topic is no lobger used"
+    ]
   },
   {
-    "id": "TALK_MSCI_THANKS",
+    "id": "TALK_MSCI_APOPHIS_SOLDIER",
     "type": "talk_topic",
     "dynamic_line": {
       "u_is_wearing": "badge_bio_weapon",
-      "yes": "You're sure about this?  Thank you... that means a lot, you know.  Be sure to bring some proof, be creative.  I'll be waiting for your return.",
-      "no": "I appreciate the sentiment but I didn't mean it.  I don't expect you to just give up your life like this.  Thanks anyway, though.  That being said, the map is still there if you want it."
+      "yes": "And that thing was created to kill you, the orginal Bio-Weapons, and anything else that gets in the way.  That's why it got the designation Apophis, pretty much opened ourselves up for that when we went with Project Mesektet for the codename.",
+      "no": "If you're really one of the super soldiers, then you should know hiding your badge won't prevent Apophis from figuring you out.  That thing was designed to hunt Bio-Weapons and Super Soldiers alike."
     },
     "responses": [
       {
-        "text": "Now for the map...",
+        "text": "...",
         "topic": "TALK_MSCI"
       }
-    ],
-    "//": "This Talk topic is no lobger used"
-  },
-  {
-    "id": "TALK_MSCI_NOTHANKS",
-    "type": "talk_topic",
-    "dynamic_line": "I understand.  It's practically a lost cause at this point.  I'll keep trying to figure something out to stop it.",
-    "responses": [
-      {
-        "text": "Sorry.",
-        "topic": "TALK_MSCI"
-      }
-    ],
-    "//": "This Talk topic is no lobger used"
+    ]
   },
   {
     "id": "TALK_MSCI_ASK_STAY",


### PR DESCRIPTION
* Minor text improvements in BFF conversation.
* Reworked Evelyn Rose's dialogue to make much more use of response conditions. Now the player can only claim to be a bio-weapon if they are one (or a super-soldier), and their reponses can confirm that depending on what type they are, along with a response for if they are one
* Can oust Evelyn Rose, and doing so is easier if the player is also a super soldier of some sort. This builds on the idea that "she's a bio-weapon hunter" implies she's a similar sort as the bio-weapon hunter profession.
* Can ask about the situation, establishing the reason for the failed bio-weapons outside and the parked vehicle. Dialogue and available responses changes if the player's a failed bio-weapon.
* Added to Lambda's dialogue. She can end up giving a little extra info on the other bio-weapons if the player is one of the ones from the Bio-Weapon Lab scenario, referencing some lore ideas that came up in other writing with Noct.
* Added to Sigma's dialogue, players with bio-weapon-related traits can admit to being a bio-weapon, getting a snarky response from Sigma and references to writing with Noct and others.
* Added to Router's dialogue, players with bio-weapon-related traits can further press Router about the "what's so dangerous about Apophis" dialogue, getting further admonishment from him about being properly prepared to deal with him.