### PR TITLE
Update battery items and weaponry

### DIFF
--- a/Monsters/c_monster_drops.json
+++ b/Monsters/c_monster_drops.json
@@ -67,7 +67,8 @@
       { "item": "boots_combat", "damage": [ 1, 4 ] },
       { "item": "jacket_army", "damage": [ 1, 4 ] },
       { "item": "dump_pouch", "damage": [ 1, 4 ], "chance": 50 },
-      { "item": "arc_laser_rifle", "damage": [ 0, 3 ] },
+      { "item": "arc_laser_rifle", "damage": [ 0, 3 ], "charges": [ 0, 2500 ] },
+      { "item": "medium_atomic_battery_cell", "damage": [ 0, 1 ], "charges": [ 0, 5000 ], "chance": 25 },
       { "item": "militarymap", "damage": [ 0, 1 ], "chance": 10 },
       { "item": "id_military", "damage": [ 0, 1 ], "chance": 10 }
     ]
@@ -91,7 +92,8 @@
       { "item": "boots_combat", "damage": [ 1, 4 ] },
       { "item": "jacket_army", "damage": [ 1, 4 ] },
       { "item": "dump_pouch", "damage": [ 1, 4 ], "chance": 50 },
-      { "item": "xarm_laser_shotgun", "damage": [ 0, 3 ] },
+      { "item": "xarm_laser_shotgun", "damage": [ 0, 3 ], "charges": [ 0, 2500 ] },
+      { "item": "medium_atomic_battery_cell", "damage": [ 0, 1 ], "charges": [ 0, 5000 ], "chance": 25 },
       { "item": "militarymap", "damage": [ 0, 1 ], "chance": 10 },
       { "item": "id_military", "damage": [ 0, 1 ], "chance": 10 }
     ]
@@ -115,8 +117,8 @@
       { "item": "boots_combat", "damage": [ 1, 4 ] },
       { "item": "jacket_army", "damage": [ 1, 4 ] },
       { "item": "dump_pouch", "damage": [ 1, 4 ], "chance": 50 },
-      { "item": "mx_laser_sniper", "damage": [ 0, 3 ] },
-      { "item": "br_bolt_rifle_elec", "damage": [ 0, 3 ], "chance": 25 },
+      { "item": "mx_laser_sniper", "damage": [ 0, 3 ], "charges": [ 0, 2500 ] },
+      { "item": "medium_atomic_battery_cell", "damage": [ 0, 1 ], "charges": [ 0, 5000 ], "chance": 25 },
       { "item": "e_tool", "damage": [ 0, 3 ], "chance": 50 },
       { "item": "mre_beef_box", "damage": [ 0, 3 ], "chance": 75 },
       { "item": "militarymap", "damage": [ 0, 1 ], "chance": 10 },
@@ -138,7 +140,8 @@
       { "item": "socks", "damage": [ 1, 4 ] },
       { "item": "lmil_armor", "damage": [ 1, 4 ] },
       { "item": "dump_pouch", "damage": [ 1, 4 ], "chance": 50 },
-      { "item": "krx_laser_lmg", "damage": [ 0, 3 ] },
+      { "item": "krx_laser_lmg", "damage": [ 0, 3 ], "charges": [ 0, 5000 ] },
+      { "item": "heavy_atomic_battery_cell", "damage": [ 0, 1 ], "charges": [ 0, 10000 ], "chance": 25 },
       { "item": "militarymap", "damage": [ 0, 1 ], "chance": 10 },
       { "item": "id_military", "damage": [ 0, 1 ], "chance": 10 }
     ]
@@ -180,7 +183,8 @@
       { "item": "boots_combat", "damage": [ 1, 4 ] },
       { "item": "jacket_army", "damage": [ 1, 4 ] },
       { "item": "dump_pouch", "damage": [ 1, 4 ], "chance": 50 },
-      { "item": "neo_laser_pistol", "damage": [ 0, 3 ] },
+      { "item": "neo_laser_pistol", "damage": [ 0, 3 ], "charges": [ 0, 250 ] },
+      { "item": "light_minus_atomic_battery_cell", "damage": [ 0, 1 ], "charges": [ 0, 500 ], "chance": 25 },
       { "item": "chemistry_set", "damage": [ 0, 1 ], "chance": 90 },
       { "item": "battery_ups", "damage": [ 0, 1 ], "chance": 50 },
       { "item": "militarymap", "damage": [ 0, 1 ], "chance": 10 },
