### PR TITLE
Implement snippet IDs

### DIFF
--- a/Surv_help/c_snippets.json
+++ b/Surv_help/c_snippets.json
@@ -2,46 +2,90 @@
   {
     "type": "snippet",
     "category": "years_old_news",
-    "text": [ "JOINT RESEARCH PROJECT TO INCREASE JOBS: A recent announcement confirmed rumors of a joint research project between several commercial and military research firms, with the stated goal of collaborating to advance several cutting-edge fields.  Though details are still sparse at this time, the project is expected to open thousands of employment opportunities in various fields and departments." ]
+    "text": [
+      {
+        "id": "years_old_news_cataplus_1",
+        "text": "JOINT RESEARCH PROJECT TO INCREASE JOBS: A recent announcement confirmed rumors of a joint research project between several commercial and military research firms, with the stated goal of collaborating to advance several cutting-edge fields.  Though details are still sparse at this time, the project is expected to open thousands of employment opportunities in various fields and departments."
+      }
+    ]
   },
   {
     "type": "snippet",
     "category": "one_year_old_news",
     "text": [
-      "BLOOD SPORT STING: Police and Federal officials have uncovered the latest lead on a series of underground \"gladiator games\" involving kidnapped victims forcibly augmented and pitted against each other.  The latest sting has led to the rescue of several victims, but no suspects have been identified or arrested thus far."
+      {
+        "id": "one_year_old_news_cataplus_1",
+        "text": "BLOOD SPORT STING: Police and Federal officials have uncovered the latest lead on a series of underground \"gladiator games\" involving kidnapped victims forcibly augmented and pitted against each other.  The latest sting has led to the rescue of several victims, but no suspects have been identified or arrested thus far."
+      }
     ]
   },
   {
     "type": "snippet",
     "category": "note",
     "text": [
-      "\"I'm in awe of the size of that one shambler I saw.  Absolute UNIT\"",
-      "\"Saw a whole fuckton of the big ones the other day.  The live ones, followin' an even bigger fucker covered in armor.  Just walked through a horde like nothing.\"",
-      "\"they look like the dead but they SHOOT LIKE MEN\"",
-      "\"The great wheel turns, I got lasers for days!  Or until my arms fall off.\"",
-      "\"Had a nice little place out innawoods until my dumb shit friends had the nerve to die on me.  Place turned into a mess in a hurry.\"",
-      "\"MANKIND IS OBSOLETE\""
+      { "id": "note_cataplus_1", "text": "\"I'm in awe of the size of that one shambler I saw.  Absolute UNIT\"" },
+      {
+        "id": "note_cataplus_2",
+        "text": "\"Saw a whole fuckton of the big ones the other day.  The live ones, followin' an even bigger fucker covered in armor.  Just walked through a horde like nothing.\""
+      },
+      { "id": "note_cataplus_3", "text": "\"they look like the dead but they SHOOT LIKE MEN\"" },
+      {
+        "id": "note_cataplus_4",
+        "text": "\"The great wheel turns, I got lasers for days!  Or until my arms fall off.\""
+      },
+      {
+        "id": "note_cataplus_5",
+        "text": "\"Had a nice little place out innawoods until my dumb shit friends had the nerve to die on me.  Place turned into a mess in a hurry.\""
+      },
+      { "id": "note_cataplus_6", "text": "\"MANKIND IS OBSOLETE\"" }
     ]
   },
   {
     "type": "snippet",
     "category": "note_apophis",
     "text": [
-      "\"The director has confirmed positive ID on local research sites also connected to Project Mesektet, with further contacts linking them to commercial and military research directives across the tri-county area.\"",
-      "\"We've tracked down the primary rehabilitation and disposal sites used by the other project assets.  The director has expressed interest in securing them after Unit One is brought online.\"",
-      "\"Unit One is to remain in standby mode in case the \"disturbance\" causes us any difficulty.  Contingency plan for on-site activation shall be provided to the research director.\"",
-      "\"3-XII is dispatching a squad to this site, with a unit from 4-VII in tow to secure against hostile action.  Cooperate as best as you are able, but do not allow them into the lab complex itself.\"",
-      "\"We've received confirmation that they're onto us.  Orders are to delay the security dispatch as long as possible, while the director gets Unit One online.\""
+      {
+        "id": "note_apophis_cataplus_1",
+        "text": "\"The director has confirmed positive ID on local research sites also connected to Project Mesektet, with further contacts linking them to commercial and military research directives across the tri-county area.\""
+      },
+      {
+        "id": "note_apophis_cataplus_2",
+        "text": "\"We've tracked down the primary rehabilitation and disposal sites used by the other project assets.  The director has expressed interest in securing them after Unit One is brought online.\""
+      },
+      {
+        "id": "note_apophis_cataplus_3",
+        "text": "\"Unit One is to remain in standby mode in case the \"disturbance\" causes us any difficulty.  Contingency plan for on-site activation shall be provided to the research director.\""
+      },
+      {
+        "id": "note_apophis_cataplus_4",
+        "text": "\"3-XII is dispatching a squad to this site, with a unit from 4-VII in tow to secure against hostile action.  Cooperate as best as you are able, but do not allow them into the lab complex itself.\""
+      },
+      {
+        "id": "note_apophis_cataplus_5",
+        "text": "\"We've received confirmation that they're onto us.  Orders are to delay the security dispatch as long as possible, while the director gets Unit One online.\""
+      }
     ]
   },
   {
     "type": "snippet",
     "category": "note_sketchy_cabin",
     "text": [
-      "\"Boss came down to show our supplier around.  Professional-looking person, would look more at home teaching college kids than working with the Organization.  Didn't seem even the least bit squeamish about the animals though.  Given she works for wherever we get our mutation and CBMs, I don't want to even think about how much worse shit they must be used to.  Didn't even fucking flinch when one of the freaks in Red Team broke its jaw gnawing on the bars, when she and the boss walked past its cell.\"",
-      "\"Got another fresh shipment, couple CBMs, along with the fresh meat to get Blue Team back up to full roster.  Boss is worried that vetting clients is going to make the next show a complete waste of time.  Told him we shouldn't have given up on streaming in favor of hosting fights on-site, but boss won't budge on that.\"",
-      "\"One of the long-runners on Red Team's getting a bit too smart for its own good.  It's figured out the bars won't give, so instead trashed the toilet in its cell.  Think it knows we have to move it to another cell while we replace the shitter.  The boss is also looking to get his supplier to get their hands on some PE065, that should make it a bit easier to keep contained like the rest.  Might make the next show more fun too.\"",
-      "\"Fight was a complete no-show, none of the clients even called in.  Something's going down back in town, can't get ahold of the boss either.  Going to lock primary access and hit full cell unlock, let the animals have fun tearing each others throats out.  Oughta keep them distracted so I can try and find out what the fuck is going on up there.\""
+      {
+        "id": "note_sketchy_cabin_cataplus_1",
+        "text": "\"Boss came down to show our supplier around.  Professional-looking person, would look more at home teaching college kids than working with the Organization.  Didn't seem even the least bit squeamish about the animals though.  Given she works for wherever we get our mutagen and CBMs, I don't want to even think about the shit they must be used to.  Didn't even fucking flinch when one of the freaks in Red Team broke its jaw gnawing on the bars, when she and the boss walked past its cell.\""
+      },
+      {
+        "id": "note_sketchy_cabin_cataplus_2",
+        "text": "\"Got another fresh shipment, couple CBMs, along with the fresh meat to get Blue Team back up to full roster.  Boss is worried that vetting clients is going to make the next show a complete waste of time.  Told him we shouldn't have given up on streaming in favor of hosting fights on-site, but boss won't budge on that.\""
+      },
+      {
+        "id": "note_sketchy_cabin_cataplus_3",
+        "text": "\"One of the long-runners on Red Team's getting a bit too smart for its own good.  It's figured out the bars won't give, so instead trashed the toilet in its cell.  Think it knows we have to move it to another cell while we replace the shitter.  The boss is also looking to get his supplier to get their hands on some PE065, that should make it a bit easier to keep contained like the rest.  Might make the next show more fun too.\""
+      },
+      {
+        "id": "note_sketchy_cabin_cataplus_4",
+        "text": "\"Fight was a complete no-show, none of the clients even called in.  Something's going down back in town, can't get ahold of the boss either.  Going to lock primary access and hit full cell unlock, let the animals have fun tearing each others throats out.  Oughta keep them distracted so I can try and find out what the fuck is going on up there.\""
+      }
     ]
   }
 ]


### PR DESCRIPTION
This turns the small JSON into the big JSON.

Fixes skippable error messages that only show up when a note citing the snippet tries to ping the ones added by mods, and suddenly notices they don't need IDs (which are now mandatory).