### PR TITLE
Updates to fungal bio-weapons, command center, recipes

### DIFF
--- a/Monsters/c_monsters.json
+++ b/Monsters/c_monsters.json
@@ -229,7 +229,6 @@
       "GROUP_BASH",
       "CBM_OP",
       "CBM_POWER",
-      "REVIVES",
       "BONES",
       "PUSH_MON"
     ]

--- a/Recipe/c_recipes.json
+++ b/Recipe/c_recipes.json
@@ -87,7 +87,7 @@
     "autolearn": true,
     "book_learn": [ [ "recipe_surv", 1 ] ],
     "qualities": [ { "id": "HAMMER", "level": 2 } ],
-    "tools": [ [ [ "can_forge_on", -1 ], [ "forge", 75 ], [ "char_forge", 50 ], [ "forgerig", 75 ] ], [ [ "mold_metal", -1 ] ] ],
+    "tools": [ [ [ "can_forge_on", -1 ], [ "forging_standard", 4, "LIST" ] ], [ [ "mold_metal", -1 ] ] ],
     "components": [ [ [ "scrap", 3 ], [ "steel_chunk", 1 ] ], [ [ "primitive_hammer", 1 ] ] ]
   },
   {
@@ -103,7 +103,7 @@
     "autolearn": true,
     "book_learn": [ [ "recipe_surv", 1 ] ],
     "qualities": [ { "id": "HAMMER", "level": 2 } ],
-    "tools": [ [ [ "can_forge_on", -1 ], [ "forge", 75 ], [ "char_forge", 50 ], [ "forgerig", 75 ] ], [ [ "mold_metal", -1 ] ] ],
+    "tools": [ [ [ "can_forge_on", -1 ], [ "forging_standard", 4, "LIST" ] ], [ [ "mold_metal", -1 ] ] ],
     "components": [ [ [ "scrap", 3 ], [ "steel_chunk", 1 ] ], [ [ "primitive_axe", 1 ] ] ]
   },
   {
@@ -119,7 +119,7 @@
     "autolearn": true,
     "book_learn": [ [ "recipe_surv", 1 ] ],
     "qualities": [ { "id": "HAMMER", "level": 2 } ],
-    "tools": [ [ [ "can_forge_on", -1 ], [ "forge", 75 ], [ "char_forge", 50 ], [ "forgerig", 75 ] ], [ [ "mold_metal", -1 ] ] ],
+    "tools": [ [ [ "can_forge_on", -1 ], [ "forging_standard", 4, "LIST" ] ], [ [ "mold_metal", -1 ] ] ],
     "components": [ [ [ "scrap", 3 ], [ "steel_chunk", 1 ] ], [ [ "primitive_knife", 1 ] ] ]
   },
   {
@@ -135,7 +135,7 @@
     "autolearn": true,
     "book_learn": [ [ "recipe_surv", 1 ] ],
     "qualities": [ { "id": "HAMMER", "level": 2 } ],
-    "tools": [ [ [ "can_forge_on", -1 ], [ "forge", 75 ], [ "char_forge", 50 ], [ "forgerig", 75 ] ], [ [ "mold_metal", -1 ] ] ],
+    "tools": [ [ [ "can_forge_on", -1 ], [ "forging_standard", 4, "LIST" ] ], [ [ "mold_metal", -1 ] ] ],
     "components": [ [ [ "scrap", 3 ], [ "steel_chunk", 1 ] ], [ [ "primitive_shovel", 1 ] ] ]
   },
   {
@@ -151,7 +151,7 @@
     "autolearn": true,
     "book_learn": [ [ "recipe_surv", 1 ] ],
     "qualities": [ { "id": "HAMMER", "level": 2 } ],
-    "tools": [ [ [ "can_forge_on", -1 ], [ "forge", 75 ], [ "char_forge", 50 ], [ "forgerig", 75 ] ], [ [ "mold_metal", -1 ] ] ],
+    "tools": [ [ [ "can_forge_on", -1 ], [ "forging_standard", 4, "LIST" ] ], [ [ "mold_metal", -1 ] ] ],
     "components": [ [ [ "scrap", 3 ], [ "steel_chunk", 1 ] ], [ [ "rock_pot", 1 ] ] ]
   },
   {
@@ -257,7 +257,7 @@
     "autolearn": true,
     "book_learn": [ [ "recipe_surv", 1 ] ],
     "qualities": [ { "id": "HAMMER", "level": 2 } ],
-    "tools": [ [ [ "can_forge_on", -1 ], [ "forge", 75 ], [ "char_forge", 50 ], [ "forgerig", 75 ] ], [ [ "mold_metal", -1 ] ] ],
+    "tools": [ [ [ "can_forge_on", -1 ], [ "forging_standard", 4, "LIST" ] ], [ [ "mold_metal", -1 ] ] ],
     "components": [ [ [ "scrap", 3 ], [ "steel_chunk", 1 ] ], [ [ "saw", 1 ] ], [ [ "hacksaw", 1 ] ] ]
   },
   {

--- a/Terrain/Unknown_Lab.json
+++ b/Terrain/Unknown_Lab.json
@@ -98,6 +98,7 @@
         "i": "f_autodoc",
         "j": "f_autodoc_couch"
       },