@@ -206,7 +210,8 @@
       { "item": "boots_combat", "damage": [ 1, 4 ] },
       { "item": "jacket_army", "damage": [ 1, 4 ] },
       { "item": "dump_pouch", "damage": [ 1, 4 ], "chance": 50 },
-      { "item": "akro_laser_smg", "damage": [ 0, 3 ] },
+      { "item": "akro_laser_smg", "damage": [ 0, 3 ], "charges": [ 0, 500 ] },
+      { "item": "light_atomic_battery_cell", "damage": [ 0, 1 ], "charges": [ 500, 1000 ], "chance": 25 },
       { "item": "chemistry_set", "damage": [ 0, 1 ], "chance": 90 },
       { "item": "battery_ups", "damage": [ 0, 1 ], "chance": 50 },
       { "item": "militarymap", "damage": [ 0, 1 ], "chance": 10 },

--- a/Npc/NC_SUPER_SOLDIERS.json
+++ b/Npc/NC_SUPER_SOLDIERS.json
@@ -19,27 +19,27 @@
   {
     "id": "NC_SUPER_SOLDIER_carry",
     "type": "item_group",
-    "//": "Super soldier items.  Now that NPCs can use UPS, we do so.",
     "subtype": "collection",
+    "ammo": 100,
     "entries": [
       { "item": "militarymap" },
       { "item": "id_military" },
-      { "item": "adv_UPS_off", "charges": [ 1250, 2500 ] }
+      { "item": "medium_atomic_battery_cell", "count": [ 1, 2 ] }
     ]
   },
   {
     "id": "NC_SUPER_SOLDIER_weapon",
     "type": "item_group",
     "subtype": "collection",
-    "//": "Randomly picks any of the weapons used by player super soldiers.",
+    "magazine": 100,
+    "ammo": 100,
+    "//": "Randomly picks any of the medium-power super soldier energy weapons.",
     "entries": [
       {
         "distribution": [
-          { "item": "arc_laser_rifle", "prob": 25, "contents-item": [ "shoulder_strap", "knife_combat" ] },
-          { "item": "neo_laser_pistol", "prob": 20, "contents-item": [ "pistol_bayonet" ] },
-          { "item": "akro_laser_smg", "prob": 15, "contents-item": [ "shoulder_strap", "knife_combat" ] },
-          { "item": "xarm_laser_shotgun", "prob": 10, "contents-item": [ "shoulder_strap", "knife_combat" ] },
-          { "item": "mx_laser_sniper", "prob": 5, "contents-item": [ "shoulder_strap", "knife_combat" ] }
+          { "item": "arc_laser_rifle", "prob": 50, "contents-item": [ "shoulder_strap", "knife_combat" ] },
+          { "item": "xarm_laser_shotgun", "prob": 30, "contents-item": [ "shoulder_strap", "knife_combat" ] },
+          { "item": "mx_laser_sniper", "prob": 20, "contents-item": [ "shoulder_strap", "knife_combat" ] }
         ]
       }
     ]
@@ -67,11 +67,13 @@
     "id": "NC_BIO_HUNTER_E_carry",
     "type": "item_group",
     "subtype": "collection",
+    "magazine": 100,
+    "ammo": 100,
     "entries": [
       { "item": "mre_veggy_box" },
       { "item": "biomap" },
       { "item": "militarymap" },
-      { "item": "adv_UPS_off", "charges": [ 1250, 2500 ] },
+      { "item": "light_atomic_battery_cell", "count": [ 5, 10 ] },
       { "group": "everyday_gear" },
       { "group": "drugs_soldier", "prob": 50 },
       { "group": "supplies_electronics", "prob": 50, "count": [ 1, 3 ] }
@@ -82,6 +84,8 @@
     "type": "item_group",
     "//": "Evelynn Rose's weapon, don't think you can define weapon overrides any other way.",
     "subtype": "collection",
+    "magazine": 100,
+    "ammo": 100,
     "entries": [ { "item": "akro_laser_smg", "contents-item": [ "shoulder_strap", "knife_combat" ] } ]
   }
 ]

