### PR TITLE
Staggered monstergroup additions

### DIFF
--- a/Monsters/c_monstergroups.json
+++ b/Monsters/c_monstergroups.json
@@ -6,14 +6,14 @@
     "auto_total": true,
     "monsters": [
       { "monster": "mon_failed_weapon", "freq": 15, "cost_multiplier": 20 },
-      { "monster": "mon_zombie_failed_weapon", "freq": 20, "cost_multiplier": 20 },
-      { "monster": "mon_zombie_bio_infantry_rifle", "freq": 20, "cost_multiplier": 15 },
-      { "monster": "mon_zombie_bio_infantry_shotgun", "freq": 20, "cost_multiplier": 15 },
-      { "monster": "mon_zombie_bio_knight_lmg", "freq": 20, "cost_multiplier": 15 },
-      { "monster": "mon_zombie_bio_knight_lauhcher", "freq": 50, "cost_multiplier": 15 },
-      { "monster": "mon_zombie_bio_scout_sniper", "freq": 20, "cost_multiplier": 15 },
-      { "monster": "mon_zombie_bio_tool_pistol", "freq": 20, "cost_multiplier": 15 },
-      { "monster": "mon_zombie_bio_tool_smg", "freq": 20, "cost_multiplier": 15 }
+      { "monster": "mon_zombie_failed_weapon", "freq": 20, "cost_multiplier": 20, "starts": 24 },
+      { "monster": "mon_zombie_bio_infantry_rifle", "freq": 20, "cost_multiplier": 15, "starts": 72 },
+      { "monster": "mon_zombie_bio_infantry_shotgun", "freq": 20, "cost_multiplier": 15, "starts": 72 },
+      { "monster": "mon_zombie_bio_knight_lmg", "freq": 20, "cost_multiplier": 15, "starts": 240 },
+      { "monster": "mon_zombie_bio_knight_lauhcher", "freq": 50, "cost_multiplier": 15, "starts": 240 },
+      { "monster": "mon_zombie_bio_scout_sniper", "freq": 20, "cost_multiplier": 15, "starts": 336 },
+      { "monster": "mon_zombie_bio_tool_pistol", "freq": 20, "cost_multiplier": 15, "starts": 168 },
+      { "monster": "mon_zombie_bio_tool_smg", "freq": 20, "cost_multiplier": 15, "starts": 168 }
     ]
   },
   {
@@ -23,14 +23,14 @@
     "auto_total": true,
     "monsters": [
       { "monster": "mon_failed_weapon", "freq": 20, "cost_multiplier": 20 },
-      { "monster": "mon_zombie_failed_weapon", "freq": 25, "cost_multiplier": 20 },
-      { "monster": "mon_zombie_bio_infantry_rifle", "freq": 20, "cost_multiplier": 15 },
-      { "monster": "mon_zombie_bio_infantry_shotgun", "freq": 20, "cost_multiplier": 15 },
-      { "monster": "mon_zombie_bio_knight_lmg", "freq": 20, "cost_multiplier": 15 },
-      { "monster": "mon_zombie_bio_knight_lauhcher", "freq": 50, "cost_multiplier": 15 },
-      { "monster": "mon_zombie_bio_scout_sniper", "freq": 20, "cost_multiplier": 15 },
-      { "monster": "mon_zombie_bio_tool_pistol", "freq": 20, "cost_multiplier": 15 },
-      { "monster": "mon_zombie_bio_tool_smg", "freq": 20, "cost_multiplier": 15 }
+      { "monster": "mon_zombie_failed_weapon", "freq": 25, "cost_multiplier": 20, "starts": 24 },
+      { "monster": "mon_zombie_bio_infantry_rifle", "freq": 20, "cost_multiplier": 15, "starts": 72 },
+      { "monster": "mon_zombie_bio_infantry_shotgun", "freq": 20, "cost_multiplier": 15, "starts": 72 },
+      { "monster": "mon_zombie_bio_knight_lmg", "freq": 20, "cost_multiplier": 15, "starts": 240 },
+      { "monster": "mon_zombie_bio_knight_lauhcher", "freq": 50, "cost_multiplier": 15, "starts": 240 },
+      { "monster": "mon_zombie_bio_scout_sniper", "freq": 20, "cost_multiplier": 15, "starts": 336 },
+      { "monster": "mon_zombie_bio_tool_pistol", "freq": 20, "cost_multiplier": 15, "starts": 168 },
+      { "monster": "mon_zombie_bio_tool_smg", "freq": 20, "cost_multiplier": 15, "starts": 168 }
     ]
   },
   {
@@ -40,14 +40,14 @@
     "auto_total": true,
     "monsters": [
       { "monster": "mon_failed_weapon", "freq": 1, "cost_multiplier": 50 },
-      { "monster": "mon_zombie_failed_weapon", "freq": 2, "cost_multiplier": 30 },
-      { "monster": "mon_fungus_failed_weapon", "freq": 1, "cost_multiplier": 30 },
-      { "monster": "mon_zombie_bio_infantry_rifle", "freq": 3, "cost_multiplier": 15 },
-      { "monster": "mon_zombie_bio_infantry_shotgun", "freq": 3, "cost_multiplier": 15 },
-      { "monster": "mon_zombie_bio_knight_lmg", "freq": 2, "cost_multiplier": 15 },
-      { "monster": "mon_zombie_bio_scout_sniper", "freq": 2, "cost_multiplier": 15 },
-      { "monster": "mon_zombie_bio_tool_pistol", "freq": 3, "cost_multiplier": 15 },
-      { "monster": "mon_zombie_bio_tool_smg", "freq": 3, "cost_multiplier": 15 }
+      { "monster": "mon_zombie_failed_weapon", "freq": 2, "cost_multiplier": 30, "starts": 24 },
+      { "monster": "mon_fungus_failed_weapon", "freq": 1, "cost_multiplier": 30, "starts": 48 },
+      { "monster": "mon_zombie_bio_infantry_rifle", "freq": 3, "cost_multiplier": 15, "starts": 72 },
+      { "monster": "mon_zombie_bio_infantry_shotgun", "freq": 3, "cost_multiplier": 15, "starts": 72 },
+      { "monster": "mon_zombie_bio_knight_lmg", "freq": 1, "cost_multiplier": 15, "starts": 240 },
+      { "monster": "mon_zombie_bio_scout_sniper", "freq": 2, "cost_multiplier": 15, "starts": 336 },
+      { "monster": "mon_zombie_bio_tool_pistol", "freq": 3, "cost_multiplier": 15, "starts": 168 },
+      { "monster": "mon_zombie_bio_tool_smg", "freq": 3, "cost_multiplier": 15, "starts": 168 }
     ]
   },
   {
@@ -57,14 +57,14 @@
     "auto_total": true,
     "monsters": [
       { "monster": "mon_failed_weapon", "freq": 1, "cost_multiplier": 50 },
-      { "monster": "mon_zombie_failed_weapon", "freq": 2, "cost_multiplier": 30 },
-      { "monster": "mon_fungus_failed_weapon", "freq": 1, "cost_multiplier": 30 },
-      { "monster": "mon_zombie_bio_infantry_rifle", "freq": 3, "cost_multiplier": 15 },
-      { "monster": "mon_zombie_bio_infantry_shotgun", "freq": 3, "cost_multiplier": 15 },
-      { "monster": "mon_zombie_bio_knight_lmg", "freq": 2, "cost_multiplier": 15 },
-      { "monster": "mon_zombie_bio_scout_sniper", "freq": 2, "cost_multiplier": 15 },
-      { "monster": "mon_zombie_bio_tool_pistol", "freq": 3, "cost_multiplier": 15 },
-      { "monster": "mon_zombie_bio_tool_smg", "freq": 3, "cost_multiplier": 15 }
+      { "monster": "mon_zombie_failed_weapon", "freq": 2, "cost_multiplier": 30, "starts": 24 },
+      { "monster": "mon_fungus_failed_weapon", "freq": 1, "cost_multiplier": 30, "starts": 48 },
+      { "monster": "mon_zombie_bio_infantry_rifle", "freq": 3, "cost_multiplier": 15, "starts": 72 },
+      { "monster": "mon_zombie_bio_infantry_shotgun", "freq": 3, "cost_multiplier": 15, "starts": 72 },
+      { "monster": "mon_zombie_bio_knight_lmg", "freq": 2, "cost_multiplier": 15, "starts": 240 },
+      { "monster": "mon_zombie_bio_scout_sniper", "freq": 2, "cost_multiplier": 15, "starts": 336 },
+      { "monster": "mon_zombie_bio_tool_pistol", "freq": 3, "cost_multiplier": 15, "starts": 168 },
+      { "monster": "mon_zombie_bio_tool_smg", "freq": 3, "cost_multiplier": 15, "starts": 168 }
     ]
   },
   {
@@ -73,13 +73,13 @@
     "override": false,
     "auto_total": true,
     "monsters": [
-      { "monster": "mon_zombie_bio_infantry_rifle", "freq": 10, "cost_multiplier": 15 },
-      { "monster": "mon_zombie_bio_infantry_shotgun", "freq": 10, "cost_multiplier": 15 },
-      { "monster": "mon_zombie_bio_knight_lmg", "freq": 10, "cost_multiplier": 15 },
-      { "monster": "mon_zombie_bio_knight_lauhcher", "freq": 5, "cost_multiplier": 15 },
-      { "monster": "mon_zombie_bio_scout_sniper", "freq": 10, "cost_multiplier": 15 },
-      { "monster": "mon_zombie_bio_tool_pistol", "freq": 10, "cost_multiplier": 15 },
-      { "monster": "mon_zombie_bio_tool_smg", "freq": 10, "cost_multiplier": 15 }
+      { "monster": "mon_zombie_bio_infantry_rifle", "freq": 10, "cost_multiplier": 15, "starts": 72 },
+      { "monster": "mon_zombie_bio_infantry_shotgun", "freq": 10, "cost_multiplier": 15, "starts": 72 },
+      { "monster": "mon_zombie_bio_knight_lmg", "freq": 10, "cost_multiplier": 15, "starts": 240 },
+      { "monster": "mon_zombie_bio_knight_lauhcher", "freq": 5, "cost_multiplier": 15, "starts": 240 },
+      { "monster": "mon_zombie_bio_scout_sniper", "freq": 10, "cost_multiplier": 15, "starts": 336 },
+      { "monster": "mon_zombie_bio_tool_pistol", "freq": 10, "cost_multiplier": 15, "starts": 168 },
+      { "monster": "mon_zombie_bio_tool_smg", "freq": 10, "cost_multiplier": 15, "starts": 168 }
     ]
   },
   {


### PR DESCRIPTION
* Pushes back entry of zombie failed bio-weapons a day after the cataclysm. Idea is that attrition rate builds up soon after Apopis' plan goes into action, but failed bio-weapons remain an active presence since day one.
* Pushes arrival of fungal failed bio-weapons back 2 days, except for fungal monstergroups. Contact with the Mycus probably happens reasonably often, but filtration back into general population might be slower. Main reason they're still a day-one presence in fungal turf however is I dunno if pushing them back a couple days will cause any weird behavior when combined with No Fungal Monsters mod.
* Pushed zombie super soldiers back 3 days. Main idea was that, in addition to giving the player some time to prepare and make day-one scouts no longer a thing, they also might plausibly survive longer than mundane soldiers. In this case, the basic grunts taking point would still suffer attrition first.
* Bio-engineers get pushed back 7 days. Gameplay-wise they're the easiest to handle so making them die first would be best, but lore-wise they're pretty survivable beyond their weakness in direct combat, and juggernauts wouldn't last as long without them. Having them be second to start showing up, after attrition of the basic soldiers makes them more vulnerable, makes more sense.
* Pushes juggernaut spawns back 10 days. Tough bois, but they're also the most dependent on logistics that the bio-engineers are probably helping hold up.
* Finally, pushes scouts back 14 days. Likely the ones most likely to survive even after the rest of the unit is picked off, and also the most infamous of the zombie super soldiers gameplay-wise.