### PR TITLE
Updates main quest line

### DIFF
--- a/Npc/c_mission_def.json
+++ b/Npc/c_mission_def.json
@@ -7,11 +7,19 @@
     "difficulty": 10,
     "value": 100000,
     "item": "badge_bio_weapon_apophis",
+    "start": {
+      "assign_mission_target": {
+        "om_terrain": "Unknown_Bunker",
+        "om_special": "Unknown_Lab_s",
+        "reveal_radius": 3,
+        "search_range": 180
+      }
+    },
     "count": 1,
     "origins": [ "ORIGIN_SECONDARY" ],
     "dialogue": {
       "describe": "If you see this, it's a bug!",
-      "offer": "Only one thing comes to mind.  You seem like a capable person, so you might have a chance.  There is a map in the locker.  It has the coordinates to the laboratory Apophis uses as its base.  I want you to take it down, rid the world of Apophis!  That lab has a lot of valuable equipment left inside - if you manage to kill that thing, it's all yours.  ...I wish we could do it ourselves, but between the portal breakthroughs, the bombs and  the undead, the chance has been lost.",
+      "offer": "Only one thing comes to mind.  You seem like a capable person, so you might have a chance.  We have pieced together the coordinates to the laboratory Apophis uses as its base.  I want you to take it down, rid the world of Apophis!  That lab has a lot of valuable equipment left inside - if you manage to kill that thing, it's all yours.  ...I wish we could do it ourselves, but between the portal breakthroughs, the bombs and  the undead, the chance has been lost.",
       "accepted": "You're sure about this?  Thank you... that means a lot, you know.  Be sure to bring some proof, be creative.  I'll be waiting for your return.",
       "rejected": "I understand.  It's practically a lost cause at this point.  I'll keep trying to figure something out to stop it.",
       "advice": "Got some decent armor and weapons, this fight won't be easy. Assemble a team to make it easier. Ask Lambda and Sigma if they want to join you, if you want.  A single person can't take it on...",
@@ -28,15 +36,23 @@
     "goal": "MGOAL_GO_TO_TYPE",
     "difficulty": 2,
     "value": 80000,
-    "start": "join",
     "origins": [ "ORIGIN_SECONDARY" ],
     "destination": "makeshift_command_center",
+    "start": {
+      "effect": "follow",
+      "assign_mission_target": {
+        "om_terrain": "makeshift_command_center",
+        "om_special": "makeshift_command_center_s",
+        "reveal_radius": 3,
+        "search_range": 180
+      }
+    },
     "dialogue": {
       "describe": "If you see this, it's a bug!",
-      "offer": "I'm trying to reach a hideout built by former scientists who worked on the Bio-Weapon project.  Rumor has it they live somewhere in the woods.  Maybe you could help me find it...",
+      "offer": "I'm trying to reach a hideout built by former scientists who worked on the Bio-Weapon project.  I think I have a lead on where they are, but I would appreciate a helping hand.  I had someone with me, but he got caught outside when company showed up.",
       "accepted": "Thank you.  I'll follow along and maybe we'll get some answers.",
       "rejected": "Oh.  I'd rather try to find the place with some help, so if you're willing to later on maybe...",
-      "advice": "I was going to search this old lab for intel that might help.  I think I saw some paperwork that marked some likely locations, guess I'll let you examine it instead.",
+      "advice": "I was searching this old lab for intel that might help.  Take a look for yourself if you need to.  In addition, the humvee my companion and I arrived in still should be parked outside, assuming those things didn't trash it...",
       "inquire": "Any closer to the others yet?",
       "success": "Excellent.  I'll go ahead and stick around for now.  Looks like they have a decent little setup going on here.  Maybe asking around will get us pointed in the right direction.",
       "success_lie": "Thanks for trying...  I guess.",


### PR DESCRIPTION
* Implements reveal and mark for the Command Center and Unknown Lab quests, no longer requiring the maps to find them. For now the map items have been retained, as a fallback and for players playing without NPCs enabled. May or may not dummy them out later on.
* Altered dialogue some to account for the fact that the map items are no longer vital to finding the locations.
* Added a bit of actual advice to Evy's quest advice.

I've been meaning to mess with Sigma and Lambda to maybe give them secondary quests of some sort, and/or tie their quests in with having the "kill Apophis" mission already active, but things keep distracting me from doing so.