### PR TITLE
Updates for bio-weapon lab, NPCs, and zombie super soldiers

### DIFF
--- a/Monsters/c_monsters.json
+++ b/Monsters/c_monsters.json
@@ -287,7 +287,7 @@
     "special_when_hit": [ "ZAPBACK", 60 ],
     "anger_triggers": [ "FRIEND_DIED", "FRIEND_ATTACKED", "HURT" ],
     "death_drops": "wild_bio_infantry",
-    "death_function": [ "NORMAL" ],
+    "death_function": [ "NORMAL", "SPLATTER" ],
     "flags": [
       "SEES",
       "REGENERATES_10",
@@ -298,7 +298,6 @@
       "CBM_POWER",
       "CBM_OP",
       "NO_BREATHE",
-      "REVIVES",
       "BONES"
     ]
   },
@@ -354,7 +353,7 @@
     "special_when_hit": [ "ZAPBACK", 60 ],
     "anger_triggers": [ "FRIEND_DIED", "FRIEND_ATTACKED", "HURT" ],
     "death_drops": "wild_bio_knight",
-    "death_function": [ "NORMAL" ],
+    "death_function": [ "NORMAL", "SPLATTER" ],
     "flags": [
       "SEES",
       "REGENERATES_10",
@@ -365,7 +364,6 @@
       "CBM_POWER",
       "CBM_OP",
       "NO_BREATHE",
-      "REVIVES",
       "BONES"
     ]
   },
@@ -422,7 +420,7 @@
     "special_when_hit": [ "ZAPBACK", 60 ],
     "anger_triggers": [ "FRIEND_DIED", "FRIEND_ATTACKED", "HURT" ],
     "death_drops": "wild_bio_scout",
-    "death_function": [ "NORMAL" ],
+    "death_function": [ "NORMAL", "SPLATTER" ],
     "flags": [
       "SEES",
       "REGENERATES_10",
@@ -433,7 +431,6 @@
       "CBM_POWER",
       "CBM_OP",
       "NO_BREATHE",
-      "REVIVES",
       "BONES"
     ]
   },
@@ -489,7 +486,7 @@
     "special_when_hit": [ "ZAPBACK", 60 ],
     "anger_triggers": [ "FRIEND_DIED", "FRIEND_ATTACKED", "HURT" ],
     "death_drops": "wild_bio_tool",
-    "death_function": [ "NORMAL" ],
-    "flags": [ "SEES", "HEARS", "SMELLS", "POISON", "BASHES", "CBM_POWER", "CBM_TECH", "NO_BREATHE", "REVIVES", "BONES" ]
+    "death_function": [ "NORMAL", "SPLATTER" ],
+    "flags": [ "SEES", "HEARS", "SMELLS", "POISON", "BASHES", "CBM_POWER", "CBM_TECH", "NO_BREATHE", "BONES" ]
   }
 ]

--- a/Npc/c_npc.json
+++ b/Npc/c_npc.json
@@ -19,7 +19,7 @@
     "class": "NC_PREPPER",
     "attitude": 0,
     "mission": 7,
-    "chat": "TALK_SHELTER",
+    "chat": "TALK_STRANGER_NEUTRAL",
     "faction": "preppers"
   },
   {
@@ -28,9 +28,9 @@
     "comment": "Use as a random NPC encounter",
     "name_suffix": "Prepper",
     "class": "NC_PREPPER",
-    "attitude": 0,
-    "mission": 0,
-    "chat": "TALK_SHELTER",
+    "attitude": 1,
+    "mission": 7,
+    "chat": "TALK_STRANGER_NEUTRAL",
     "faction": "preppers"
   },
   {
@@ -121,7 +121,7 @@
     "gender": "male",
     "class": "NC_SLAVE_FIGHTER_RED",
     "attitude": 10,
-    "mission": 0,
+    "mission": 7,
     "chat": "TALK_DONE",
     "faction": "slave_fighter"
   },
@@ -133,7 +133,7 @@
     "gender": "male",
     "class": "NC_SLAVE_FIGHTER_BLUE",
     "attitude": 3,
-    "mission": 0,
+    "mission": 7,
     "chat": "TALK_DONE",
     "faction": "slave_fighter_allied"
   }

