### PR TITLE
Assorted changes

### DIFF
--- a/Recipe/c_recipes.json
+++ b/Recipe/c_recipes.json
@@ -1555,6 +1555,8 @@
   {
     "result": "badge_bio_weapon",
     "type": "uncraft",
-    "copy-from": "badge_cybercop"
+    "time": 500,
+    "qualities": [ { "id": "HAMMER", "level": 1 } ],
+    "components": [ [ [ "silver_small", 20 ] ] ]
   }
 ]

--- a/Surv_help/c_bionics.json
+++ b/Surv_help/c_bionics.json
@@ -17,7 +17,7 @@
     "sight_dispersion": 150,
     "aim_speed": 0,
     "durability": 10,
-    "modes": [ [ "DEFAULT", "auto", 20 ] ],
+    "modes": [ [ "DEFAULT", "auto", 5 ] ],
     "reload": 500,
     "ammo_effects": [ "LASER", "INCENDIARY" ],
     "flags": [ "NEVER_JAMS", "TRADER_AVOID" ]
@@ -26,10 +26,11 @@
     "type": "bionic",
     "id": "bio_laser_armgun",
     "name": "Laser Gatling Arm",
+    "//": "To be re-added if this ever gets accessible in JSON: However, you are unable to use or carry two-handed items, and your strength limits what you can use with your one hand.",
     "occupied_bodyparts": [ [ "ARM_L", 20 ], [ "HAND_L", 5 ] ],
-    "act_cost": 100,
+    "act_cost": 50,
     "fake_item": "bio_laser_minigun",
-    "description": "Your left arm has been replaced by a rapid fire laser gatling gun!  You may use your energy banks to fire a barrage of lasers.  However, you are unable to use or carry two-handed items, and your strength limits what you can use with your one hand.",
+    "description": "Your left arm has been outfitted with a complex array of rotating laser projectors.  Or in layman's terms, a laser gatling gun!  You may use your energy banks to fire a barrage of lasers.",
     "flags": [ "BIONIC_GUN" ]
   },
   {
@@ -37,7 +38,7 @@
     "copy-from": "bionic_general",
     "type": "BIONIC_ITEM",
     "name": "Laser Gatling Arm CBM",
-    "description": "Your left arm has been replaced by a rapid fire laser gatling gun!  You may use your energy banks to fire a barrage of lasers.  However, you are unable to use or carry two-handed items, and your strength limits what you can use with your one hand.",
+    "description": "Your left arm has been outfitted with a complex array of rotating laser projectors.  Or in layman's terms, a laser gatling gun!  You may use your energy banks to fire a barrage of lasers.",
     "price": 220000,
     "difficulty": 3
   },

