### PR TITLE
Remove self-copy-from vehicle parts

### DIFF
--- a/Vehicles/c_vehicle_parts.json
+++ b/Vehicles/c_vehicle_parts.json
@@ -75,30 +75,6 @@
   },
   {
     "type": "vehicle_part",
-    "id": "engine_electric_small",
-    "copy-from": "engine_electric_small",
-    "override": true,
-    "flags": [ "FOLDABLE", "ENGINE" ],
-    "folded_volume": 2
-  },
-  {
-    "type": "vehicle_part",
-    "id": "tank_little",
-    "copy-from": "tank_little",
-    "override": true,
-    "flags": [ "FOLDABLE" ],
-    "folded_volume": 2
-  },
-  {
-    "type": "vehicle_part",
-    "id": "funnel",
-    "copy-from": "funnel",
-    "override": true,
-    "flags": [ "FOLDABLE" ],
-    "folded_volume": 2
-  },
-  {
-    "type": "vehicle_part",
     "id": "surv_full_223_t",
     "copy-from": "turret",
     "name": "mounted survivor's .223 assault rifle",


### PR DESCRIPTION
Seems that self copy-from for vehicleparts breaks some intended behavior, plus the apparent change making these parts foldable seems to not be utilized in any vehicles at present (as none of the relevent vehicles added would be foldable anyway).

Closes https://github.com/Noctifer-de-Mortem/nocts_cata_mod/issues/82