### PR TITLE
Implement RTG CBM inductor item

### DIFF
--- a/Char_creation/c_classes_bw.json
+++ b/Char_creation/c_classes_bw.json
@@ -310,11 +310,9 @@
       "bio_power_storage_mkII",
       "bio_power_storage_mkII",
       "bio_power_armor_interface_mkII",
-      "bio_torsionratchet",
-      "bio_advreactor",
-      "bio_plut_filter"
+      "bio_torsionratchet"
     ],
-    "items": { "both": [ "badge_bio_weapon", "subsuit_xl", "footrags" ], "male": [ "briefs" ], "female": [ "bra", "panties" ] },
+    "items": { "both": [ "badge_bio_weapon", "subsuit_xl", "footrags", "cbm_rtg_inductor" ], "male": [ "briefs" ], "female": [ "bra", "panties" ] },
     "flags": [ "SCEN_ONLY" ]
   },
   {
@@ -548,8 +546,6 @@
       "bio_purifier",
       "bio_nanobots",
       "bio_painkiller",
-      "bio_advreactor",
-      "bio_plut_filter",
       "bio_radscrubber",
       "bio_power_armor_interface_mkII",
       "bio_ups",
@@ -565,7 +561,7 @@
       { "level": 3, "name": "dodge" }
     ],
     "items": {
-      "both": { "items": [ "hmil_armor" ], "entries": [ { "item": "krx_laser_lmg", "contents-item": [ "shoulder_strap" ] } ] },
+      "both": { "items": [ "hmil_armor", "cbm_rtg_inductor" ], "entries": [ { "item": "krx_laser_lmg", "contents-item": [ "shoulder_strap" ] } ] },
       "male": [ "boxer_shorts" ],
       "female": [ "bra", "panties" ]
     },

--- a/Monsters/c_monster_drops.json
+++ b/Monsters/c_monster_drops.json
@@ -142,6 +142,7 @@
       { "item": "dump_pouch", "damage": [ 1, 4 ], "chance": 50 },
       { "item": "krx_laser_lmg", "damage": [ 0, 3 ], "charges": [ 0, 5000 ] },
       { "item": "heavy_atomic_battery_cell", "damage": [ 0, 1 ], "charges": [ 0, 10000 ], "chance": 25 },
+      { "item": "cbm_rtg_inductor", "damage": [ 0, 3 ], "chance": 25 },
       { "item": "militarymap", "damage": [ 0, 1 ], "chance": 10 },
       { "item": "id_military", "damage": [ 0, 1 ], "chance": 10 }
     ]
@@ -160,6 +161,7 @@
       { "item": "lmil_armor", "damage": [ 1, 4 ] },
       { "item": "dump_pouch", "damage": [ 1, 4 ], "chance": 50 },
       { "item": "mk_ionic_cannon", "damage": [ 0, 3 ] },
+      { "item": "cbm_rtg_inductor", "damage": [ 0, 3 ], "chance": 25 },
       { "item": "militarymap", "damage": [ 0, 1 ], "chance": 10 },
       { "item": "id_military", "damage": [ 0, 1 ], "chance": 10 }
     ]

--- a/Surv_help/c_item_groups.json
+++ b/Surv_help/c_item_groups.json
@@ -198,7 +198,6 @@
       [ "stim", 5 ],
       [ "stealth_cloak_f", 3 ],
       [ "boots_stealth", 3 ],
-      [ "goggles_nv_clairvoyance", 3 ],
       { "group": "ammo_atomic_batteries", "prob": 5 }
     ]
   },
@@ -405,6 +404,7 @@
       [ "xarm_laser_shotgun", 2 ],
       [ "br_bolt_rifle_elec", 2 ],
       [ "mk_ionic_cannon", 2 ],
+      [ "cbm_rtg_inductor", 1 ],
       { "group": "ammo_atomic_batteries_full", "prob": 5 }
     ]
   },
@@ -453,6 +453,7 @@
       [ "goggles_nv_clairvoyance", 2 ],
       [ "blood_m", 1 ],
       [ "blood_p", 1 ],
+      [ "cbm_rtg_inductor", 1 ],
       { "group": "ammo_atomic_batteries", "prob": 10 }
     ]
   },
