### PR TITLE
Itemgroup alterations

### DIFF
--- a/Surv_help/c_item_groups.json
+++ b/Surv_help/c_item_groups.json
@@ -287,11 +287,17 @@
     ]
   },
   {
-    "id": "homebooks",
+    "id": "mansion_bookcase",
+    "type": "item_group",
+    "subtype": "collection",
+    "groups": [
+      [ "encylopedias_rare", 5 ]
+    ]
+  },
+  {
+    "id": "encylopedias_common",
     "type": "item_group",
     "items": [
-      [ "recipe_surv", 2 ],
-      [ "manual_surv", 2 ],
       [ "encyclopedia_mechanics", 1 ],
       [ "encyclopedia_fabrication", 1 ],
       [ "encyclopedia_archery", 1 ],
@@ -322,39 +328,10 @@
     ]
   },
   {
-    "id": "mansion_books",
+    "id": "encylopedias_rare",
     "type": "item_group",
     "items": [
-      [ "recipe_surv", 2 ],
-      [ "manual_surv", 2 ],
-      [ "encyclopedia_mechanics", 1 ],
-      [ "encyclopedia_fabrication", 1 ],
-      [ "encyclopedia_archery", 1 ],
-      [ "encyclopedia_barter", 1 ],
-      [ "encyclopedia_bashing", 1 ],
-      [ "encyclopedia_computer", 1 ],
-      [ "encyclopedia_cooking", 1 ],
-      [ "encyclopedia_cutting", 1 ],
-      [ "encyclopedia_dodge", 1 ],
-      [ "encyclopedia_driving", 1 ],
-      [ "encyclopedia_electronics", 1 ],
-      [ "encyclopedia_firstaid", 1 ],
-      [ "encyclopedia_gun", 1 ],
-      [ "encyclopedia_launcher", 1 ],
-      [ "encyclopedia_melee", 1 ],
-      [ "encyclopedia_pistol", 1 ],
-      [ "encyclopedia_rifle", 1 ],
-      [ "encyclopedia_shotgun", 1 ],
-      [ "encyclopedia_smg", 1 ],
-      [ "encyclopedia_speech", 1 ],
-      [ "encyclopedia_stabbing", 1 ],
-      [ "encyclopedia_survival", 1 ],
-      [ "encyclopedia_swimming", 1 ],
-      [ "encyclopedia_tailor", 1 ],
-      [ "encyclopedia_throw", 1 ],
-      [ "encyclopedia_traps", 1 ],
-      [ "encyclopedia_unarmed", 1 ],
-	  [ "encyclopedia_mechanics_advance", 1 ],
+      [ "encyclopedia_mechanics_advance", 1 ],
       [ "encyclopedia_fabrication_advance", 1 ],
       [ "encyclopedia_archery_advance", 1 ],
       [ "encyclopedia_barter_advance", 1 ],
@@ -384,65 +361,40 @@
     ]
   },
   {
-    "id": "shelter",
+    "id": "homebooks",
+    "type": "item_group",
+    "items": [
+      [ "recipe_surv", 1 ],
+      [ "manual_surv", 1 ],
+      { "group": "encylopedias_common", "prob": 1 }
+    ]
+  },
+  {
+    "id": "manuals",
+    "type": "item_group",
+    "items": [
+      [ "recipe_surv", 1 ],
+      [ "manual_surv", 1 ],
+      { "group": "encylopedias_common", "prob": 1 }
+    ]
+  },
+  {
+    "id": "mansion_books",
     "type": "item_group",
     "items": [
       [ "recipe_surv", 2 ],
       [ "manual_surv", 2 ],
-      [ "encyclopedia_mechanics", 1 ],
-      [ "encyclopedia_fabrication", 1 ],
-      [ "encyclopedia_archery", 1 ],
-      [ "encyclopedia_barter", 1 ],
-      [ "encyclopedia_bashing", 1 ],
-      [ "encyclopedia_computer", 1 ],
-      [ "encyclopedia_cooking", 1 ],
-      [ "encyclopedia_cutting", 1 ],
-      [ "encyclopedia_dodge", 1 ],
-      [ "encyclopedia_driving", 1 ],
-      [ "encyclopedia_electronics", 1 ],
-      [ "encyclopedia_firstaid", 1 ],
-      [ "encyclopedia_gun", 1 ],
-      [ "encyclopedia_launcher", 1 ],
-      [ "encyclopedia_melee", 1 ],
-      [ "encyclopedia_pistol", 1 ],
-      [ "encyclopedia_rifle", 1 ],
-      [ "encyclopedia_shotgun", 1 ],
-      [ "encyclopedia_smg", 1 ],
-      [ "encyclopedia_speech", 1 ],
-      [ "encyclopedia_stabbing", 1 ],
-      [ "encyclopedia_survival", 1 ],
-      [ "encyclopedia_swimming", 1 ],
-      [ "encyclopedia_tailor", 1 ],
-      [ "encyclopedia_throw", 1 ],
-      [ "encyclopedia_traps", 1 ],
-      [ "encyclopedia_unarmed", 1 ],
-	  [ "encyclopedia_mechanics_advance", 1 ],
-      [ "encyclopedia_fabrication_advance", 1 ],
-      [ "encyclopedia_archery_advance", 1 ],
-      [ "encyclopedia_barter_advance", 1 ],
-      [ "encyclopedia_bashing_advance", 1 ],
-      [ "encyclopedia_computer_advance", 1 ],
-      [ "encyclopedia_cooking_advance", 1 ],
-      [ "encyclopedia_cutting_advance", 1 ],
-      [ "encyclopedia_dodge_advance", 1 ],
-      [ "encyclopedia_driving_advance", 1 ],
-      [ "encyclopedia_electronics_advance", 1 ],
-      [ "encyclopedia_firstaid_advance", 1 ],
-      [ "encyclopedia_gun_advance", 1 ],
-      [ "encyclopedia_launcher_advance", 1 ],
-      [ "encyclopedia_melee_advance", 1 ],
-      [ "encyclopedia_pistol_advance", 1 ],
-      [ "encyclopedia_rifle_advance", 1 ],
-      [ "encyclopedia_shotgun_advance", 1 ],
-      [ "encyclopedia_smg_advance", 1 ],
-      [ "encyclopedia_speech_advance", 1 ],
-      [ "encyclopedia_stabbing_advance", 1 ],
-      [ "encyclopedia_survival_advance", 1 ],
-      [ "encyclopedia_swimming_advance", 1 ],
-      [ "encyclopedia_tailor_advance", 1 ],
-      [ "encyclopedia_throw_advance", 1 ],
-      [ "encyclopedia_traps_advance", 1 ],
-      [ "encyclopedia_unarmed_advance", 1 ]
+      { "group": "encylopedias_common", "prob": 5 }
+    ]
+  },
+  {
+    "id": "shelter",
+    "type": "item_group",
+    "items": [
+      [ "recipe_surv", 1 ],
+      [ "manual_surv", 1 ],
+      { "group": "encylopedias_common", "prob": 1 },
+      [ "biomap", 1 ]
     ]
   },
   {
@@ -451,60 +403,16 @@
     "items": [
       [ "recipe_surv", 2 ],
       [ "manual_surv", 2 ],
-      [ "encyclopedia_mechanics", 1 ],
-      [ "encyclopedia_fabrication", 1 ],
-      [ "encyclopedia_archery", 1 ],
-      [ "encyclopedia_barter", 1 ],
-      [ "encyclopedia_bashing", 1 ],
-      [ "encyclopedia_computer", 1 ],
-      [ "encyclopedia_cooking", 1 ],
-      [ "encyclopedia_cutting", 1 ],
-      [ "encyclopedia_dodge", 1 ],
-      [ "encyclopedia_driving", 1 ],
-      [ "encyclopedia_electronics", 1 ],
-      [ "encyclopedia_firstaid", 1 ],
-      [ "encyclopedia_gun", 1 ],
-      [ "encyclopedia_launcher", 1 ],
-      [ "encyclopedia_melee", 1 ],
-      [ "encyclopedia_pistol", 1 ],
-      [ "encyclopedia_rifle", 1 ],
-      [ "encyclopedia_shotgun", 1 ],
-      [ "encyclopedia_smg", 1 ],
-      [ "encyclopedia_speech", 1 ],
-      [ "encyclopedia_stabbing", 1 ],
-      [ "encyclopedia_survival", 1 ],
-      [ "encyclopedia_swimming", 1 ],
-      [ "encyclopedia_tailor", 1 ],
-      [ "encyclopedia_throw", 1 ],
-      [ "encyclopedia_traps", 1 ],
-      [ "encyclopedia_unarmed", 1 ],
-	  [ "encyclopedia_mechanics_advance", 1 ],
-      [ "encyclopedia_fabrication_advance", 1 ],
-      [ "encyclopedia_archery_advance", 1 ],
-      [ "encyclopedia_barter_advance", 1 ],
-      [ "encyclopedia_bashing_advance", 1 ],
-      [ "encyclopedia_computer_advance", 1 ],
-      [ "encyclopedia_cooking_advance", 1 ],
-      [ "encyclopedia_cutting_advance", 1 ],
-      [ "encyclopedia_dodge_advance", 1 ],
-      [ "encyclopedia_driving_advance", 1 ],
-      [ "encyclopedia_electronics_advance", 1 ],
-      [ "encyclopedia_firstaid_advance", 1 ],
-      [ "encyclopedia_gun_advance", 1 ],
-      [ "encyclopedia_launcher_advance", 1 ],
-      [ "encyclopedia_melee_advance", 1 ],
-      [ "encyclopedia_pistol_advance", 1 ],
-      [ "encyclopedia_rifle_advance", 1 ],
-      [ "encyclopedia_shotgun_advance", 1 ],
-      [ "encyclopedia_smg_advance", 1 ],
-      [ "encyclopedia_speech_advance", 1 ],
-      [ "encyclopedia_stabbing_advance", 1 ],
-      [ "encyclopedia_survival_advance", 1 ],
-      [ "encyclopedia_swimming_advance", 1 ],
-      [ "encyclopedia_tailor_advance", 1 ],
-      [ "encyclopedia_throw_advance", 1 ],
-      [ "encyclopedia_traps_advance", 1 ],
-      [ "encyclopedia_unarmed_advance", 1 ]
+      { "group": "encylopedias_common", "prob": 1 }
+    ]
+  },
+  {
+    "id": "gear_survival",
+    "type": "item_group",
+    "items": [
+      { "group": "encylopedias_common", "prob": 10 },
+      { "group": "encylopedias_rare", "prob": 5 },
+      [ "biomap", 1 ]
     ]
   },
   {
@@ -562,96 +470,7 @@
     ]
   },
   {
-    "id": "livingroom",
-    "type": "item_group",
-    "items": [
-      [ "biomap", 1 ],
-      [ "encyclopedia_mechanics", 1 ],
-      [ "encyclopedia_fabrication", 1 ],
-      [ "encyclopedia_archery", 1 ],
-      [ "encyclopedia_barter", 1 ],
-      [ "encyclopedia_bashing", 1 ],
-      [ "encyclopedia_computer", 1 ],
-      [ "encyclopedia_cooking", 1 ],
-      [ "encyclopedia_cutting", 1 ],
-      [ "encyclopedia_dodge", 1 ],
-      [ "encyclopedia_driving", 1 ],
-      [ "encyclopedia_electronics", 1 ],
-      [ "encyclopedia_firstaid", 1 ],
-      [ "encyclopedia_gun", 1 ],
-      [ "encyclopedia_launcher", 1 ],
-      [ "encyclopedia_melee", 1 ],
-      [ "encyclopedia_pistol", 1 ],
-      [ "encyclopedia_rifle", 1 ],
-      [ "encyclopedia_shotgun", 1 ],
-      [ "encyclopedia_smg", 1 ],
-      [ "encyclopedia_speech", 1 ],
-      [ "encyclopedia_stabbing", 1 ],
-      [ "encyclopedia_survival", 1 ],
-      [ "encyclopedia_swimming", 1 ],
-      [ "encyclopedia_tailor", 1 ],
-      [ "encyclopedia_throw", 1 ],
-      [ "encyclopedia_traps", 1 ],
-      [ "encyclopedia_unarmed", 1 ]
-    ]
-  },
-  {
-    "id": "kitchen",
-    "type": "item_group",
-    "items": [ [ "biomap", 1 ] ]
-  },
-  {
-    "id": "bed",
-    "type": "item_group",
-    "items": [ [ "biomap", 1 ] ]
-  },
-  {
-    "id": "bedroom",
-    "type": "item_group",
-    "items": [
-      [ "biomap", 1 ],
-      [ "fr_22", 1 ],
-      [ "fr_223", 1 ],
-      [ "fr_308", 1 ],
-      [ "fr_9mm", 1 ],
-      [ "fr_12", 1 ],
-      [ "fr_762", 1 ],
-      [ "22aux", 1 ],
-      [ "9mmaux", 1 ],
-      [ "45aux", 1 ],
-      [ "recipe_surv", 2 ],
-      [ "manual_surv", 2 ]
-    ]
-  },
-  {
-    "id": "dresser",
-    "type": "item_group",
-    "items": [
-      [ "biomap", 1 ],
-      [ "fr_22", 1 ],
-      [ "fr_223", 1 ],
-      [ "fr_308", 1 ],
-      [ "fr_9mm", 1 ],
-      [ "fr_12", 1 ],
-      [ "fr_762", 1 ],
-      [ "22aux", 1 ],
-      [ "9mmaux", 1 ],
-      [ "45aux", 1 ],
-      [ "recipe_surv", 2 ],
-      [ "manual_surv", 2 ],
-      [ "dress_skirt", 75 ],
-      [ "microskirt", 10 ],
-      [ "fancy_bra", 70 ],
-      [ "thong", 70 ]
-    ]
-  },
-  {
-    "id": "behindcounter",
-    "type": "item_group",
-    "items": [ [ "biomap", 1 ] ]
-  },
-  {
-    "id": "trash",
+    "id": "mut_lab",
     "type": "item_group",
     "items": [ [ "biomap", 1 ] ]
   },