--- a/Terrain/Bio_Weapon_Lab.json
+++ b/Terrain/Bio_Weapon_Lab.json
@@ -8,7 +8,7 @@
       "rows": [
         "F,,,,,,,,,C,,,,,,,,,,,,F",
         "|||||||||||dd|||||||||||",
-        "|&&&{{{{{.C....{{{{{&&&|",
+        "|&&&LLLLL.C....LLLLL&&&|",
         "|&&&................&&&|",
         "|6....................6|",
         "|6..sSs..........sSs..6|",
@@ -43,6 +43,7 @@
         "D": "t_door_o",
         "E": "t_elevator_control_off",
         "F": "t_chainfence_v",
+        "L": "t_metal_floor",
         "S": "t_station_disc",
         "T": "t_metal_floor",
         "U": "t_metal_floor",
@@ -63,6 +64,7 @@
       "furniture": {
         "#": "f_chair",
         "A": "f_autodoc",
+        "L": "f_locker",
         "T": "f_trashcan",
         "U": "f_autodoc_couch",
         "b": "f_bench",
@@ -75,12 +77,12 @@
       },
       "place_toilets": [ { "x": 1, "y": 10 }, { "x": 22, "y": 10 } ],
       "place_items": [
-        { "item": "fridge", "x": 22, "y": [ 17, 19 ], "chance": 90, "repeat": [ 1, 5 ] },
-        { "item": "fridge", "x": 1, "y": [ 17, 19 ], "chance": 80, "repeat": [ 1, 5 ] },
-        { "item": "oven", "x": 22, "y": 20, "chance": 80, "repeat": [ 1, 5 ] },
-        { "item": "oven", "x": 1, "y": 20, "chance": 80, "repeat": [ 1, 5 ] },
-        { "item": "science", "x": [ 15, 19 ], "y": 2, "chance": 90, "repeat": [ 1, 5 ] },
-        { "item": "science", "x": [ 4, 8 ], "y": 2, "chance": 90, "repeat": [ 1, 5 ] },
+        { "item": "fridge", "x": 22, "y": [ 17, 19 ], "chance": 90, "repeat": 4 },
+        { "item": "fridge", "x": 1, "y": [ 17, 19 ], "chance": 80, "repeat": 4 },
+        { "item": "oven", "x": 22, "y": 20, "chance": 80, "repeat": 4 },
+        { "item": "oven", "x": 1, "y": 20, "chance": 80, "repeat": 4 },
+        { "item": "science", "x": [ 15, 19 ], "y": 2, "chance": 90, "repeat": 3 },
+        { "item": "science", "x": [ 4, 8 ], "y": 2, "chance": 90, "repeat": 3 },
         { "item": "mon_zombie_scientist_death_drops", "x": 13, "y": 20, "chance": 50 },
         { "item": "mon_zombie_scientist_death_drops", "x": 10, "y": 20, "chance": 50 },
         { "item": "mon_zombie_scientist_death_drops", "x": 5, "y": 20, "chance": 50 },
@@ -97,10 +99,10 @@
         { "item": "mon_zombie_scientist_death_drops", "x": 7, "y": 6, "chance": 50 }
       ],
       "add": [
-        { "item": "mccmap", "x": 12, "y": 12, "repeat": 1 },
-        { "item": "laser_rifle", "x": 12, "y": 11, "repeat": 1 },
+        { "item": "mccmap", "x": 12, "y": 12 },
+        { "item": "laser_rifle", "x": 12, "y": 11 },
         { "item": "goggles_welding", "x": 4, "y": 20, "repeat": 1 },
-        { "item": "anesthesia", "x": [ 11, 12 ], "y": 19, "chance": 50, "repeat": [ 1, 3 ] }
+        { "item": "anesthesia", "x": [ 11, 12 ], "y": 19, "chance": 50, "repeat": 3 }
       ],
       "place_npcs": [ { "class": "bio_hunter", "x": 5, "y": 21 } ],
       "place_vehicles": [


### PR DESCRIPTION
* Reduced odds of gladiator NPCs running off in random directions.
* Set it so that random prepper NPCs will run towards you to talk instead of fucking off in a random direction, closer to the behavior of dynamic NPCs.
* Set prepper default talk topic to TALK_STRANGER_NEUTRAL instead of TALK_SHELTER, since only a handful of them really have shelter, plus "Hello there." makes more sense for an NPC that now actively tries to greet you.
* Changed some fridges in the bio-weapon lab to lockers, the ones holding non-food stuff.
* Removed some redundant uses of "repeat 1" for bio-weapon lab item spawns.
* Further rebalanced some problematic use of variable repeat in bio-weapon lab.
* Implemented the idea Noct and I discussed of making zombie super soldiers not revive, since they drop their armament on death. Decided to add a little extra flavor to it via also having it call the "spray some gore on death" function that skeletons now use in addition to leaving a corpse.