### PR TITLE
Fix two error messages, bionic consistency

### DIFF
--- a/Char_creation/c_classes_bw.json
+++ b/Char_creation/c_classes_bw.json
@@ -414,6 +414,7 @@
     "points": 12,
     "CBMs": [
       "bio_eye_enhancer",
+      "bio_ups",
       "bio_eye_optic",
       "bio_night_vision",
       "bio_targeting",
@@ -535,6 +536,7 @@
     "points": 15,
     "CBMs": [
       "bio_armor_eyes",
+      "bio_ups",
       "bio_armor_head",
       "bio_armor_torso",
       "bio_armor_arms",

--- a/Monsters/c_monsters.json
+++ b/Monsters/c_monsters.json
@@ -387,7 +387,7 @@
         "type": "gun",
         "cooldown": 5,
         "move_cost": 350,
-        "gun_type": "laser_lmg_monster",
+        "gun_type": "krx_laser_lmg_monster",
         "ammo_type": "generic_no_ammo",
         "fake_str": 4,
         "fake_dex": 3,

--- a/Surv_help/c_item_groups.json
+++ b/Surv_help/c_item_groups.json
@@ -681,7 +681,8 @@
       [ "bio_purifier", 7 ],
       [ "bio_radscrubber", 7 ],
       [ "bio_sunglasses", 7 ],
-      [ "bio_targeting", 5 ]
+      [ "bio_targeting", 5 ],
+      [ "bio_ups", 8 ]
     ]
   },
   {
@@ -700,7 +701,8 @@
       [ "bio_night_vision", 1 ],
       [ "bio_recycler", 5 ],
       [ "bio_targeting", 5 ],
-      [ "bio_tools", 5 ]
+      [ "bio_tools", 5 ],
+      [ "bio_ups", 8 ]
     ]
   },
   {

--- a/legacy.json
+++ b/legacy.json
@@ -2,12 +2,12 @@
   {
     "id": "laser_sniper",
     "type": "MIGRATION",
-    "replace": "mx_laser_sniper"
+    "replace": "laser_rifle"
   },
   {
     "id": "bolt_rifle_elec",
     "type": "MIGRATION",
-    "replace": "br_bolt_rifle_elec"
+    "replace": "emp_gun"
   },
   {
     "id": "neo_33_manual",
@@ -42,32 +42,32 @@
   {
     "id": "neo_laser_pistol_plut",
     "type": "MIGRATION",
-    "replace": "neo_laser_pistol"
+    "replace": "v29"
   },
   {
     "id": "akro_laser_smg_plut",
     "type": "MIGRATION",
-    "replace": "akro_laser_smg"
+    "replace": "laser_rifle"
   },
   {
     "id": "arc_laser_rifle_plut",
     "type": "MIGRATION",
-    "replace": "arc_laser_rifle"
+    "replace": "laser_rifle"
   },
   {
     "id": "krx_laser_lmg_plut",
     "type": "MIGRATION",
-    "replace": "krx_laser_lmg"
+    "replace": "laser_rifle"
   },
   {
     "id": "mx_laser_sniper_plut",
     "type": "MIGRATION",
-    "replace": "mx_laser_sniper"
+    "replace": "laser_rifle"
   },
   {
     "id": "xarm_laser_shotgun_plut",
     "type": "MIGRATION",
-    "replace": "xarm_laser_shotgun"
+    "replace": "laser_rifle"
   },
   {
     "id": "omnitech_plut_core",


### PR DESCRIPTION
1. Fixed error message causes by zombie super juggernauts trying to fire a gun with the wrong ID.
2. Also fixes migration errors caused when loading a save without Cata++ after having loaded a save with said mod.
3. Made UPS access consistent between super soldier professions and the CBM harvests for zombie super soldiers. This means that super soldier players can now all start off able to use their weapon. NPCs still use an advanced UPS however, as I don't yet know whether trying to start them with a UPS bionic will work right.

Closes https://github.com/Noctifer-de-Mortem/nocts_cata_mod/issues/76
Closes https://github.com/Noctifer-de-Mortem/nocts_cata_mod/issues/75