@@ -628,7 +629,6 @@
     "subtype": "distribution",
     "//": "Bionics for Bio-Weapon Apophis.  Roughly mocked up from what bionics might fit his in-game properties.",
     "items": [
-      [ "bio_advreactor", 1 ],
       [ "bio_armor_arms", 8 ],
       [ "bio_armor_eyes", 6 ],
       [ "bio_armor_head", 6 ],
@@ -644,7 +644,6 @@
       [ "bio_metabolics", 7 ],
       [ "bio_nanobots", 5 ],
       [ "bio_painkiller", 7 ],
-      [ "bio_plut_filter", 5 ],
       [ "bio_radscrubber", 7 ],
       [ "bio_shock", 6 ],
       [ "bio_sword", 3 ],
@@ -676,7 +675,6 @@
     "subtype": "distribution",
     "//": "Bionics for zombie super juggernauts.",
     "items": [
-      [ "bio_advreactor", 1 ],
       [ "bio_armor_arms", 8 ],
       [ "bio_armor_eyes", 6 ],
       [ "bio_armor_head", 6 ],
@@ -686,7 +684,6 @@
       [ "bio_ears", 5 ],
       [ "bio_nanobots", 5 ],
       [ "bio_painkiller", 7 ],
-      [ "bio_plut_filter", 5 ],
       [ "bio_power_armor_interface_mkII", 3 ],
       [ "bio_purifier", 7 ],
       [ "bio_radscrubber", 7 ],

--- a/Surv_help/c_spells.json
+++ b/Surv_help/c_spells.json
@@ -1,0 +1,43 @@
+[
+  {
+    "id": "c_cbm_rtg_induction",
+    "type": "SPELL",
+    "name": "CBM Induction",
+    "description": "Charges the user's bionic reserves via induction.",
+    "valid_targets": [ "self" ],
+    "flags": [ "SILENT", "NO_HANDS", "NO_LEGS" ],
+    "min_damage": 50,
+    "max_damage": 50,
+    "base_casting_time": 200,
+    "max_level": 10,
+    "effect": "recover_energy",
+    "effect_str": "BIONIC",
+    "extra_effects": [ { "id": "c_cbm_rtg_induction_2", "hit_self": true, "max_level": 10 }, { "id": "c_cbm_rtg_induction_3", "hit_self": true, "max_level": 10 } ]
+  },
+  {
+    "id": "c_cbm_rtg_induction_2",
+    "type": "SPELL",
+    "name": "CBM Induction Heat",
+    "description": "Vented waste heat.",
+    "valid_targets": [ "self" ],
+    "effect": "target_attack",
+    "max_level": 10,
+    "field_id": "fd_hot_air3",
+    "min_field_intensity": 2,
+    "max_field_intensity": 2,
+    "field_chance": 1
+  },
+  {
+    "id": "c_cbm_rtg_induction_3",
+    "type": "SPELL",
+    "name": "CBM Induction Rads",
+    "description": "Radiation!",
+    "valid_targets": [ "self" ],
+    "effect": "target_attack",
+    "max_level": 10,
+    "field_id": "fd_nuke_gas",
+    "min_field_intensity": 1,
+    "max_field_intensity": 1,
+    "field_chance": 1
+  }
+]

--- a/Surv_help/c_tools.json
+++ b/Surv_help/c_tools.json
@@ -862,5 +862,28 @@
     "volume": 12,
     "to_hit": -2,
     "material": [ "plastic", "steel" ]
+  },
+  {
+    "id": "cbm_rtg_inductor",
+    "type": "TOOL_ARMOR",
+    "symbol": ";",
+    "color": "light_green",
+    "name": "inductive CBM charger",
+    "description": "A prototype device giving off noticeable heat, housing a compact radioisotope thermoelectric generator.  It does not seem to accept batteries or even provide a UPS hookup, instead housing an inductive charging system designed specifically for CBM power storage.  Being an unfinished design, the only way to dump power into the inductor without electrocuting yourself requires opening up part of the mechanism, exposing you to radiation.",
+    "price": 1200000,
+    "material": [ "plastic", "aluminum" ],
+    "covers": [ "TORSO" ],
+    "flags": [ "LEAK_DAM", "RADIOACTIVE", "WAIST", "OVERSIZE" ],
+    "weight": 2200,
+    "volume": 12,
+    "bashing": 4,
+    "max_charges": 50,
+    "charges_per_use": 1,
+    "use_action": { "type": "cast_spell", "spell_id": "c_cbm_rtg_induction", "no_fail": true, "level": 10 },
+    "coverage": 25,
+    "encumbrance": 5,
+    "warmth": 20,
+    "material_thickness": 2,
+    "artifact_data": { "charge_type": "ARTC_TIME" }
   }
 ]

--- a/Terrain/Unknown_Lab.json
+++ b/Terrain/Unknown_Lab.json
@@ -491,6 +491,7 @@
         { "group": "mut_lab", "x": 18, "y": [ 15, 18 ], "chance": 50, "repeat": 12 },
         { "group": "bionics_mil", "x": 20, "y": [ 3, 7 ], "chance": 75, "repeat": 5 },
         { "group": "bionics_sci", "x": 20, "y": [ 3, 7 ], "chance": 75, "repeat": 5 },
+        { "item": "cbm_rtg_inductor", "x": 20, "y": [ 3, 7 ] },
         { "item": "anesthesia", "x": [ 7, 8 ], "y": 4, "chance": 75, "repeat": 2 },
         { "group": "map_extra_military", "x": 8, "y": 11, "chance": 95 },
         { "group": "map_extra_military", "x": 12, "y": 9, "chance": 95 },


### PR DESCRIPTION
This is an item idea that the spell system has finally made possible, via both items able to cast spells and via a spell being able to charge CBM power, as a way to deal with the fact that CBMs have been getting fewer and fewer powergen options. Eventually minireactor CBM will likely stop working, so...

* Implemented the CBM induction charger. Wearable item meant to provide an alternative method of power at a steady rate, with some disadvantages if overused. Uses artifact charging properties to simulate RTG power generation (over time), and its spell-based `use_action` provides a proper conversion of 1 hour's worth of charging into a given amount of bionic power.
* Gave the item to Bio-Weapon Beta and the super soldier juggernaut professions, in return removed their reactor CBM and plutonium filter.
* Also added the item, potentially damaged, to the drop list of zombie super juggernauts.
* Removed minireactor and related CBM from the harvest list for zombie super soldiers and Apophis.
* Added CBM inductive charger to a handful of other itemgroups.

Some things that oughta be done though:
* Spell effects current can't give radiation properly, so for now it spawns radioactive gas in addition to hot air. Will want to have it increment rads directly when used, once that option is available.
* Was tempted to add an option for crafting one very late in the game, but still sorting out what would be needed for that. As it is, having it be loot-only seems fine and more plausible anyway.
* Spawning on in the Unknown Lab might be a good idea too, sometime.