### PR TITLE
Update bio-weapon power sources

### DIFF
--- a/Char_creation/c_classes_bw.json
+++ b/Char_creation/c_classes_bw.json
@@ -235,6 +235,7 @@
       "bio_evap",
       "bio_climate",
       "bio_furnace",
+      "bio_ethanol",
       "bio_recycler",
       "bio_carbon",
       "bio_watch",
@@ -311,6 +312,7 @@
       "bio_power_storage_mkII",
       "bio_power_storage_mkII",
       "bio_power_armor_interface_mkII",
+      "bio_torsionratchet",
       "bio_advreactor",
       "bio_plut_filter"
     ],
@@ -346,7 +348,7 @@
       "bio_remote",
       "bio_resonator",
       "bio_shock",
-      "bio_torsionratchet",
+      "bio_batteries",
       "bio_cable",
       "bio_tools",
       "bio_razors",
@@ -489,7 +491,7 @@
       "bio_memory",
       "bio_tools",
       "bio_flashlight",
-      "bio_torsionratchet",
+      "bio_batteries",
       "bio_power_storage_mkII",
       "bio_power_storage_mkII"
     ],


### PR DESCRIPTION
* Gave Beta Joint Torsion Ratchet as a backup power source.
* Changed Gamma's Joint Torsion Ratchet for Battery System.
* Gave Delta Ethanol Burner as a backup to Internal Furnace.
* Gave super soldier B.A.M.R.U. Battery System instead of Joint Torsion Ratchet.

General idea is this gives each of the bio-weapons two different power systems, one primary and one secondary (Alpha's backup method being Heat Drain, as MI is pretty much the only power source that's still practical in almost all situations).

Likewise, this also makes the super solider professions each use a different power system that references how the specific versions match up with one of the bio-weapons, with the standard super soldier being the odd one out due to not taking after Alpha.