### PR TITLE
Two command center fixes

### DIFF
--- a/Npc/TALK_MSCI.json
+++ b/Npc/TALK_MSCI.json
@@ -10,7 +10,7 @@
     "responses": [
       {
         "text": "So now what are you going to do?",
-        "condition": { "not": { "or": [ { "has_assigned_mission": true }, { "has_available_mission": true } ] } },
+        "condition": { "and": [ { "not": { "u_has_mission": "MISSION_PROOF_APOPHIS_DEAD" } }, { "u_has_effect": "router_mission" } ] },
         "topic": "TALK_MSCI_NOWWHAT"
       },
       { "text": "What is this place?", "topic": "TALK_MSCI_CC_EXPLAIN" },

--- a/Npc/c_effect_npc.json
+++ b/Npc/c_effect_npc.json
@@ -11,6 +11,11 @@
   },
   {
     "type": "effect_type",
+    "id": "router_mission",
+    "//": "Used to specifiy that a specific player has accepted the mission to slay Apophis.  Intended to be permanant."
+  },
+  {
+    "type": "effect_type",
     "id": "router_suggestion",
     "//": "Used to specifiy that a specific player has received Router's suggestion to give the bio-weapons something to do.  Intended to be permanant."
   },

--- a/Npc/c_mission_def.json
+++ b/Npc/c_mission_def.json
@@ -8,6 +8,7 @@
     "value": 100000,
     "item": "badge_bio_weapon_apophis",
     "start": {
+      "effect": { "u_add_effect": "router_mission", "duration": "PERMANENT" },
       "assign_mission_target": { "om_terrain": "Unknown_Bunker", "om_special": "Unknown_Lab_s", "reveal_radius": 3, "search_range": 180 }
     },
     "count": 1,

--- a/Terrain/makeshift_command_center.json
+++ b/Terrain/makeshift_command_center.json
@@ -36,14 +36,14 @@
         "#": "t_metal_floor",
         "&": "t_metal_floor",
         "+": "t_rdoor_c",
-        ",": "t_dirt",
+        ",": "t_grass",
         "-": "t_metal_floor",
         ".": "t_metal_floor",
         "/": "t_door_metal_locked",
         "4": "t_plut_generator",
         "6": "t_metal_floor",
         "<": "t_door_metal_c",
-        "=": "t_metal_floor",
+        "=": "t_dirt",
         ">": "t_wall",
         "A": "t_metal_floor",
         "B": "t_metal_floor",
@@ -104,7 +104,10 @@
         "w": "f_wreckage",
         "{": "f_dresser"
       },
-      "mapping": { "w": { "item": [ { "item": "scrap", "count": [ 1, 3 ] } ] } },
+      "mapping": [
+        { "w": { "item": [ { "item": "scrap", "count": [ 1, 3 ] } ] } },
+        { "%": { "item": [ { "item": "scrap", "count": [ 1, 3 ] } ] } }
+      ],
       "place_traps": [ { "trap": "tr_dissector", "x": 15, "y": 21 } ],
       "place_toilets": [ { "x": 1, "y": 22 } ],
       "place_items": [


### PR DESCRIPTION
1. Smol fix of terrain under the smoking racks.
2. Fixed Router's post-quest dialogue showing up early.

Now the latter especially works as intended, correctly only opening up if the player started the quest then completed it (there's technically no way to fail the mission barring death, which puts missions in limbo anyway).