### PR TITLE
Remove bonus gunmods from Evy and other NPCs

### DIFF
--- a/Npc/NC_BIO_WEAPONS.json
+++ b/Npc/NC_BIO_WEAPONS.json
@@ -26,7 +26,7 @@
     "type": "item_group",
     "//": "Bio-Weapon Sigma's weapon, don't think you can define weapon overrides any other way.",
     "subtype": "collection",
-    "entries": [ { "item": "arc_laser_rifle", "contents-item": [ "shoulder_strap", "knife_combat" ] } ]
+    "entries": [ { "item": "arc_laser_rifle" } ]
   },
   {
     "id": "NC_BIO_WEAPON_carry",

--- a/Npc/NC_SUPER_SOLDIERS.json
+++ b/Npc/NC_SUPER_SOLDIERS.json
@@ -37,9 +37,9 @@
     "entries": [
       {
         "distribution": [
-          { "item": "arc_laser_rifle", "prob": 50, "contents-item": [ "shoulder_strap", "knife_combat" ] },
-          { "item": "xarm_laser_shotgun", "prob": 30, "contents-item": [ "shoulder_strap", "knife_combat" ] },
-          { "item": "mx_laser_sniper", "prob": 20, "contents-item": [ "shoulder_strap", "knife_combat" ] }
+          { "item": "arc_laser_rifle", "prob": 50 },
+          { "item": "xarm_laser_shotgun", "prob": 30 },
+          { "item": "mx_laser_sniper", "prob": 20 }
         ]
       }
     ]
@@ -86,6 +86,6 @@
     "subtype": "collection",
     "magazine": 100,
     "ammo": 100,
-    "entries": [ { "item": "akro_laser_smg", "contents-item": [ "shoulder_strap", "knife_combat" ] } ]
+    "entries": [ { "item": "akro_laser_smg" } ]
   }
 ]


### PR DESCRIPTION
This removes bayonets and shoulder straps from Evy, Lambda, Sigma, and the super soldier NPCs. A little more testing revealed that it's not strictly necessary to remove the shoulder strap, but I'd rather be thorough and this prevents any inevitable issues that might come 

For a bit of context, the bayonets were a holdover from the brief period when I was able to get the NPCs to successfully use UPS laser weapons, which mandated adding a bayonet or else their AI would refuse to acknowledge actually having a gun in their hands. When that had to be undone because UPS weapons started just plain crashing when used by NPCs in general, I left the gunmods on figuring it wouldn't hurt.

I did leave the shoulder straps intact for the player versions of the super soldiers however, but might later on switch to having them start off wielding them instead.

Root cause seems to be basically whatever odd behavior is causing https://github.com/CleverRaven/Cataclysm-DDA/issues/35117, with thanks to @ymber for opening the issue that made me realize what the cause was.

Closes https://github.com/Noctifer-de-Mortem/nocts_cata_mod/issues/131