### PR TITLE
Proposed changes to Survivor Combatives

### DIFF
--- a/Surv_help/c_martialarts.json
+++ b/Surv_help/c_martialarts.json
@@ -8,6 +8,8 @@
     "learn_difficulty": 7,
     "arm_block": 2,
     "leg_block": 8,
+    "arm_block_with_bio_armor_arms": true,
+    "leg_block_with_bio_armor_legs": true,
     "allow_melee": true,
     "onmove_buffs": [
       {
@@ -20,8 +22,8 @@
         "melee_allowed": true,
         "throw_immune": true,
         "buff_duration": 1,
-        "bonus_dodges": 2,
-        "flat_bonuses": [ [ "dodge", "int", 0.5 ] ]
+        "bonus_dodges": 1,
+        "flat_bonuses": [ [ "dodge", "int", 0.25 ] ]
       }
     ],
     "onhit_buffs": [
@@ -33,8 +35,8 @@
         "unarmed_allowed": true,
         "melee_allowed": true,
         "buff_duration": 2,
-        "bonus_blocks": 2,
-        "flat_bonuses": [ [ "block", "int", 0.75 ] ]
+        "bonus_blocks": 1,
+        "flat_bonuses": [ [ "block", "int", 1.0 ] ]
       }
     ],
     "onkill_buffs": [
@@ -46,7 +48,7 @@
         "unarmed_allowed": true,
         "melee_allowed": true,
         "stealthy": true,
-        "buff_duration": 3,
+        "buff_duration": 6,
         "bonus_dodges": 2,
         "bonus_blocks": 2,
         "flat_bonuses": [ [ "speed", "int", 1.0 ] ]

--- a/Surv_help/c_techniques.json
+++ b/Surv_help/c_techniques.json
@@ -20,7 +20,7 @@
     "melee_allowed": true,
     "dodge_counter": true,
     "crit_ok": true,
-    "mult_bonuses": [ [ "movecost", 0.0 ] ],
+    "mult_bonuses": [ [ "movecost", 0.0 ], [ "damage", "bash", 0.5 ], [ "damage", "cut", 0.5 ], [ "damage", "stab", 0.5 ] ],
     "down_dur": 1
   },
   {
@@ -33,7 +33,7 @@
     "melee_allowed": true,
     "block_counter": true,
     "crit_ok": true,
-    "mult_bonuses": [ [ "movecost", 0.0 ] ],
+    "mult_bonuses": [ [ "movecost", 0.0 ], [ "damage", "bash", 0.5 ], [ "damage", "cut", 0.5 ], [ "damage", "stab", 0.5 ] ],
     "knockback_dist": 1,
     "stun_dur": 1
   },


### PR DESCRIPTION
Implemented some suggestions that came up in DMs with Hymore, sadly after the initial overhaul was merged.

* Re-implemented gaining limb blocks with armor CBMs, as Hymore confirmed that the UI override is just a display issue, you can have both "blocks at level X" alongside "blocks with this CBM"
* Halved the bonus blocks and dodges of Elusiveness and Active Defense.
* Reduced Int scaling of the dodge skill bonus from Elusiveness.
* Increased Int scaling of the damage blocked bonus from Active Defense.
* Doubled duration of Misdirection.
* Gave the counter-attacks reduced damage, like what Dragon Kung-fu gets (in this case due to allowing weapons, instead of being a stronks-based style).