### PR TITLE
Minor improvements

### DIFF
--- a/Char_creation/c_classes_bw.json
+++ b/Char_creation/c_classes_bw.json
@@ -154,11 +154,10 @@
       "NIGHTVISION",
       "PSYCHOPATH",
       "CLUMSY",
-      "THRESH_CHIMERA",
       "EATDEAD",
       "SHOUT3",
       "EATHEALTH",
-      "PRED4",
+      "PRED2",
       "BIO_WEAPON_ALPHA"
     ],
     "skills": [ { "level": 5, "name": "dodge" }, { "level": 5, "name": "melee" }, { "level": 5, "name": "unarmed" } ],
@@ -316,7 +315,7 @@
     "name": "Bio-Weapon Gamma",
     "description": "'The Mechanic', created to sabotage, destroy, assimilate or repair bio-technology.  You are a walking, adaptive repair machine.  You awoke to the sounds of machines fighting abominations.  You could help them, or destroy them, if they get in your way.",
     "points": 8,
-    "traits": [ "PROF_MED", "PSYCHOPATH", "INT_UP_2", "GOODMEMORY", "FASTLEARNER", "FASTREADER", "BIO_WEAPON_GAMMA" ],
+    "traits": [ "PROF_MED", "PSYCHOPATH", "LOVES_BOOKS", "GOODMEMORY", "FASTLEARNER", "FASTREADER", "BIO_WEAPON_GAMMA" ],
     "skills": [
       { "level": 5, "name": "firstaid" },
       { "level": 5, "name": "electronics" },

--- a/Npc/NC_SUPER_SOLDIERS.json
+++ b/Npc/NC_SUPER_SOLDIERS.json
@@ -54,7 +54,7 @@
   {
     "id": "NC_BIO_HUNTER_F_worn",
     "type": "item_group",
-    "//": "Evelynn Rose's kit, mimics player version except for some concessions to using claw mutation instead of CBM.",
+    "//": "Evelynn Rose's kit, mimics player version except for some concessions to using claw mutation instead of CBM, and a MOLLE pack to ensure she can carry items as quest fodder, instead of handing you her P90.",
     "subtype": "collection",
     "entries": [
       { "item": "bra" },
@@ -85,7 +85,10 @@
       { "item": "militarymap" },
       { "item": "fnp90mag" },
       { "item": "fnp90mag" },
-      { "item": "fnp90mag" }
+      { "item": "fnp90mag" },
+      { "group": "everyday_gear" },
+      { "group": "drugs_soldier", "prob": 50 },
+      { "group": "supplies_electronics", "prob": 50, "count": [ 1, 3 ] }
     ]
   },
   {

--- a/Recipe/c_recipes.json
+++ b/Recipe/c_recipes.json
@@ -1551,5 +1551,10 @@
     "qualities": [ { "id": "CHEM", "level": 2 } ],
     "tools": [ [ [ "surface_heat", 31, "LIST" ] ] ],
     "components": [ [ [ "mutagen", 1 ] ], [ [ "egg_reptile", 1 ] ], [ [ "egg_bird", 1 ] ], [ [ "ammonia", 1 ], [ "lye_powder", 100 ] ] ]
+  },
+  {
+    "result": "badge_bio_weapon",
+    "type": "uncraft",
+    "copy-from": "badge_cybercop"
   }
 ]


### PR DESCRIPTION
* Couple random items for Evelynn Rose to hand out instead of her
fucking gun, along with a backpack to ensure she can carry it.
* Allow breaking apart bio-weapon badges into silver.
* Downgraded Alphas's Apex Predator to Hunter, as the intelligence
penalty has weird effects in character generation.
* Removed Chaos threshold for UI reasons, after confirming it still
permits starting with Eater of The Dead without it. Leaving the fungal
failed bio-weapon with Mycus is both fine UI-wise and vital, as it makes
sense for Mycus to override that, plus it needs the threshold to
function.
* Replaced Gamma's Very Smart mutation with Bookworm, as the int bonus
likewise has weird effects if you switch professions during chargen.