@@ -659,16 +478,6 @@
     "id": "traveler",
     "type": "item_group",
     "items": [ [ "biomap", 1 ], [ "dress_skirt", 75 ], [ "microskirt", 10 ], [ "fancy_bra", 30 ], [ "thong", 30 ] ]
-  },
-  {
-    "id": "shelter",
-    "type": "item_group",
-    "items": [ [ "biomap", 1 ] ]
-  },
-  {
-    "id": "trash_forest",
-    "type": "item_group",
-    "items": [ [ "biomap", 1 ] ]
   },
   {
     "id": "bionics",
@@ -684,26 +493,6 @@
     "id": "bionics_op",
     "type": "item_group",
     "items": [ [ "bio_laser_armgun", 5 ], [ "bio_sword", 5 ], [ "bio_flamethrower", 5 ] ]
-  },
-  {
-    "id": "mil_surplus",
-    "type": "item_group",
-    "items": [
-      [ "m4a1", 2 ],
-      [ "m9", 2 ],
-      [ "m9mag", 2 ],
-      [ "m9bigmag", 1 ],
-      [ "stanag30", 2 ],
-      [ "stanag10", 1 ],
-      [ "556", 4 ],
-      [ "9mm", 4 ],
-      [ "suppressor", 2 ]
-    ]
-  },
-  {
-    "id": "cleaning",
-    "type": "item_group",
-    "items": [ [ "soap", 250 ] ]
   },
   {
     "id": "female_underwear_top",


### PR DESCRIPTION
* Extensively rebalances how common Rebuilding Civilization is. Adds a shot at encountering the advanced books to `mansion_bookcase` as suggested in the relevent issue, while likewise grouping the placement of basic-tier Rebuilding Civilization into a single group that the groups can likewise call as a possible result, allowing for rarity to be tweaked without running into the fact that a book for every skill enofrces a high minimum weight.
* Made it so that basic book itemgroups will sometimes have basic Rebuilding Civilization books, while made the rare ones sometimes in prepper locations (in addition to mansions).
* Shifted around the widespread appearances of hand-drawn map, making them most common in labs rather than common bedrooms, and also showing up in prepper/survivalist locations rather than in almost every household itemgroup.
* Combined redundant calls to existing itemgroups.
* Removed the highly-common soap spawn now that detergent is a thing.

Net effects are that Rebuilding Civilization is much less ubiquitous all around, but more reliably spawns in mansions, LMOE shelters, and fortified basements. Labs become the primary source of hand-drawn maps, with other sources such as LMOE shelters still being an occasional option.