+      "mapping": { "%": { "item": [ { "item": "scrap", "count": [ 1, 3 ] } ] } },
       "place_toilets": [ { "x": 1, "y": 12 }, { "x": 22, "y": 12 } ],
       "place_loot": [
         { "group": "chem_lab", "x": 4, "y": 22, "chance": 90, "repeat": [ 15, 20 ] },
@@ -127,13 +128,6 @@
         { "item": "UPS_off", "x": 1, "y": 18 },
         { "item": "megamap", "x": 1, "y": 18 },
         { "item": "stealth_cloak_f", "x": 1, "y": 18 },
-        { "item": "scrap", "x": 10, "y": 15, "repeat": [ 1, 5 ] },
-        { "item": "scrap", "x": 15, "y": 13, "repeat": [ 1, 5 ] },
-        { "item": "scrap", "x": 14, "y": 15, "repeat": [ 1, 5 ] },
-        { "item": "scrap", "x": 11, "y": 16, "repeat": [ 1, 5 ] },
-        { "item": "scrap", "x": 12, "y": 17, "repeat": [ 1, 5 ] },
-        { "item": "scrap", "x": 13, "y": 17, "repeat": [ 1, 5 ] },
-        { "item": "scrap", "x": 11, "y": 18, "repeat": [ 1, 5 ] },
         { "item": "anesthesia", "x": 9, "y": 22, "chance": 50, "repeat": [ 1, 3 ] }
       ],
       "place_monster": [

--- a/Terrain/makeshift_command_center.json
+++ b/Terrain/makeshift_command_center.json
@@ -104,12 +104,9 @@
         "w": "f_wreckage",
         "{": "f_dresser"
       },
-      "place_traps": [
-        { "trap": "tr_dissector", "x": 15, "y": 21 }
-      ],
-      "place_toilets": [
-        { "x": 1, "y": 22 }
-      ],
+      "mapping": { "w": { "item": [ { "item": "scrap", "count": [ 1, 3 ] } ] } },
+      "place_traps": [ { "trap": "tr_dissector", "x": 15, "y": 21 } ],
+      "place_toilets": [ { "x": 1, "y": 22 } ],
       "place_items": [
         { "item": "stash_food", "x": 8, "y": 1, "chance": 85, "repeat": 12 },
         { "item": "textbooks", "x": 17, "y": 14, "chance": 75, "repeat": 4 },


### PR DESCRIPTION
* Removed `REVIVES` from fungal failed bio-weapons, to be consistent with fungal zombies. I was going to give them dual-species because I thought that was how they were, but instead fungal zombies are fungal species only and lack `REVIVES`.
* Added metal underneath the wreckage in the makeshift command center. Also changed the metal wreckage in the unknown lab to use the same method, as it saves a little text.
* Updated forging recipes to not use redundant charcoal forge and forgerig, as both substitute for electric forges. Rounded up to nearest 20 due to use of `forging_standard` crafting requirement.

On the to-do list eventually:
1. Overhauling molded tools to better mimic working with cast iron (I'll likely either copy the abstract method bronzecasting in Medieval mod uses, or use sand/clay as a tool as used by More Survival Tools for lead bearings).
2. Updating the small-scale charcoal recipe to better match the larger version, in terms of material-yield ratio, and time taken. Can't yet until portable kilns make sense again.