### PR TITLE
Gives Beta gasoline cell instead of RTG inducer

### DIFF
--- a/Char_creation/c_classes_bw.json
+++ b/Char_creation/c_classes_bw.json
@@ -310,10 +310,11 @@
       "bio_power_storage_mkII",
       "bio_power_storage_mkII",
       "bio_power_armor_interface_mkII",
+      "bio_fuel_cell_gasoline",
       "bio_torsionratchet"
     ],
     "items": {
-      "both": [ "badge_bio_weapon", "subsuit_xl", "footrags", "cbm_rtg_inductor" ],
+      "both": [ "badge_bio_weapon", "subsuit_xl", "footrags" ],
       "male": [ "briefs" ],
       "female": [ "bra", "panties" ]
     },


### PR DESCRIPTION
This is at least an interesting option that's easier to make use of than the hacky artifact method the RTG CBM inductor relies on. Item remains existent for now, as it does have some interesting uses.

Was pondering whether I could devise any other CBMs to add, ideally to make Delta's powergen setpup more unique, but nothing good game to mind...