### PR TITLE
Update generator parts

### DIFF
--- a/Vehicles/c_vehicle_parts.json
+++ b/Vehicles/c_vehicle_parts.json
@@ -200,16 +200,38 @@
     "breaks_into": [ { "item": "krx_laser_lmg", "prob": 50 } ]
   },
   {
+    "id": "generator_electric_tiny",
+    "copy-from": "vehicle_alternator",
+    "type": "vehicle_part",
+    "name": "tiny electric dynamo",
+    "description": "An electric motor improvised to serve as an electric generator, to be attatched to an internal combustion engine.  Its small size makes it rather inefficient compared to its normal efficency as a motor.",
+    "item": "motor_tiny",
+    "difficulty": 1,
+    "durability": 80,
+    "power": -750,
+    "epower": 370,
+    "//": "30.8A @12VDC ~ 1HP drain @ 49% efficiency.  Based more on a sane value relative to motorbike alternators than a straight translation of the motor's efficiency.  Even Mark's rate of 65% would make this blow motorbike alternators out of the water.",
+    "damage_modifier": 80,
+    "folded_volume": 1,
+    "breaks_into": [
+      { "item": "plastic_chunk", "count": [ 1, 2 ] },
+      { "item": "scrap", "count": [ 1, 2 ] },
+      { "item": "cable", "charges": [ 1, 3 ] }
+    ],
+    "extend": { "flags": [ "TOOL_SCREWDRIVER", "FOLDABLE" ] }
+  },
+  {
     "id": "generator_electric_small",
     "copy-from": "vehicle_alternator",
     "type": "vehicle_part",
-    "name": "small electric generator",
+    "name": "small electric dynamo",
+    "description": "An electric motor improvised to serve as an electric generator, to be attatched to an internal combustion engine.  Its small size has a negative impact on its efficiency.",
     "item": "motor_small",
     "difficulty": 1,
     "durability": 120,
-    "power": -1492,
-    "epower": 1000,
-    "//": "1 kW ~ 2HP drain @ 68% effficiency",
+    "power": -7460,
+    "epower": 5300,
+    "//": "440A @12VDC ~ 10HP drain @ 71% efficiency.  Based on Mark's recommended efficiency for small motors.",
     "damage_modifier": 80,
     "folded_volume": 1,
     "breaks_into": [
@@ -218,19 +240,21 @@
       { "item": "scrap", "count": [ 1, 2 ] },
       { "item": "cable", "charges": [ 3, 6 ] }
     ],
-    "extend": { "flags": [ "TOOL_SCREWDRIVER", "FOLDABLE" ] }
+    "extend": { "flags": [ "TOOL_SCREWDRIVER", "FOLDABLE" ] },
+    "damage_reduction": { "all": 6 }
   },
   {
     "id": "generator_electric",
     "copy-from": "vehicle_alternator",
     "type": "vehicle_part",
-    "name": "electric generator",
+    "name": "electric dynamo",
+    "description": "An electric motor improvised to serve as an electric generator, to be attatched to an internal combustion engine.  While relatively energy-intensive, it makes about as efficient a dynamo as it does a motor.",
     "item": "motor",
     "difficulty": 2,
     "durability": 200,
-    "power": -6341,
-    "epower": 5000,
-    "//": "5 kW ~ 8.5HP drain @ 80% effficiency",
+    "power": -37300,
+    "epower": 33500,
+    "//": "2791A @12VDC ~ 50HP drain @ 89% efficiency",
     "damage_modifier": 80,
     "breaks_into": [
       { "item": "steel_lump", "count": [ 3, 5 ] },
@@ -238,19 +262,21 @@
       { "item": "scrap", "count": [ 3, 5 ] },
       { "item": "cable", "charges": [ 10, 15 ] }
     ],
-    "extend": { "flags": [ "TOOL_WRENCH" ] }
+    "extend": { "flags": [ "TOOL_WRENCH" ] },
+    "damage_reduction": { "all": 32 }
   },
   {
     "id": "generator_electric_large",
     "copy-from": "vehicle_alternator",
     "type": "vehicle_part",
     "name": "large electric generator",
+    "description": "An electric motor improvised to serve as an electric generator, to be attatched to an internal combustion engine.  It would need a fairly powerful engine to effectively generate power.",
     "item": "motor_large",
     "difficulty": 3,
     "durability": 400,
-    "power": -50728,
-    "epower": 40000,
-    "//": "40 kW ~ 68HP drain @ 80% effficiency",
+    "power": -149200,
+    "epower": 134100,
+    "//": "11175A @12VDC ~ 200HP drain @ 89% efficiency",
     "damage_modifier": 80,
     "breaks_into": [
       { "item": "steel_lump", "count": [ 3, 5 ] },
@@ -258,19 +284,21 @@
       { "item": "scrap", "count": [ 3, 5 ] },
       { "item": "cable", "charges": [ 10, 15 ] }
     ],
-    "extend": { "flags": [ "TOOL_WRENCH" ] }
+    "extend": { "flags": [ "TOOL_WRENCH" ] },
+    "damage_reduction": { "all": 43 }
   },
   {
     "id": "generator_electric_enhanced",
     "copy-from": "vehicle_alternator",
     "type": "vehicle_part",
-    "name": "enhanced electric generator",
+    "name": "enhanced electric dynamo",
+    "description": "An electric motor improvised to serve as an electric generator, to be attatched to an internal combustion engine.  While it retains much of its efficiency, it still requires a rather powerful engine to operate.",
     "item": "motor_enhanced",
     "difficulty": 4,
     "durability": 200,
-    "power": -76092,
-    "epower": 60000,
-    "//": "60 kW ~ 102HP drain @ 80% effficiency",
+    "power": -313300,
+    "epower": 283200,
+    "//": "23600A @12VDC ~ 420HP drain @ 90% efficiency",
     "damage_modifier": 80,
     "breaks_into": [
       { "item": "steel_lump", "count": [ 3, 5 ] },
@@ -278,6 +306,29 @@
       { "item": "scrap", "count": [ 3, 5 ] },
       { "item": "cable", "charges": [ 10, 15 ] }
     ],
-    "extend": { "flags": [ "TOOL_WRENCH" ] }
+    "extend": { "flags": [ "TOOL_WRENCH" ] },
+    "damage_reduction": { "all": 50 }
+  },
+  {
+    "id": "generator_electric_super",
+    "copy-from": "vehicle_alternator",
+    "type": "vehicle_part",
+    "name": "super electric dynamo",
+    "description": "An electric motor improvised to serve as an electric generator, to be attatched to an internal combustion engine.  You would need one hell of an engine to use this as a generator!",
+    "item": "motor_super",
+    "difficulty": 5,
+    "durability": 400,
+    "power": -400000,
+    "epower": 359500,
+    "//": "29958A @12VDC ~ 536HP drain @ 89% efficiency.  Honestly seems like it'd probably fry something if you tried to dump this much power into a car battery.",
+    "damage_modifier": 80,
+    "breaks_into": [
+      { "item": "steel_lump", "count": [ 6, 10 ] },
+      { "item": "steel_chunk", "count": [ 6, 10 ] },
+      { "item": "scrap", "count": [ 6, 10 ] },
+      { "item": "cable", "charges": [ 20, 30 ] }
+    ],
+    "extend": { "flags": [ "TOOL_WRENCH" ] },
+    "damage_reduction": { "all": 60 }
   }
 ]


### PR DESCRIPTION
* Renamed the generators and added descriptions to make it a bit more clear what these parts are.
* Updated their stats to be more in line with how electric motors have been updated over the past year or so.
* Added variants for the tiny and super motors too.

A couple notes:
1. Tiny alternators are intentionally a fair bit less efficient than they would be if I just straight-up took the math for turning a motor into a dynamo, because they pretty much directly compete with motorcycle alternators.
2. Small electric dynamos are also a bit less efficient, but this is consistent with numbers that Mark suggested, based on some long-term plans for making tiny and small electric motors more power-hungry to reduce total efficiency.
3. Super electric dynamos are fucking loco. You'll need at least a V12 to run them at all, and I'm not 100% convinced yet that trying to jury-rig something like this would realistically turn your generator into a novel form of electrical fire.