--- a/Surv_help/c_item_groups.json
+++ b/Surv_help/c_item_groups.json
@@ -198,7 +198,8 @@
       [ "stim", 5 ],
       [ "stealth_cloak_f", 3 ],
       [ "boots_stealth", 3 ],
-      [ "goggles_nv_clairvoyance", 3 ]
+      [ "goggles_nv_clairvoyance", 3 ],
+      { "group": "ammo_atomic_batteries", "prob": 5 }
     ]
   },
   {
@@ -370,11 +371,7 @@
   {
     "id": "manuals",
     "type": "item_group",
-    "items": [
-      [ "recipe_surv", 1 ],
-      [ "manual_surv", 1 ],
-      { "group": "encylopedias_common", "prob": 1 }
-    ]
+    "items": [ [ "recipe_surv", 1 ], [ "manual_surv", 1 ], { "group": "encylopedias_common", "prob": 1 } ]
   },
   {
     "id": "mansion_books",
@@ -397,20 +394,6 @@
     "items": [ { "group": "encylopedias_common", "prob": 10 }, { "group": "encylopedias_rare", "prob": 5 }, [ "biomap", 1 ] ]
   },
   {
-    "id": "mil_rifles",
-    "type": "item_group",
-    "items": [
-      [ "neo_laser_pistol", 2 ],
-      [ "akro_laser_smg", 2 ],
-      [ "arc_laser_rifle", 2 ],
-      [ "krx_laser_lmg", 2 ],
-      [ "mx_laser_sniper", 2 ],
-      [ "xarm_laser_shotgun", 2 ],
-      [ "br_bolt_rifle_elec", 2 ],
-      [ "mk_ionic_cannon", 2 ]
-    ]
-  },
-  {
     "id": "helicopter",
     "type": "item_group",
     "items": [
@@ -421,21 +404,8 @@
       [ "mx_laser_sniper", 2 ],
       [ "xarm_laser_shotgun", 2 ],
       [ "br_bolt_rifle_elec", 2 ],
-      [ "mk_ionic_cannon", 2 ]
-    ]
-  },
-  {
-    "id": "army_rifles",
-    "type": "item_group",
-    "items": [
-      [ "neo_laser_pistol", 2 ],
-      [ "akro_laser_smg", 2 ],
-      [ "arc_laser_rifle", 2 ],
-      [ "krx_laser_lmg", 2 ],
-      [ "mx_laser_sniper", 2 ],
-      [ "xarm_laser_shotgun", 2 ],
-      [ "br_bolt_rifle_elec", 2 ],
-      [ "mk_ionic_cannon", 2 ]
+      [ "mk_ionic_cannon", 2 ],
+      { "group": "ammo_atomic_batteries_full", "prob": 5 }
     ]
   },
   {
@@ -460,7 +430,8 @@
       [ "evil_invitation", 2 ],
       [ "blood_m", 2 ],
       [ "blood_p", 2 ],
-      [ "anesthesia", 2 ]
+      [ "anesthesia", 2 ],
+      { "group": "ammo_atomic_batteries", "prob": 10 }
     ]
   },
   {
@@ -481,7 +452,8 @@
       [ "boots_stealth", 2 ],
       [ "goggles_nv_clairvoyance", 2 ],
       [ "blood_m", 1 ],
-      [ "blood_p", 1 ]
+      [ "blood_p", 1 ],
+      { "group": "ammo_atomic_batteries", "prob": 10 }
     ]
   },
   {
@@ -567,13 +539,7 @@
     "type": "item_group",
     "magazine": 100,
     "ammo": 75,
-    "items": [
-      [ "makarov", 25 ],
-      [ "ak47", 5 ],
-      [ "ak74", 10 ],
-      [ "sks", 10 ],
-      [ "shotgun_d", 50 ]
-    ]
+    "items": [ [ "makarov", 25 ], [ "ak47", 5 ], [ "ak74", 10 ], [ "sks", 10 ], [ "shotgun_d", 50 ] ]
   },
   {
     "id": "sketchy_cabin_gore",
@@ -588,36 +554,50 @@
   {
     "id": "sketchy_cabin_ashes",
     "type": "item_group",
-    "items": [
-      { "item": "ash", "prob": 50, "charges": [ 50, 250 ] },
-      { "item": "meal_bone", "prob": 50, "charges": [ 5, 10 ] }
-    ]
+    "items": [ { "item": "ash", "prob": 50, "charges": [ 50, 250 ] }, { "item": "meal_bone", "prob": 50, "charges": [ 5, 10 ] } ]
   },
   {
     "id": "guns_pistol_improvised",
     "type": "item_group",
-    "items": [ [ "unbio_laser_gun", 1 ], [ "surv_battery_pistol", 1 ] ]
+    "items": [ [ "unbio_laser_gun", 1 ], { "item": "surv_battery_pistol", "prob": 1, "charges-min": 0, "charges-max": 50 } ]
   },
   {
     "id": "guns_smg_improvised",
     "type": "item_group",
-    "items": [ [ "surv_full_22", 1 ], [ "surv_full_9mm", 1 ], [ "surv_full_45", 1 ] ]
+    "items": [
+      { "item": "surv_full_22", "prob": 1, "charges-min": 0, "charges-max": 30 },
+      { "item": "surv_full_9mm", "prob": 1, "charges-min": 0, "charges-max": 30 },
+      { "item": "surv_full_45", "prob": 1, "charges-min": 0, "charges-max": 30 }
+    ]
   },
   {
     "id": "guns_rifle_improvised",
     "type": "item_group",
     "items": [
       [ "unbio_chain_lightning", 1 ],
-      [ "surv_battery_rifle", 1 ],
-      [ "surv_full_223", 1 ],
-      [ "surv_full_308", 1 ],
-      [ "surv_full_762", 1 ]
+      { "item": "surv_battery_rifle", "prob": 1, "charges-min": 0, "charges-max": 100 },
+      { "item": "surv_full_223", "prob": 1, "charges-min": 0, "charges-max": 20 },
+      { "item": "surv_full_308", "prob": 1, "charges-min": 0, "charges-max": 20 },
+      { "item": "surv_full_762", "prob": 1, "charges-min": 0, "charges-max": 20 }
     ]
   },
   {
     "id": "guns_shotgun_improvised",
     "type": "item_group",
-    "items": [ [ "surv_full_12", 1 ] ]
+    "items": [ { "item": "surv_full_12", "prob": 1, "charges-min": 0, "charges-max": 10 } ]
+  },
+  {
+    "id": "guns_energy",
+    "type": "item_group",
+    "items": [
+      [ "mk_ionic_cannon", 1 ],
+      { "item": "neo_laser_pistol", "prob": 1, "charges-min": 0, "charges-max": 500 },
+      { "item": "akro_laser_smg", "prob": 1, "charges-min": 0, "charges-max": 1000 },
+      { "item": "arc_laser_rifle", "prob": 1, "charges-min": 0, "charges-max": 5000 },
+      { "item": "krx_laser_lmg", "prob": 1, "charges-min": 0, "charges-max": 10000 },
+      { "item": "mx_laser_sniper", "prob": 1, "charges-min": 0, "charges-max": 5000 },
+      { "item": "xarm_laser_shotgun", "prob": 1, "charges-min": 0, "charges-max": 5000 }
+    ]
   },
   {
     "type": "item_group",
@@ -751,6 +731,41 @@
       [ "bio_sunglasses", 7 ],
       [ "bio_ups", 8 ],
       [ "bio_watch", 10 ]
+    ]
+  },
+  {
+    "id": "electronics",
+    "type": "item_group",
+    "items": [ { "group": "ammo_atomic_batteries", "prob": 1 } ]
+  },
+  {
+    "id": "vault",
+    "type": "item_group",
+    "items": [ { "group": "ammo_atomic_batteries", "prob": 5 } ]
+  },
+  {
+    "id": "tools_science",
+    "type": "item_group",
+    "items": [ { "group": "ammo_atomic_batteries_full", "prob": 10 } ]
+  },
+  {
+    "id": "ammo_atomic_batteries",
+    "type": "item_group",
+    "items": [
+      { "item": "light_battery_cell", "prob": 4, "charges-min": 0, "charges-max": 1000 },
+      { "item": "light_minus_atomic_battery_cell", "prob": 3, "charges-min": 0, "charges-max": 500 },
+      { "item": "medium_battery_cell", "prob": 2, "charges-min": 0, "charges-max": 5000 },
+      { "item": "heavy_battery_cell", "prob": 1, "charges-min": 0, "charges-max": 10000 }
+    ]
+  },
+  {
+    "id": "ammo_atomic_batteries_full",
+    "type": "item_group",
+    "items": [
+      { "item": "light_battery_cell", "prob": 4, "charges-min": 1000, "charges-max": 1000 },
+      { "item": "light_minus_atomic_battery_cell", "prob": 3, "charges-min": 500, "charges-max": 500 },
+      { "item": "medium_battery_cell", "prob": 2, "charges-min": 5000, "charges-max": 5000 },
+      { "item": "heavy_battery_cell", "prob": 1, "charges-min": 10000, "charges-max": 10000 }
     ]
   }
 ]

