### PR TITLE
Fix stealth cloak, typo fixes

### DIFF
--- a/Surv_help/c_armor.json
+++ b/Surv_help/c_armor.json
@@ -161,9 +161,9 @@
     "material_thickness": 1,
     "environmental_protection": 4,
     "max_charges": 100,
-    "initial_charges": 5,
     "turns_per_charge": 5,
     "artifact_data": { "charge_type": "ARTC_TIME", "effects_worn": [ "AEP_INVISIBLE", "AEP_STR_DOWN", "AEP_DEX_DOWN", "AEP_SPEED_DOWN" ] },
+    "revert_to": "solar_flashlight",
     "use_action": { "menu_text": "Turn off", "type": "transform", "msg": "You turn off your cloak.", "target": "acs_74_stealth_cloak_off" },
     "flags": [ "OVERSIZE", "HOOD", "WATERPROOF", "OUTER", "VARSIZE" ]
   },
@@ -189,7 +189,7 @@
     "max_charges": 100,
     "initial_charges": 5,
     "artifact_data": { "charge_type": "ARTC_TIME", "effects_worn": [ "AEP_STR_DOWN", "AEP_DEX_DOWN", "AEP_SPEED_DOWN" ] },
-    "use_action": { "active": true, "need_charges": 1, "need_charges_msg": "The stored energy has run dry", "menu_text": "Activate Cloaking", "target": "acs_74_stealth_cloak_on", "msg": "You turn on your cloak.", "type": "transform" },
+    "use_action": { "active": true, "need_charges": 1, "need_charges_msg": "The stored energy has run dry.", "menu_text": "Activate Cloaking", "target": "acs_74_stealth_cloak_on", "msg": "You turn on your cloak.", "type": "transform" },
     "flags": [ "OVERSIZE", "HOOD", "WATERPROOF", "OUTER", "VARSIZE" ]
   },
   {

--- a/Surv_help/c_bionics.json
+++ b/Surv_help/c_bionics.json
@@ -28,7 +28,7 @@
     "name": "Laser Gatling Arm",
     "//": "To be re-added if this ever gets accessible in JSON: However, you are unable to use or carry two-handed items, and your strength limits what you can use with your one hand.",
     "occupied_bodyparts": [ [ "ARM_L", 20 ], [ "HAND_L", 5 ] ],
-    "act_cost": 50,
+    "act_cost": "50 kJ",
     "fake_item": "bio_laser_minigun",
     "description": "Your left arm has been outfitted with a complex array of rotating laser projectors.  Or in layman's terms, a laser gatling gun!  You may use your energy banks to fire a barrage of lasers.",
     "flags": [ "BIONIC_GUN" ]
@@ -63,7 +63,7 @@
     "id": "bio_sword",
     "name": "Monomolecular Sword",
     "occupied_bodyparts": [ [ "ARM_R", 5 ], [ "HAND_R", 2 ] ],
-    "act_cost": 200,
+    "act_cost": "1 kJ",
     "fake_item": "bio_sword_weapon",
     "description": "A deadly yard-long blade made of advanced material now resides inside your forearm, capable of being extended through the back of your wrist at the cost of a small amount of power.  Though exceptionally sharp, it will prevent you from holding anything else while extended.",
     "flags": [ "BIONIC_TOGGLED", "BIONIC_WEAPON" ]
@@ -105,7 +105,7 @@
     "id": "bio_flamethrower",
     "name": "Dual-Hand Flamethrower",
     "occupied_bodyparts": [ [ "HAND_R", 2 ], [ "HAND_L", 2 ] ],
-    "act_cost": 100,
+    "act_cost": "100 kJ",
     "fake_item": "bio_flamethrower_gun",
     "description": "Implanted in the palms of your hands lie a compact flamethrower system that uses bionic power and oxygen in the air as ignition, use as any other gun.",
     "flags": [ "BIONIC_GUN" ]

--- a/Surv_help/c_effects.json
+++ b/Surv_help/c_effects.json
@@ -1,0 +1,8 @@
+[
+  {
+    "type": "effect_type",
+    "id": "rtg_induction_radiation",
+    "max_duration": "2 m",
+    "base_mods": { "rad_min": [ 1 ] }
+  }
+]

--- a/Surv_help/c_martialarts.json
+++ b/Surv_help/c_martialarts.json
@@ -119,7 +119,7 @@
     "id": "style_biojutsu",
     "copy-from": "style_biojutsu",
     "type": "martial_art",
-    "name": "KBionic Combatives",
+    "name": "Bionic Combatives",
     "extend": { "weapons": [ "unbio_bladed_weapon", "unbio_sword_weapon", "unbio_claws_weapon", "bio_sword_weapon" ] }
   },
   {

--- a/Surv_help/c_spells.json
+++ b/Surv_help/c_spells.json
@@ -9,10 +9,9 @@
     "min_damage": 50,
     "max_damage": 50,
     "base_casting_time": 200,
-    "max_level": 10,
     "effect": "recover_energy",
     "effect_str": "BIONIC",
-    "extra_effects": [ { "id": "c_cbm_rtg_induction_2", "hit_self": true, "max_level": 10 }, { "id": "c_cbm_rtg_induction_3", "hit_self": true, "max_level": 10 } ]
+    "extra_effects": [ { "id": "c_cbm_rtg_induction_2", "hit_self": true }, { "id": "c_cbm_rtg_induction_3", "hit_self": true } ]
   },
   {
     "id": "c_cbm_rtg_induction_2",
@@ -21,7 +20,6 @@
     "description": "Vented waste heat.",
     "valid_targets": [ "self" ],
     "effect": "target_attack",
-    "max_level": 10,
     "field_id": "fd_hot_air3",
     "min_field_intensity": 2,
     "max_field_intensity": 2,
@@ -33,11 +31,10 @@
     "name": "CBM Induction Rads",
     "description": "Radiation!",
     "valid_targets": [ "self" ],
+    "flags": [ "RANDOM_DURATION" ],
     "effect": "target_attack",
-    "max_level": 10,
-    "field_id": "fd_nuke_gas",
-    "min_field_intensity": 1,
-    "max_field_intensity": 1,
-    "field_chance": 1
+    "effect_str": "rtg_induction_radiation",
+    "min_duration": 500,
+    "max_duration": 1000
   }
 ]


### PR DESCRIPTION
* Added a reversion to the active stealth cloak so it no longer vanishes when depleted.
* Updated CBM RTG Inductor to implement radiation correctly instead of acting weird.
* Updated the power cost values of the bionics to use kilojoules, since CBM power is now basically straight kJ. Only the cost of deploying the bionic sword is actually affected by WIP changes, currently.
* Couple typo fixes.

Costs for bionics are nonetheless informed by work being done in https://github.com/CleverRaven/Cataclysm-DDA/pull/34456, with thanks to @RDru. Not sure yet what the final costs will be, but they seem reasonable so Noct and I likely won't have to chance much on Cata++'s end. The ridiculously-high deployment cost for CBM weapons always struck me as odd...

Also closes https://github.com/Noctifer-de-Mortem/nocts_cata_mod/issues/124