### PR TITLE
Fix Survivor Combatives not learning off melee

### DIFF
--- a/Surv_help/c_martialarts.json
+++ b/Surv_help/c_martialarts.json
@@ -6,6 +6,7 @@
     "description": "You learned how to handle yourself in the cataclysm.  Whether armed or unarmed, you know how to use your wits to stay alive.  Survival is of the highest priority.",
     "initiate": [ "You steady yourself, prepared for the fights ahead.", "%s prepares for the fights ahead." ],
     "learn_difficulty": 7,
+    "primary_skill": "melee",
     "arm_block": 2,
     "leg_block": 8,
     "arm_block_with_bio_armor_arms": true,


### PR DESCRIPTION
Noticed I forgot to give it melee as its primary learning skill, when it uses melee a lot more than unarmed. Easy enough to change.