--- a/Weapons/c_ranged.json
+++ b/Weapons/c_ranged.json
@@ -358,7 +358,18 @@
     "ammo_effects": [ "LIGHTNING" ],
     "flags": [ "FIRE_50" ],
     "ammo": "battery",
-    "magazines": [ [ "battery", [ "light_battery_cell", "light_plus_battery_cell", "light_minus_battery_cell" ] ] ],
+    "magazines": [
+      [
+        "battery",
+        [
+          "light_battery_cell",
+          "light_plus_battery_cell",
+          "light_minus_battery_cell",
+          "light_disposable_cell",
+          "light_minus_disposable_cell"
+        ]
+      ]
+    ],
     "skill": "pistol",
     "ranged_damage": 4,
     "range": 10,
@@ -387,7 +398,7 @@
     "ammo_effects": [ "LIGHTNING" ],
     "flags": [ "FIRE_100", "ALWAY_TWOHAND" ],
     "ammo": "battery",
-    "magazines": [ [ "battery", [ "medium_battery_cell", "medium_plus_battery_cell" ] ] ],
+    "magazines": [ [ "battery", [ "medium_battery_cell", "medium_plus_battery_cell", "medium_disposable_cell" ] ] ],
     "skill": "rifle",
     "ranged_damage": 8,
     "range": 15,
