### PR TITLE
Updates charcoal recipe to be consistent with vanilla

### DIFF
--- a/Recipe/c_recipes.json
+++ b/Recipe/c_recipes.json
@@ -162,13 +162,12 @@
     "subcategory": "CSC_OTHER_MATERIALS",
     "skill_used": "survival",
     "difficulty": 2,
-    "time": 60000,
-    "reversible": false,
+    "time": 20000,
     "autolearn": true,
     "book_learn": [ [ "recipe_surv", 1 ] ],
-    "qualities": [ { "id": "CUT", "level": 1 } ],
-    "tools": [ [ [ "fire", -1 ] ], [ [ "can_food_unsealed", -1 ], [ "can_drink_unsealed", -1 ] ] ],
-    "components": [ [ [ "stick", 1 ], [ "2x4", 1 ] ] ]
+    "charges": 10,
+    "tools": [ [ [ "surface_heat", 10, "LIST" ] ], [ [ "can_food_unsealed", -1 ], [ "can_drink_unsealed", -1 ] ] ],
+    "components": [ [ [ "splinter", 2 ], [ "bone_human", 2 ], [ "bone_tainted", 2 ], [ "pine_bough", 10 ] ] ]
   },
   {
     "result": "wear_solar_flashlight",


### PR DESCRIPTION
Simple update to make the charcoal output, material demand, and time consumed more consistent with vanilla's item-based charcoal production. Now takes 2 volume of material, producing 10 charges in 20 minutes (2 minute increase relative to 5% of a lit charcoal kiln's burn time).

As a consequence, while sticks and two-by-fours are no longer used, it instead allows all of the other low-volume items accepted for filling a charcoal kiln, including splintered wood.