### PR TITLE
Martial Art Updates

### DIFF
--- a/Surv_help/c_martialarts.json
+++ b/Surv_help/c_martialarts.json
@@ -27,7 +27,7 @@
         "min_unarmed": 6,
         "description": "Careful movement allows to dodge surprise attacks easily.",
         "bonus_dodges": 3,
-		"bonus_blocks": 3
+        "bonus_blocks": 3
       },
       {
         "id": "style_surv_recovery",
@@ -41,11 +41,11 @@
       {
         "id": "style_surv_passive_weapon_ultimate",
         "name": "Ultimate Weapon Focus",
-		"melee_allowed": true,
+        "melee_allowed": true,
         "min_melee": 10,
         "description": "Perfected weapon technique allows the user to dodge and block almost any attack.",
         "bonus_dodges": 99,
-		"bonus_blocks": 99
+        "bonus_blocks": 99
       },
       {
         "id": "style_surv_passive_hand_ultimate",
@@ -54,7 +54,7 @@
         "min_unarmed": 10,
         "description": "Perfected stance allows the user to dodge and block almost any attack.",
         "bonus_dodges": 99,
-		"bonus_blocks": 99
+        "bonus_blocks": 99
       },
       {
         "id": "style_surv_hand_quiet",
@@ -100,33 +100,114 @@
       }
     ],
     "techniques": [
-	  "tec_surv_com_break_unarmed",
-	  "tec_surv_com_counter_unarmed",
-	  "tec_surv_com_feint_unarmed",
-	  "tec_surv_com_disarm_unarmed",
-	  "tec_surv_com_power_unarmed",
-	  "tec_surv_com_trip_unamred",
-	  "tec_surv_com_rapid_unarmed",
-	  "tec_surv_com_precise_unarmed",
-	  "tec_surv_com_surprise_unarmed",
-	  "tec_surv_com_break_melee",
-	  "tec_surv_com_counter_melee",
-	  "tec_surv_com_feint_melee",
-	  "tec_surv_com_disarm_melee"
+      "tec_surv_com_break_unarmed",
+      "tec_surv_com_counter_unarmed",
+      "tec_surv_com_feint_unarmed",
+      "tec_surv_com_disarm_unarmed",
+      "tec_surv_com_power_unarmed",
+      "tec_surv_com_trip_unamred",
+      "tec_surv_com_rapid_unarmed",
+      "tec_surv_com_precise_unarmed",
+      "tec_surv_com_surprise_unarmed",
+      "tec_surv_com_break_melee",
+      "tec_surv_com_counter_melee",
+      "tec_surv_com_feint_melee",
+      "tec_surv_com_disarm_melee"
     ]
   },
   {
-    "type": "martial_art",
     "id": "style_biojutsu",
     "copy-from": "style_biojutsu",
-    "name": "Bionic Combatives",
-    "weapons": [
-      "unbio_bladed_weapon",
-      "unbio_sword_weapon",
-      "unbio_claws_weapon",
-      "bio_sword_weapon",
-      "bio_claws_weapon",
-      "bio_blade_weapon"
-    ]
+    "type": "martial_art",
+    "name": "KBionic Combatives",
+    "extend": { "weapons": [ "unbio_bladed_weapon", "unbio_sword_weapon", "unbio_claws_weapon", "bio_sword_weapon" ] }
+  },
+  {
+    "id": "style_aikido",
+    "copy-from": "style_aikido",
+    "type": "martial_art",
+    "name": "Aikido",
+    "extend": { "weapons": [ "unbio_claws_weapon" ] }
+  },
+  {
+    "id": "style_judo",
+    "copy-from": "style_judo",
+    "type": "martial_art",
+    "name": "Judo",
+    "extend": { "weapons": [ "unbio_claws_weapon" ] }
+  },
+  {
+    "id": "style_silat",
+    "copy-from": "style_silat",
+    "type": "martial_art",
+    "name": "Silat",
+    "extend": { "weapons": [ "elc_bld", "elc_blds", "molded_knife", "unbio_bladed_weapon", "flesh_knife" ] }
+  },
+  {
+    "id": "style_eskrima",
+    "copy-from": "style_eskrima",
+    "type": "martial_art",
+    "name": "Eskrima",
+    "extend": { "weapons": [ "elc_bld", "elc_blds", "molded_knife", "unbio_bladed_weapon", "flesh_knife" ] }
+  },
+  {
+    "id": "style_krav_maga",
+    "copy-from": "style_krav_maga",
+    "type": "martial_art",
+    "name": "Krav Maga",
+    "extend": {
+      "weapons": [
+        "elc_bld",
+        "elc_blds",
+        "molded_knife",
+        "unbio_bladed_weapon",
+        "flesh_knife",
+        "neo_laser_pistol",
+        "neo_laser_pistol_ups",
+        "akro_laser_smg",
+        "akro_laser_smg_ups",
+        "arc_laser_rifle",
+        "arc_laser_rifle_ups"
+      ]
+    }
+  },
+  {
+    "id": "style_fencing",
+    "copy-from": "style_fencing",
+    "type": "martial_art",
+    "name": "Fencing",
+    "extend": { "weapons": [ "unbio_sword_weapon", "flesh_blade", "flesh_blade_on" ] }
+  },
+  {
+    "id": "style_swordsmanship",
+    "copy-from": "style_swordsmanship",
+    "type": "martial_art",
+    "name": "Medieval Swordsmanship",
+    "extend": { "weapons": [ "unbio_sword_weapon", "flesh_blade", "flesh_blade_on" ] }
+  },
+  {
+    "id": "style_ninjutsu",
+    "copy-from": "style_ninjutsu",
+    "type": "martial_art",
+    "name": "Ninjutsu",
+    "extend": {
+      "weapons": [
+        "elc_bld",
+        "elc_blds",
+        "molded_knife",
+        "unbio_bladed_weapon",
+        "unbio_sword_weapon",
+        "flesh_knife",
+        "flesh_blade",
+        "flesh_blade_on"
+      ]
+    }
+  },
+  {
+    "id": "style_medievalpole",
+    "copy-from": "style_medievalpole",
+    "type": "martial_art",
+    "name": "Fior Di Battaglia",
+    "extend": { "weapons": [ "molded_axe" ] }
   }
 ]


### PR DESCRIPTION
* Overhauled the override to Bionic Combatives to use extend instead for injecting the mod-specific items to its weapons list.
* Converted bionic claws added to a few martial arts that now specify which unarmed weapons are permitted.
* Tazer blades, converted bionic knives, flesh knives, and molded knives added to styles that allow knives, especially those that allow vanilla makeshift knives.
* Converted bionic swords and biological swords added to sword-focused swords where they're reasonably close to other swords and sword-like-objects used by said styles. Notably affected by this are Medieval Swordsmanship (yaaaay at it being mainlined), and Ninjutsu that now defines its weapon list explicitly.
* Fior Di Battaglia only gets molded axe added because it allows stone axes.
* Since Krav Maga explicitly counts a selection of guns (mainly pistols, SMGs, and rifles), also added the comparable Omnitech weapons to the list. These are explicitly more militarized than the vanilla laser pistol and rifle, with provisions for bayonets (albeit that was originally part of the defunct "get NPCs to use UPS weapons" workaround) and noted to have more familiar ergonomics.