@@ -930,13 +941,13 @@
     "symbol": "(",
     "color": "dark_gray",
     "name": "NEO-33 laser pistol",
-    "description": "A relatively small laser pistol. Features a boxy design with just enough concessions to ergonomics to fit well in the hand.  The markings refer to \"Omnitech Labs\" as the manufacturer.  It appears to be geared toward energy efficiency at the expense of damage, range, and modularity.",
+    "description": "A relatively small laser pistol, boxy design having just enough concessions to ergonomics to fit well in the hand.  It draws power from compact atomic batteries, offering energy efficiency and prolonged usage, at the expense of firepower and range.  The markings refer to \"Omnitech Labs\" as the manufacturer.",
     "price": 1800000,
     "material": [ "superalloy", "steel" ],
     "ammo_effects": [ "LASER", "INCENDIARY" ],
-    "flags": [ "NO_AMMO", "NEVER_JAMS", "NO_UNLOAD" ],
-    "ups_charges": 5,
+    "flags": [ "NEVER_JAMS", "FIRE_20" ],
     "skill": "pistol",
+    "ammo": "battery",
     "weight": 720,
     "volume": 4,
     "bashing": 4,
@@ -944,12 +955,9 @@
     "ranged_damage": 10,
     "pierce": 2,
     "range": 10,
-    "dispersion": 0,
-    "//": "Laser means no dispersion.",
     "aim_speed": 4,
-    "recoil": 0,
     "durability": 10,