--- a/Terrain/makeshift_command_center.json
+++ b/Terrain/makeshift_command_center.json
@@ -6,7 +6,7 @@
     "weight": 1000,
     "object": {
       "rows": [
-        "F,,,,,,,,,,,,,,,,,,,,,,F",
+        "F,,,==,,,,,,,,,,,,,,,,,F",
         "!!!!!!!!!!!<<!!!!!!!!!!!",
         "!Wbaaaa.f|K..|.....6T.Z!",
         "!........|>//|.ppp._..Z!",
@@ -16,7 +16,7 @@
         "!..&CC&..||++|||||++|||!",
         "!........|....|HH{..{mm!",
         "!........+....|_......{!",
-        "!eD.....=|....+......mm!",
+        "!eD......|....+......mm!",
         "!|||++||||....+..._...{!",
         "!........+....|_.....mm!",
         "!........+....|.......{!",
@@ -111,19 +111,19 @@
         { "x": 1, "y": 22 }
       ],
       "place_items": [
-        { "item": "stash_food", "x": 8, "y": 1, "chance": 85, "repeat": [ 10, 15 ] },
-        { "item": "textbooks", "x": 17, "y": 14, "chance": 85, "repeat": [ 2, 5 ] },
-        { "item": "textbooks", "x": 17, "y": 8, "chance": 85, "repeat": [ 2, 5 ] },
-        { "item": "farming_seeds", "x": 7, "y": [ 19, 20 ], "chance": 85, "repeat": [ 6, 12 ] },
-        { "item": "farming_seeds", "x": 7, "y": [ 15, 16 ], "chance": 85, "repeat": [ 6, 12 ] },
-        { "item": "allclothes", "x": 22, "y": 13, "chance": 85, "repeat": [ 5, 10 ] },
-        { "item": "allclothes", "x": 22, "y": 11, "chance": 85, "repeat": [ 5, 10 ] },
-        { "item": "allclothes", "x": 22, "y": 9, "chance": 85, "repeat": [ 5, 10 ] },
-        { "item": "tools_common", "x": 20, "y": 8, "chance": 85, "repeat": [ 8, 12 ] },
-        { "item": "science", "x": 22, "y": [ 18, 20 ], "chance": 85, "repeat": [ 5, 10 ] },
-        { "item": "surgery", "x": 22, "y": [ 18, 20 ], "chance": 85, "repeat": [ 5, 10 ] },
-        { "item": "sketchy_cabin_weapons", "x": 20, "y": 14, "chance": 90, "repeat": [ 5, 15 ] },
-        { "item": "farming_tools", "x": 13, "y": [ 20, 22 ], "chance": 60, "repeat": [ 5, 10 ] }
+        { "item": "stash_food", "x": 8, "y": 1, "chance": 85, "repeat": 12 },
+        { "item": "textbooks", "x": 17, "y": 14, "chance": 75, "repeat": 4 },
+        { "item": "textbooks", "x": 17, "y": 8, "chance": 75, "repeat": 4 },
+        { "item": "farming_seeds", "x": 7, "y": [ 19, 20 ], "chance": 75, "repeat": 8 },
+        { "item": "farming_seeds", "x": 7, "y": [ 15, 16 ], "chance": 75, "repeat": 8 },
+        { "item": "allclothes", "x": 22, "y": 13, "chance": 80, "repeat": 7 },
+        { "item": "allclothes", "x": 22, "y": 11, "chance": 80, "repeat": 7 },
+        { "item": "allclothes", "x": 22, "y": 9, "chance": 80, "repeat": 7 },
+        { "item": "tools_common", "x": 20, "y": 8, "chance": 80, "repeat": 10 },
+        { "item": "science", "x": 22, "y": [ 18, 20 ], "chance": 60, "repeat": 8 },
+        { "item": "surgery", "x": 22, "y": [ 18, 20 ], "chance": 75, "repeat": 7 },
+        { "item": "sketchy_cabin_weapons", "x": 20, "y": 14, "chance": 50, "repeat": 10 },
+        { "item": "farming_tools", "x": 13, "y": [ 20, 22 ], "chance": 50, "repeat": 7 }
       ],
       "add": [
         { "item": "ulmap", "x": 22, "y": 20, "repeat": 1 },
@@ -148,7 +148,7 @@
         { "class": "main_bio_sci", "x": 20, "y": 22 },
         { "class": "bio_weapon_1", "x": 22, "y": 10 },
         { "class": "bio_weapon_2", "x": 22, "y": 14 },
-        { "class": "cmnd_guard_1", "x": 15, "y": 5 },
+        { "class": "cmnd_guard_1", "x": 15, "y": 6 },
         { "class": "cmnd_guard_2", "x": 19, "y": 4 }
       ]
     }


### PR DESCRIPTION
* Fixed bio-weapon badges turning into nothing when uncrafted. Turns out
that that feature doesn't work despite it being used, and for all I know
it may have never worked.
* Some changes to itemgroup spawns in the makeshift command center, as
varible-repeat is now WAY less predictable. Oughta fix up the other
locations sometime.
* Replaced the command center's indoor charcoal smoker with a pair
outdoors, as using it for non-recipe smoking indoors is a Bad Idea.
* Moved that one guard a step down so they aren't in the middle of the
walking path.
* Rebalanced and reworded the laser gatling gun, because sadly "takes up
an arm" is hardcoded into the fusion blaster arm. Main effects are
reducing cost to 50 and burst size to 50, sae as fusion blaster (which
has more damag). Power per activation is consumed on a per-shot basics
when full-auto is involved, so that's a burst of laser shots for 250
power vs "dump 2000 power and one target dies instantly"