### PR TITLE
Removes smol flavor splatter

### DIFF
--- a/Monsters/c_monsters.json
+++ b/Monsters/c_monsters.json
@@ -288,7 +288,7 @@
     "special_when_hit": [ "ZAPBACK", 60 ],
     "anger_triggers": [ "FRIEND_DIED", "FRIEND_ATTACKED", "HURT" ],
     "death_drops": "wild_bio_infantry",
-    "death_function": [ "NORMAL", "SPLATTER" ],
+    "death_function": [ "NORMAL" ],
     "flags": [
       "SEES",
       "REGENERATES_10",
@@ -355,7 +355,7 @@
     "special_when_hit": [ "ZAPBACK", 60 ],
     "anger_triggers": [ "FRIEND_DIED", "FRIEND_ATTACKED", "HURT" ],
     "death_drops": "wild_bio_knight",
-    "death_function": [ "NORMAL", "SPLATTER" ],
+    "death_function": [ "NORMAL" ],
     "flags": [
       "SEES",
       "REGENERATES_10",
@@ -423,7 +423,7 @@
     "special_when_hit": [ "ZAPBACK", 60 ],
     "anger_triggers": [ "FRIEND_DIED", "FRIEND_ATTACKED", "HURT" ],
     "death_drops": "wild_bio_scout",
-    "death_function": [ "NORMAL", "SPLATTER" ],
+    "death_function": [ "NORMAL" ],
     "flags": [
       "SEES",
       "REGENERATES_10",
@@ -490,7 +490,7 @@
     "special_when_hit": [ "ZAPBACK", 60 ],
     "anger_triggers": [ "FRIEND_DIED", "FRIEND_ATTACKED", "HURT" ],
     "death_drops": "wild_bio_tool",
-    "death_function": [ "NORMAL", "SPLATTER" ],
+    "death_function": [ "NORMAL" ],
     "flags": [ "SEES", "HEARS", "SMELLS", "POISON", "BASHES", "CBM_POWER", "CBM_TECH", "NO_BREATHE", "BONES", "FILTHY" ]
   }
 ]


### PR DESCRIPTION
* Was a cute idea when I added it, but not really needed, and have already had one person confused by it.

If I cold set custom death messages, and if there was also a very smol death explosion effect available, I'd do that...