-    "reload": 0,
+    "reload": 150,
     "built_in_mods": [ "rail_laser_sight" ],
     "valid_mod_locations": [
       [ "accessories", 2 ],
@@ -959,7 +967,8 @@
       [ "underbarrel", 1 ],
       [ "emitter", 1 ],
       [ "lens", 1 ]
-    ]
+    ],
+    "magazines": [ [ "battery", [ "light_minus_atomic_battery_cell", "light_atomic_battery_cell" ] ] ]
   },
   {
     "id": "akro_laser_smg",
@@ -968,12 +977,12 @@
     "symbol": "(",
     "color": "dark_gray",
     "name": "AKRO-388 laser SMG",
-    "description": "Based on the design of the NEO-33, the AKRO-388 is built balance energy efficiency with rate of fire, offering decent firepower relative to the laser pistol that influenced it.  Its body is scaled up and adapted to better handle like common submachineguns in active service.  Its manufacturer is listed as Omnitech Labs.",
+    "description": "Based on the design of the NEO-33, the AKRO-388 is balances energy efficiency with rate of fire, offering decent firepower.  Its body is scaled up and adapted to better handle like common submachineguns in active service.  Relies on atomic batteries instead of a UPS connection.  Its manufacturer is listed as Omnitech Labs.",
     "price": 1800000,
     "material": [ "superalloy", "steel" ],
     "ammo_effects": [ "LASER", "INCENDIARY" ],
-    "flags": [ "NO_AMMO", "MODE_BURST", "NEVER_JAMS", "NO_UNLOAD" ],
-    "ups_charges": 10,
+    "flags": [ "MODE_BURST", "NEVER_JAMS", "FIRE_20" ],
+    "ammo": "battery",
     "skill": "smg",
     "weight": 2680,
     "volume": 6,
@@ -982,12 +991,9 @@
     "ranged_damage": 20,
     "pierce": 5,
     "range": 20,
-    "dispersion": 0,
-    "//": "Laser means no dispersion.",
-    "recoil": 0,
     "durability": 10,
     "modes": [ [ "DEFAULT", "semi", 1 ], [ "BURST", "spray", 10 ], [ "AUTO", "auto", 15 ] ],
-    "reload": 0,
+    "reload": 200,
     "default_mods": [ "rail_laser_sight", "holo_sight", "pistol_grip" ],
     "built_in_mods": [ "grip" ],
     "valid_mod_locations": [
@@ -1000,7 +1006,8 @@
       [ "underbarrel", 2 ],
       [ "emitter", 1 ],
       [ "lens", 1 ]
-    ]
+    ],
+    "magazines": [ [ "battery", [ "light_atomic_battery_cell", "light_minus_atomic_battery_cell" ] ] ]
   },
   {
     "id": "arc_laser_rifle",
@@ -1009,12 +1016,12 @@
     "color": "dark_gray",
     "looks_like": "laser_rifle",
     "name": "ARC-314 laser rifle",
-    "description": "An experimental laser rifle based on the A7 and AKRO-388.  Offers the modular benefits of a combat rifle with the efficiency of a laser weapon, in a relatively compact package.  Overall it mimics the handling and operation of common rifles currently in service, for ease-of-use.  The manufacturer is listed as Omnitech Labs.",
+    "description": "An experimental laser rifle based on the A7 and AKRO-388, adapted to rely on atomic batteries.  Offers the modular benefits of a combat rifle with the efficiency of a laser weapon, in a relatively compact package.  Overall it mimics the handling and operation of common rifles currently in service, for ease-of-use.  The manufacturer is listed as Omnitech Labs.",
     "price": 1800000,
     "material": [ "superalloy", "steel" ],
     "ammo_effects": [ "LASER", "INCENDIARY" ],
-    "flags": [ "NO_AMMO", "MODE_BURST", "NEVER_JAMS", "NO_UNLOAD" ],
-    "ups_charges": 20,
+    "flags": [ "MODE_BURST", "NEVER_JAMS", "FIRE_50" ],
+    "ammo": "battery",
     "skill": "rifle",
     "weight": 3120,
     "volume": 8,
@@ -1023,12 +1030,9 @@
     "ranged_damage": 50,
     "pierce": 10,
     "range": 30,
-    "dispersion": 0,
-    "//": "Laser means no dispersion.",
-    "recoil": 0,
     "durability": 10,
     "modes": [ [ "DEFAULT", "semi", 1 ], [ "BURST", "burst", 3 ], [ "AUTO", "auto", 10 ] ],
-    "reload": 0,
+    "reload": 200,
     "default_mods": [ "holo_sight", "pistol_grip", "grip" ],
     "valid_mod_locations": [
       [ "accessories", 4 ],
@@ -1040,7 +1044,8 @@
       [ "underbarrel", 2 ],
       [ "emitter", 1 ],
       [ "lens", 1 ]
-    ]
+    ],
+    "magazines": [ [ "battery", [ "medium_atomic_battery_cell" ] ] ]
   },
   {
     "id": "krx_laser_lmg",
@@ -1049,12 +1054,12 @@
     "symbol": "(",
     "color": "dark_gray",
     "name": "KRX-108 laser LMG",
-    "description": "With the power per shot of the ARC and the firerate of the AKRO, Omnitech Labs' KRX-108 was made to overwhelm enemies with supreme firepower.  While not very energy-efficient, this behemoth can deal a devastating blow to large groups of enemies, if you can afford its energy demands.  If attached to a vehicle mount, it can also make full use of its otherwise-limited automated targeting.",
+    "description": "With the power per shot of the ARC and the firerate of the AKRO, Omnitech Labs' KRX-108 was made to overwhelm enemies with supreme firepower.  While not very energy-efficient, this behemoth can deal a devastating blow to large groups of enemies, but each pulse draws heavily from a proprietary atomic battery connection.  If attached to a vehicle mount, it can also make full use of its otherwise-limited automated targeting.",
     "price": 1800000,
     "material": [ "superalloy", "steel" ],
     "ammo_effects": [ "LASER", "INCENDIARY" ],
-    "flags": [ "ALWAYS_TWOHAND", "NO_AMMO", "MODE_BURST", "NEVER_JAMS", "NO_UNLOAD" ],
-    "ups_charges": 50,
+    "flags": [ "ALWAYS_TWOHAND", "MODE_BURST", "NEVER_JAMS", "FIRE_50" ],
+    "ammo": "battery",
     "skill": "rifle",
     "weight": 5620,
     "volume": 12,
@@ -1068,7 +1073,7 @@
     "recoil": 5,
     "durability": 8,
     "modes": [ [ "DEFAULT", "low auto", 10 ], [ "BURST", "medium auto", 15 ], [ "AUTO", "high auto", 25 ] ],
-    "reload": 0,
+    "reload": 500,
     "valid_mod_locations": [
       [ "accessories", 2 ],
       [ "sling", 1 ],
@@ -1077,7 +1082,8 @@
       [ "underbarrel", 1 ],
       [ "emitter", 1 ],
       [ "lens", 1 ]
-    ]
+    ],
+    "magazines": [ [ "battery", [ "heavy_atomic_battery_cell" ] ] ]
   },
   {
     "id": "mx_laser_sniper",
@@ -1086,12 +1092,12 @@
     "symbol": "(",
     "color": "dark_gray",
     "name": "MX-84 laser sniper",
-    "description": "Omnitech Labs' single shot laser rifle, designed to deal massive damage to a single target.  Intended to be used as a long-range support weapon by modern special forces.  Requires an insane amount of energy to fire a single powerful laser, additionally providing EMP effects.",
+    "description": "Omnitech Labs' single shot laser rifle, designed to deal massive damage to a single target.  Intended to be used as a long-range support weapon by modern special forces.  Requires an insane amount of energy to fire a single powerful laser, additionally providing EMP effects.  Uses a propietary atomic battery capacitor system",
     "price": 1600000,
     "material": [ "superalloy", "steel" ],
     "ammo_effects": [ "DRAW_LASER_BEAM", "EMP", "INCENDIARY" ],
-    "flags": [ "ALWAYS_TWOHAND", "NO_AMMO", "NEVER_JAMS", "NO_UNLOAD" ],
-    "ups_charges": 100,
+    "flags": [ "ALWAYS_TWOHAND", "NEVER_JAMS", "FIRE_100" ],
+    "ammo": "battery",
     "skill": "rifle",
     "weight": 2950,
     "volume": 12,
@@ -1100,10 +1106,9 @@
     "ranged_damage": 150,
     "pierce": 20,
     "range": 60,
-    "dispersion": 0,
     "recoil": 10,
     "durability": 10,
-    "reload": 100,
+    "reload": 300,
     "default_mods": [ "bipod" ],
     "built_in_mods": [ "rifle_scope" ],
     "valid_mod_locations": [
@@ -1116,7 +1121,8 @@
       [ "underbarrel", 2 ],
       [ "emitter", 1 ],
       [ "lens", 1 ]
-    ]
+    ],
+    "magazines": [ [ "battery", [ "medium_atomic_battery_cell" ] ] ]
   },
   {
     "id": "xarm_laser_shotgun",
@@ -1125,12 +1131,12 @@
     "symbol": "(",
     "color": "dark_gray",
     "name": "XARM-37 Pulse Scatter Gun",
-    "description": "This is a modified double-barreled ARC rifle, designed by Omnitech Labs.  Gains an EMP effect at the cost of range and firepower.  It is fired in short pulses that act like buckshot; still decent against conventional threats but best against electronics.",
+    "description": "This is a modified double-barreled ARC rifle, designed by Omnitech Labs.  Gains an EMP effect at the cost of range and firepower, still relies on atonic cells instead of a UPS hookup.  It is fired in short pulses that act like buckshot; still decent against conventional threats but best against electronics.",
     "price": 1800000,
     "material": [ "superalloy", "steel" ],
     "ammo_effects": [ "LASER", "INCENDIARY", "SHOT", "EMP" ],
-    "flags": [ "NO_AMMO", "MODE_BURST", "NEVER_JAMS", "NO_UNLOAD" ],
-    "ups_charges": 20,
+    "flags": [ "MODE_BURST", "NEVER_JAMS", "FIRE_50" ],
+    "ammo": "battery",
     "skill": "shotgun",
     "weight": 2950,
     "volume": 8,
@@ -1140,12 +1146,10 @@
     "pierce": 5,
     "range": 10,
     "dispersion": 300,
-    "//": "Shotgun is a shotgun.",
-    "recoil": 0,
     "durability": 8,
     "default_mods": [ "rail_laser_sight", "pistol_grip" ],
     "modes": [ [ "DEFAULT", "semi", 1 ], [ "BURST", "double-barrel", 2 ] ],
-    "reload": 0,
+    "reload": 250,
     "valid_mod_locations": [
       [ "accessories", 2 ],
       [ "sling", 1 ],
@@ -1156,7 +1160,8 @@
       [ "underbarrel", 1 ],
       [ "emitter", 1 ],
       [ "lens", 1 ]
-    ]
+    ],
+    "magazines": [ [ "battery", [ "medium_atomic_battery_cell" ] ] ]
   },
   {
     "id": "br_bolt_rifle_elec",


### PR DESCRIPTION
Thanks to @jmattspartacus for finding the cause of the bug this fixes.

* Overhauled the fancy laser weapons once again. Now they use atomic batteries instead of UPS, as a properly-functional version of the older "use plutonium cells outright" idea Noct had.
* Also rebalanced the Omnitech laser weapons to use variously FIRE_20 (I only just now learned that's a thing), FIRE_50, or FIRE_100. In addition they make use of reload time now (generally slower than changing a mag for mundane guns), with description tweaks to mention the change, and removal of some properties that were just setting the default 0.
* Set the NPCs that had UPS weapons to now use the right sorts of atomic-powered versions of the weapon, and have the right sorts of cells on hand.
* Because it turns out that neither the atomic batteries nor their recipe book SPAWN anywhere in vanilla, some itemgroup entries have been added to allow them to spawn in likely places, to make them rare but not impossible to find.
* Changed zombie super soldiers to drop their weapons with random amounts of charge left in the battery, and a chance of dropping a less-depleted spare battery.
* Added disposable batteries to the options available for loading survivor battery guns.

Closes https://github.com/Noctifer-de-Mortem/nocts_cata_mod/issues/106

One thing that could be done as well, maybe, would be to re-implement the idea of converting the Omnitech laser weapons to use something else. In this case, instead of converting UPS weapons to plutonium cells, either they could be converted to UPS, OR one could add converting them to allow comparable non-atomic batteries. If the latter, in addition to rather obviously burning energy extremely fast when fueled by normal batteries, one could also add reliability and other penalties.