### PR TITLE
[WIP] Overhaul for Survivor Combatives

### DIFF
--- a/Surv_help/c_martialarts.json
+++ b/Surv_help/c_martialarts.json
@@ -3,116 +3,61 @@
     "type": "martial_art",
     "id": "style_surv_com",
     "name": "Survivor Combatives",
-    "description": "You learned how to handle yourself in the cataclysm.  You have become good at using proper, improvised and hand made weaponry, including your fists.  Not flashy but it keeps you alive.",
+    "description": "You learned how to handle yourself in the cataclysm.  Whether armed or unarmed, you know how to use your wits to stay alive.  Survival is of the highest priority.",
     "initiate": [ "You steady yourself, prepared for the fights ahead.", "%s prepares for the fights ahead." ],
-    "arm_block": 99,
-    "leg_block": 99,
-    "arm_block_with_bio_armor_arms": true,
-    "leg_block_with_bio_armor_legs": true,
+    "learn_difficulty": 7,
+    "arm_block": 2,
+    "leg_block": 8,
     "allow_melee": true,
-    "static_buffs": [
+    "onmove_buffs": [
       {
-        "id": "style_surv_passive_weapon",
-        "name": "Weapon Focus",
-        "melee_allowed": true,
-        "min_melee": 6,
-        "description": "Weapon proficiency allows to block and dodge surprise attacks.",
-        "bonus_dodges": 3,
-        "bonus_blocks": 3
-      },
-      {
-        "id": "style_surv_passive_hand",
-        "name": "Unarmed Focus",
-        "unarmed_allowed": true,
-        "min_unarmed": 6,
-        "description": "Careful movement allows to dodge surprise attacks easily.",
-        "bonus_dodges": 3,
-        "bonus_blocks": 3
-      },
-      {
-        "id": "style_surv_recovery",
-        "name": "Combat Roll",
+        "id": "buff_surv_com_onmove",
+        "name": "Elusiveness",
+        "//": "Note: Doubled percentage signs are needed for correct formatting, not a typo.",
+        "description": "Quick and fluid movements make you harder to catch.\n\n+2 Dodge attempts, Dodge skill increased by 50%% of Intelligence, immunity to knockdown.\nLasts for 1 turn.",
+        "min_melee": 4,
         "unarmed_allowed": true,
         "melee_allowed": true,
-        "min_melee": 8,
         "throw_immune": true,
-        "description": "User has learned to to recover from being thrown off their feet."
-      },
-      {
-        "id": "style_surv_passive_weapon_ultimate",
-        "name": "Ultimate Weapon Focus",
-        "melee_allowed": true,
-        "min_melee": 10,
-        "description": "Perfected weapon technique allows the user to dodge and block almost any attack.",
-        "bonus_dodges": 99,
-        "bonus_blocks": 99
-      },
-      {
-        "id": "style_surv_passive_hand_ultimate",
-        "name": "Ultimate Unarmed Focus",
-        "unarmed_allowed": true,
-        "min_unarmed": 10,
-        "description": "Perfected stance allows the user to dodge and block almost any attack.",
-        "bonus_dodges": 99,
-        "bonus_blocks": 99
-      },
-      {
-        "id": "style_surv_hand_quiet",
-        "name": "Quiet Unarmed Combat",
-        "unarmed_allowed": true,
-        "min_unarmed": 10,
-        "quiet": true,
-        "description": "User has learned how to deal all weapon strikes quietly."
-      },
-      {
-        "id": "style_surv_weapon_quiet",
-        "name": "Quiet Weapon Combat",
-        "melee_allowed": true,
-        "min_melee": 10,
-        "quiet": true,
-        "description": "User has learned how to deal all unarmed attacks quietly."
+        "buff_duration": 1,
+        "bonus_dodges": 2,
+        "flat_bonuses": [ [ "dodge", "int", 0.5 ] ]
       }
     ],
-    "onattack_buffs": [
+    "onhit_buffs": [
       {
-        "id": "style_surv_com_attack_momentum",
-        "name": "Combat Momentum",
-        "description": "Each successful hit make the next one more likely to land and more powerful as well.",
+        "id": "buff_surv_com_onhit",
+        "name": "Active Defense",
+        "description": "The best defense is a good offense.\n\n+2 Block attempts, damage blocked increased by 75%% of Intelligence.\nLasts 2 turns.",
+        "min_melee": 5,
         "unarmed_allowed": true,
         "melee_allowed": true,
-        "min_melee": 8,
-        "buff_duration": 5,
-        "max_stacks": 10,
-        "flat_bonuses": [ [ "damage", "bash", 1.5 ], [ "damage", "cut", 1.5 ], [ "damage", "stab", 1.5 ], [ "hit", 1.25 ] ]
+        "buff_duration": 2,
+        "bonus_blocks": 2,
+        "flat_bonuses": [ [ "block", "int", 0.75 ] ]
       }
     ],
     "onkill_buffs": [
       {
-        "id": "style_surv_com_kill_momentum",
-        "name": "Deadly Momentum",
-        "description": "Each successful hit make the next one more likely to land and more powerful as well.",
+        "id": "buff_surv_com_onkill",
+        "name": "Misdirection",
+        "description": "The shock and awe of combat gives you an opportunity to slip away.\n\n+2 Block attempts, +2 Dodge attempts, movement speed increased by 100%% of Intelligence, moving generates 1/2 as much noise.\nLast 3 turns.",
+        "min_melee": 6,
         "unarmed_allowed": true,
         "melee_allowed": true,
-        "min_melee": 10,
-        "buff_duration": 5,
-        "max_stacks": 10,
-        "flat_bonuses": [ [ "damage", "bash", 2.0 ], [ "damage", "cut", 2.0 ], [ "damage", "stab", 2.0 ], [ "hit", 1.5 ] ]
+        "stealthy": true,
+        "buff_duration": 3,
+        "bonus_dodges": 2,
+        "bonus_blocks": 2,
+        "flat_bonuses": [ [ "speed", "int", 1.0 ] ]
       }
     ],
     "techniques": [
-      "tec_surv_com_break_unarmed",
-      "tec_surv_com_counter_unarmed",
-      "tec_surv_com_feint_unarmed",
-      "tec_surv_com_disarm_unarmed",
-      "tec_surv_com_power_unarmed",
-      "tec_surv_com_trip_unamred",
-      "tec_surv_com_rapid_unarmed",
-      "tec_surv_com_precise_unarmed",
-      "tec_surv_com_surprise_unarmed",
-      "tec_surv_com_break_melee",
-      "tec_surv_com_counter_melee",
-      "tec_surv_com_feint_melee",
-      "tec_surv_com_disarm_melee"
+      "tec_surv_com_break",
+      "tec_surv_com_counter_dodge",
+      "tec_surv_com_counter_block",
+      "tec_surv_com_disarm",
+      "tec_surv_com_feint"
     ]
   },
   {

--- a/Surv_help/c_techniques.json
+++ b/Surv_help/c_techniques.json
@@ -1,185 +1,61 @@
 [
   {
     "type": "technique",
-    "id": "tec_surv_com_break_melee",
+    "id": "tec_surv_com_break",
     "name": "Grab Break",
     "messages": [ "The %s tries to grab you, but you force yourself free!", "The %s tries to grab <npcname>, but they break free!" ],
-    "min_melee": 4,
+    "min_melee": 7,
+    "unarmed_allowed": true,
     "melee_allowed": true,
     "defensive": true,
     "grab_break": true
   },
   {
     "type": "technique",
-    "id": "tec_surv_com_break_unarmed",
-    "name": "Grab Break",
-    "messages": [ "The %s tries to grab you, but you force yourself free!", "The %s tries to grab <npcname>, but they break free!" ],
-    "min_unarmed": 4,
+    "id": "tec_surv_com_counter_dodge",
+    "name": "Counter Sweep",
+    "messages": [ "You dodge and send %s tumbling to the ground", "<npcname> dodges and trips %s" ],
+    "min_melee": 6,
     "unarmed_allowed": true,
-    "defensive": true,
-    "grab_break": true
+    "melee_allowed": true,
+    "dodge_counter": true,
+    "crit_ok": true,
+    "mult_bonuses": [ [ "movecost", 0.0 ] ],
+    "down_dur": 1
   },
   {
     "type": "technique",
-    "id": "tec_surv_com_counter_melee",
-    "name": "Counter",
-    "messages": [ "You catch %s's attack, and hit back", "<npcname> catches %s, and counters" ],
-    "min_melee": 4,
+    "id": "tec_surv_com_counter_block",
+    "name": "Counter Strike",
+    "messages": [ "You catch %s's attack, and send them staggering back", "<npcname> catches %s, and knocks them back" ],
+    "min_melee": 6,
+    "unarmed_allowed": true,
     "melee_allowed": true,
     "block_counter": true,
     "crit_ok": true,
-    "mult_bonuses": [ [ "movecost", 0.0 ] ]
+    "mult_bonuses": [ [ "movecost", 0.0 ] ],
+    "knockback_dist": 1,
+    "stun_dur": 1
   },
   {
     "type": "technique",
-    "id": "tec_surv_com_counter_unarmed",
-    "name": "Counter",
-    "messages": [ "You catch %s's attack, and hit back", "<npcname> catches %s, and counters" ],
-    "min_unarmed": 4,
-    "unarmed_allowed": true,
-    "block_counter": true,
-    "crit_ok": true,
-    "mult_bonuses": [ [ "movecost", 0.0 ] ]
-  },
-  {
-    "type": "technique",
-    "id": "tec_surv_com_feint_melee",
+    "id": "tec_surv_com_feint",
     "name": "Feint",
     "messages": [ "You fake a strike at %s", "<npcname> fakes a strike at %s" ],
-    "min_melee": 3,
+    "min_melee": 4,
+    "unarmed_allowed": true,
     "melee_allowed": true,
     "defensive": true,
     "miss_recovery": true
   },
   {
     "type": "technique",
-    "id": "tec_surv_com_feint_unarmed",
-    "name": "Feint",
-    "messages": [ "You fake a strike at %s", "<npcname> fakes a strike at %s" ],
-    "min_unarmed": 3,
-    "unarmed_allowed": true,
-    "defensive": true,
-    "miss_recovery": true,
-    "flat_bonuses": [ [ "hit", 1.5 ] ]
-  },
-  {
-    "type": "technique",
-    "id": "tec_surv_com_disarm_melee",
+    "id": "tec_surv_com_disarm",
     "name": "Disarm",
     "messages": [ "You knock %s's weapon away", "<npcname> knock %s's weapon away" ],
-    "min_melee": 5,
-    "melee_allowed": true,
-    "disarms": true,
-    "crit_ok": true
-  },
-  {
-    "type": "technique",
-    "id": "tec_surv_com_disarm_unarmed",
-    "name": "Disarm",
-    "messages": [ "You knock %s's weapon away", "<npcname> knock %s's weapon away" ],
-    "min_unarmed": 5,
+    "min_melee": 9,
     "unarmed_allowed": true,
-    "disarms": true,
-    "crit_ok": true
-  },
-  {
-    "type": "technique",
-    "id": "tec_surv_com_power_unarmed",
-    "name": "Power Hit",
-    "messages": [ "You send %s reeling", "<npcname> sends %s reeling" ],
-    "min_unarmed": 4,
-    "unarmed_allowed": true,
-    "crit_tec": true,
-    "knockback_dist": 1,
-    "stun_dur": 1
-  },
-  {
-    "type": "technique",
-    "id": "tec_surv_com_power_melee",
-    "name": "Power Strike",
-    "messages": [ "You send %s reeling", "<npcname> sends %s reeling" ],
-    "min_melee": 4,
     "melee_allowed": true,
-    "crit_tec": true,
-    "knockback_dist": 1,
-    "stun_dur": 1
-  },
-  {
-    "type": "technique",
-    "id": "tec_surv_com_trip_unamred",
-    "name": "Trip",
-    "messages": [ "You trip %s", "<npcname> trip %s" ],
-    "min_unarmed": 3,
-    "unarmed_allowed": true,
-    "down_dur": 1
-  },
-  {
-    "type": "technique",
-    "id": "tec_surv_com_trip_melee",
-    "name": "Trip",
-    "messages": [ "You trip %s", "<npcname> trip %s" ],
-    "min_melee": 3,
-    "melee_allowed": true,
-    "down_dur": 1
-  },
-  {
-    "type": "technique",
-    "id": "tec_surv_com_rapid_unarmed",
-    "name": "quick punch",
-    "min_unarmed": 2,
-    "unarmed_allowed": true,
-    "messages": [ "You quickly punch %s", "<npcname> quickly punches %s" ],
-    "mult_bonuses": [ [ "movecost", 0.25 ], [ "damage", "bash", 0.5 ], [ "damage", "cut", 0.5 ], [ "damage", "stab", 0.5 ] ]
-  },
-  {
-    "type": "technique",
-    "id": "tec_surv_com_rapid_melee",
-    "name": "quick strike",
-    "min_melee": 2,
-    "melee_allowed": true,
-    "messages": [ "You quickly strike %s", "<npcname> quickly strike %s" ],
-    "mult_bonuses": [ [ "movecost", 0.5 ], [ "damage", "bash", 0.75 ], [ "damage", "cut", 0.75 ], [ "damage", "stab", 0.75 ] ]
-  },
-  {
-    "type": "technique",
-    "id": "tec_surv_com_precise_unarmed",
-    "name": "precise strike",
-    "min_unarmed": 6,
-    "unarmed_allowed": true,
-    "crit_tec": true,
-    "messages": [ "You jab %s", "<npcname> jabs %s" ],
-    "stun_dur": 2
-  },
-  {
-    "type": "technique",
-    "id": "tec_surv_com_precise_melee",
-    "name": "precise strike",
-    "min_melee": 6,
-    "melee_allowed": true,
-    "crit_tec": true,
-    "messages": [ "You strike %s", "<npcname> strikes %s" ],
-    "stun_dur": 2
-  },
-  {
-    "type": "technique",
-    "id": "tec_surv_com_surprise_unarmed",
-    "name": "surprise attack",
-    "min_unarmed": 6,
-    "unarmed_allowed": true,
-    "crit_tec": true,
-    "messages": [ "You surprise attack %s", "<npcname> surprise attacks %s" ],
-    "stun_dur": 2,
-    "mult_bonuses": [ [ "damage", "bash", 2 ], [ "damage", "cut", 2 ], [ "damage", "stab", 2 ] ]
-  },
-  {
-    "type": "technique",
-    "id": "tec_surv_com_surprise_melee",
-    "name": "surprise attack",
-    "min_melee": 6,
-    "melee_allowed": true,
-    "crit_tec": true,
-    "messages": [ "You surprise attack %s", "<npcname> surprise attacks %s" ],
-    "stun_dur": 2,
-    "mult_bonuses": [ [ "damage", "bash", 2 ], [ "damage", "cut", 2 ], [ "damage", "stab", 2 ] ]
+    "disarms": true
   }
 ]


### PR DESCRIPTION
`You learned how to handle yourself in the cataclysm.  Whether armed or unarmed, you know how to use your wits to stay alive.  Survival is of the highest priority.`

Name | Level Available | Type | Effect
------------ | ------------- | ------------- | -------------
Arm Block | Melee 2 |  | 
Leg Block | Melee 8 |  | 
Elusiveness | Melee 4 | Unarmed/Melee Onmove Buff | +2 Dodges, Dodge Skill increased by 50% of Intelligence, knockdown immunity. Lasts 1 turn.
Active Defense | Melee 5 | Unarmed/Melee Onhit Buff | +2 Blocks, damage blocked increased by 75% of Intelligence. Lasts 2 turns.
Misdirection | Melee 6 | Unarmed/Melee Onkill Buff | +2 Dodges, +2 Blocks, speed increased by 100% of Intelligence, stealthy movement. Lasts 3 turns.
Grab Break | Melee 7 | Unarmed/Melee Defensive Tech | Grab break
Counter Sweep | Melee 6 | Unarmed/Melee Dodge Counter | Crits allowed, Knockdown 1, 0% Movecost
Counter Strike | Melee 6 | Unarmed/Melee Block Counter | Crits allowed, Knockback 1, Stun 1, 0% Movecost
Feint | Melee 4 | Unarmed/Melee Defensive Tech | Miss recovery
Disarm | Melee 9 | Unarmed/Melee Tech | Disarms target

Weapons: any

This overhaul shifts the focus of Survivor Combatives massively, from a do-anything grabbag of abilities (some broken in the sense of being OP, others broken in not quite working at all) into a mixture of Brawling with a few complimentary buffs, based off other styles. Two themes that came to mind were making it more defensive, and also making its central buffs scale off of intelligence rather than strength. It gets some potent effects if you have enough intelligence, but all of the techniques are fairly basic and no-frills, and nothing affects damage or accuracy. You'll already get plenty killtastic by making use of the "no limit to your weapon selection" thing as it is, making it more useful for survival is a more interesting niche to give it.

In general its technique options mimic Brawling, except for Power Hit and Trip having been essentially merged with Hit Them Back, forming two separate counter techniques, one for blocking and another for dodging.

Its only other special features are basically mimicking elements of Judo and Ninjutsu, gaining knockdown immunity and stealthy movement. Unlike those styles, these are conditional rather than static buffs, respectively only taking effect while you're moving and for a brief moment after a kill.

Had to remove the "gain blocks from CBMs" feature because it seems to disable learning limb blocks naturally, at least the martial arts UI seems to imply this.

Closes https://github.com/Noctifer-de-Mortem/nocts_cata_mod/issues/129