### PR TITLE
Harvest and autoclave updates

### DIFF
--- a/Monsters/c_monster_harvest.json
+++ b/Monsters/c_monster_harvest.json
@@ -3,9 +3,24 @@
     "id": "CBM_FAILED_BIO",
     "type": "harvest",
     "entries": [
-      { "drop": "bio_power_storage_mkII", "type": "bionic" },
-      { "drop": "bio_power_storage_mkII", "type": "bionic" },
-      { "drop": "bionics_failed_bio", "type": "bionic_group" },
+      {
+        "drop": "bio_power_storage_mkII",
+        "type": "bionic",
+        "flags": [ "NO_STERILE", "NO_PACKED" ],
+        "faults": [ "fault_bionic_salvaged" ]
+      },
+      {
+        "drop": "bio_power_storage_mkII",
+        "type": "bionic",
+        "flags": [ "NO_STERILE", "NO_PACKED" ],
+        "faults": [ "fault_bionic_salvaged" ]
+      },
+      {
+        "drop": "bionics_failed_bio",
+        "type": "bionic_group",
+        "flags": [ "NO_STERILE", "NO_PACKED" ],
+        "faults": [ "fault_bionic_salvaged" ]
+      },
       { "drop": "human_flesh", "type": "flesh", "mass_ratio": 0.2 },
       { "drop": "hstomach", "scale_num": [ 1, 1 ], "max": 1, "type": "offal" },
       { "drop": "fat", "type": "flesh", "mass_ratio": 0.1 },
@@ -18,9 +33,24 @@
     "id": "CBM_FAILED_BIO_ZOMBIE",
     "type": "harvest",
     "entries": [
-      { "drop": "bio_power_storage_mkII", "type": "bionic" },
-      { "drop": "bio_power_storage_mkII", "type": "bionic" },
-      { "drop": "bionics_failed_bio", "type": "bionic_group" },
+      {
+        "drop": "bio_power_storage_mkII",
+        "type": "bionic",
+        "flags": [ "FILTHY", "NO_STERILE", "NO_PACKED" ],
+        "faults": [ "fault_bionic_salvaged" ]
+      },
+      {
+        "drop": "bio_power_storage_mkII",
+        "type": "bionic",
+        "flags": [ "FILTHY", "NO_STERILE", "NO_PACKED" ],
+        "faults": [ "fault_bionic_salvaged" ]
+      },
+      {
+        "drop": "bionics_failed_bio",
+        "type": "bionic_group",
+        "flags": [ "FILTHY", "NO_STERILE", "NO_PACKED" ],
+        "faults": [ "fault_bionic_salvaged" ]
+      },
       { "drop": "meat_tainted", "type": "flesh", "mass_ratio": 0.25 },
       { "drop": "fat_tainted", "type": "flesh", "mass_ratio": 0.08 },
       { "drop": "bone_tainted", "type": "bone", "mass_ratio": 0.1 }
@@ -30,12 +60,42 @@
     "id": "CBM_APOPHIS",
     "type": "harvest",
     "entries": [
-      { "drop": "bio_power_storage_mkII", "type": "bionic" },
-      { "drop": "bio_power_storage_mkII", "type": "bionic" },
-      { "drop": "bio_power_storage_mkII", "type": "bionic" },
-      { "drop": "bionics_apophis", "type": "bionic_group" },
-      { "drop": "bionics_apophis", "type": "bionic_group" },
-      { "drop": "bionics_apophis", "type": "bionic_group" },
+      {
+        "drop": "bio_power_storage_mkII",
+        "type": "bionic",
+        "flags": [ "NO_STERILE", "NO_PACKED" ],
+        "faults": [ "fault_bionic_salvaged" ]
+      },
+      {
+        "drop": "bio_power_storage_mkII",
+        "type": "bionic",
+        "flags": [ "NO_STERILE", "NO_PACKED" ],
+        "faults": [ "fault_bionic_salvaged" ]
+      },
+      {
+        "drop": "bio_power_storage_mkII",
+        "type": "bionic",
+        "flags": [ "NO_STERILE", "NO_PACKED" ],
+        "faults": [ "fault_bionic_salvaged" ]
+      },
+      {
+        "drop": "bionics_apophis",
+        "type": "bionic_group",
+        "flags": [ "NO_STERILE", "NO_PACKED" ],
+        "faults": [ "fault_bionic_salvaged" ]
+      },
+      {
+        "drop": "bionics_apophis",
+        "type": "bionic_group",
+        "flags": [ "NO_STERILE", "NO_PACKED" ],
+        "faults": [ "fault_bionic_salvaged" ]
+      },
+      {
+        "drop": "bionics_apophis",
+        "type": "bionic_group",
+        "flags": [ "NO_STERILE", "NO_PACKED" ],
+        "faults": [ "fault_bionic_salvaged" ]
+      },
       { "drop": "human_flesh", "type": "flesh", "mass_ratio": 0.2 },
       { "drop": "hstomach", "scale_num": [ 1, 1 ], "max": 1, "type": "offal" },
       { "drop": "fat", "type": "flesh", "mass_ratio": 0.1 },
@@ -48,8 +108,18 @@
     "id": "CBM_SOLDAT_ZOMBIE",
     "type": "harvest",
     "entries": [
-      { "drop": "bio_power_storage_mkII", "type": "bionic" },
-      { "drop": "bionics_soldat_zombie", "type": "bionic_group" },
+      {
+        "drop": "bio_power_storage_mkII",
+        "type": "bionic",
+        "flags": [ "FILTHY", "NO_STERILE", "NO_PACKED" ],
+        "faults": [ "fault_bionic_salvaged" ]
+      },
+      {
+        "drop": "bionics_soldat_zombie",
+        "type": "bionic_group",
+        "flags": [ "FILTHY", "NO_STERILE", "NO_PACKED" ],
+        "faults": [ "fault_bionic_salvaged" ]
+      },
       { "drop": "meat_tainted", "type": "flesh", "mass_ratio": 0.25 },
       { "drop": "fat_tainted", "type": "flesh", "mass_ratio": 0.08 },
       { "drop": "bone_tainted", "type": "bone", "mass_ratio": 0.1 }
@@ -59,8 +129,18 @@
     "id": "CBM_SOLDAT_KNIGHT_ZOMBIE",
     "type": "harvest",
     "entries": [
-      { "drop": "bio_power_storage_mkII", "type": "bionic" },
-      { "drop": "bionics_soldat_knight_zombie", "type": "bionic_group" },
+      {
+        "drop": "bio_power_storage_mkII",
+        "type": "bionic",
+        "flags": [ "FILTHY", "NO_STERILE", "NO_PACKED" ],
+        "faults": [ "fault_bionic_salvaged" ]
+      },
+      {
+        "drop": "bionics_soldat_knight_zombie",
+        "type": "bionic_group",
+        "flags": [ "FILTHY", "NO_STERILE", "NO_PACKED" ],
+        "faults": [ "fault_bionic_salvaged" ]
+      },
       { "drop": "meat_tainted", "type": "flesh", "mass_ratio": 0.25 },
       { "drop": "fat_tainted", "type": "flesh", "mass_ratio": 0.08 },
       { "drop": "bone_tainted", "type": "bone", "mass_ratio": 0.1 }
@@ -70,8 +150,18 @@
     "id": "CBM_SOLDAT_SNIPER_ZOMBIE",
     "type": "harvest",
     "entries": [
-      { "drop": "bio_power_storage_mkII", "type": "bionic" },
-      { "drop": "bionics_soldat_sniper_zombie", "type": "bionic_group" },
+      {
+        "drop": "bio_power_storage_mkII",
+        "type": "bionic",
+        "flags": [ "FILTHY", "NO_STERILE", "NO_PACKED" ],
+        "faults": [ "fault_bionic_salvaged" ]
+      },
+      {
+        "drop": "bionics_soldat_sniper_zombie",
+        "type": "bionic_group",
+        "flags": [ "FILTHY", "NO_STERILE", "NO_PACKED" ],
+        "faults": [ "fault_bionic_salvaged" ]
+      },
       { "drop": "meat_tainted", "type": "flesh", "mass_ratio": 0.25 },
       { "drop": "fat_tainted", "type": "flesh", "mass_ratio": 0.08 },
       { "drop": "bone_tainted", "type": "bone", "mass_ratio": 0.1 }
@@ -81,8 +171,18 @@
     "id": "CBM_SOLDAT_TOOL_ZOMBIE",
     "type": "harvest",
     "entries": [
-      { "drop": "bio_power_storage_mkII", "type": "bionic" },
-      { "drop": "bionics_soldat_tool_zombie", "type": "bionic_group" },
+      {
+        "drop": "bio_power_storage_mkII",
+        "type": "bionic",
+        "flags": [ "FILTHY", "NO_STERILE", "NO_PACKED" ],
+        "faults": [ "fault_bionic_salvaged" ]
+      },
+      {
+        "drop": "bionics_soldat_tool_zombie",
+        "type": "bionic_group",
+        "flags": [ "FILTHY", "NO_STERILE", "NO_PACKED" ],
+        "faults": [ "fault_bionic_salvaged" ]
+      },
       { "drop": "meat_tainted", "type": "flesh", "mass_ratio": 0.25 },
       { "drop": "fat_tainted", "type": "flesh", "mass_ratio": 0.08 },
       { "drop": "bone_tainted", "type": "bone", "mass_ratio": 0.1 }

--- a/Terrain/Bio_Weapon_Lab.json
+++ b/Terrain/Bio_Weapon_Lab.json
@@ -243,7 +243,8 @@
       ],
       "place_vehicles": [
         { "vehicle": "welding_cart", "x": 1, "y": 21, "chance": 99, "fuel": 25, "status": 25, "rotation": 0 },
-        { "vehicle": "chem_cart", "x": 22, "y": 21, "chance": 99, "fuel": 25, "status": 25, "rotation": 0 }
+        { "vehicle": "chem_cart", "x": 22, "y": 21, "chance": 99, "fuel": 25, "status": 25, "rotation": 0 },
+        { "vehicle": "autoclave_cart", "x": 6, "y": 17, "chance": 99, "fuel": 25, "status": 25, "rotation": 0 }
       ]
     }
   }

--- a/Terrain/Unknown_Lab.json
+++ b/Terrain/Unknown_Lab.json
@@ -113,9 +113,7 @@
         "e": "t_pavement_y",
         "f": "t_chainfence_v"
       },
-      "place_loot": [
-        { "group": "map_extra_science", "x": 14, "y": 8, "chance": 75 }
-      ],
+      "place_loot": [ { "group": "map_extra_science", "x": 14, "y": 8, "chance": 75 } ],
       "place_fields": [
         { "field": "fd_blood", "x": 14, "y": 8 },
         { "field": "fd_blood", "x": 14, "y": 7 },
@@ -300,9 +298,7 @@
         "|": "t_wall_metal"
       },
       "furniture": { "c": "f_chair" },
-      "place_loot": [
-        { "group": "map_extra_science", "x": 10, "y": 13, "chance": 75 }
-      ],
+      "place_loot": [ { "group": "map_extra_science", "x": 10, "y": 13, "chance": 75 } ],
       "place_fields": [
         { "field": "fd_blood", "x": 10, "y": 13 },
         { "field": "fd_blood", "x": 11, "y": 14 },
@@ -411,7 +407,8 @@
         { "monster": "mon_failed_weapon", "x": 6, "y": 15 },
         { "monster": "mon_failed_weapon", "x": 12, "y": 21 },
         { "monster": "mon_failed_weapon", "x": 22, "y": 23 }
-      ]
+      ],
+      "place_vehicles": [ { "vehicle": "autoclave_cart", "x": 13, "y": 17, "chance": 99, "fuel": 25, "status": 25, "rotation": 0 } ]
     }
   },
   {
@@ -517,9 +514,7 @@
         { "field": "fd_blood", "x": 12, "y": 23 },
         { "field": "fd_blood", "x": 13, "y": 23 }
       ],
-      "place_vehicles": [
-        { "vehicle": "chem_cart", "x": 16, "y": 12, "chance": 99, "fuel": 25, "status": 25, "rotation": 0 }
-      ],
+      "place_vehicles": [ { "vehicle": "chem_cart", "x": 16, "y": 12, "chance": 99, "fuel": 25, "status": 25, "rotation": 0 } ],
       "place_monster": [
         { "monster": "mon_failed_weapon", "x": 1, "y": 22 },
         { "monster": "mon_failed_weapon", "x": 15, "y": 21 },
@@ -728,9 +723,7 @@
         { "field": "fd_blood", "x": 12, "y": 17 },
         { "field": "fd_blood", "x": 12, "y": 18 }
       ],
-      "place_vehicles": [
-        { "vehicle": "welding_cart", "x": 9, "y": 9, "chance": 99, "fuel": 25, "status": 25, "rotation": 0 }
-      ],
+      "place_vehicles": [ { "vehicle": "welding_cart", "x": 9, "y": 9, "chance": 99, "fuel": 25, "status": 25, "rotation": 0 } ],
       "place_monster": [
         { "monster": "mon_failed_weapon", "x": 3, "y": 6 },
         { "monster": "mon_failed_weapon", "x": 6, "y": 11 },

--- a/Terrain/makeshift_command_center.json
+++ b/Terrain/makeshift_command_center.json
@@ -246,7 +246,8 @@
         { "class": "bio_weapon_1", "x": 22, "y": 10 },
         { "class": "bio_weapon_2", "x": 22, "y": 14 },
         { "class": "cmnd_guard_1", "x": 15, "y": 6 }
-      ]
+      ],
+      "place_vehicles": [ { "vehicle": "autoclave_cart", "x": 15, "y": 22, "chance": 99, "fuel": 85, "status": -1, "rotation": 90 } ]
     }
   }
 ]

--- a/Terrain/sketchy_cabin.json
+++ b/Terrain/sketchy_cabin.json
@@ -242,7 +242,6 @@
         { "item": "scrap", "x": [ 16, 22 ], "y": [ 11, 12 ], "repeat": [ 1, 5 ] },
         { "item": "cu_pipe", "x": [ 16, 22 ], "y": [ 11, 12 ], "chance": 50 },
         { "item": "ceramic_shard", "x": [ 16, 22 ], "y": [ 11, 12 ], "repeat": [ 2, 8 ] },
-
         { "group": "dissection", "x": [ 11, 12 ], "y": 2, "chance": 75, "repeat": 5 },
         { "group": "bionics", "x": [ 2, 5 ], "y": 6, "chance": 75, "repeat": 5 },
         { "group": "NC_GLADIATOR_LIGHT_weapon", "x": 7, "y": [ 10, 11 ], "chance": 50, "repeat": 3 },
@@ -259,10 +258,8 @@
         { "group": "trash", "x": 6, "y": 21, "repeat": [ 1, 3 ] },
         { "group": "dojo_manuals", "x": 13, "y": [ 17, 18 ], "chance": 50, "repeat": 4 }
       ],
-      "place_npcs": [
-        { "class": "slave_fight", "x": 16, "y": 3 },
-        { "class": "slave_fight", "x": 15, "y": 12 }
-      ]
+      "place_npcs": [ { "class": "slave_fight", "x": 16, "y": 3 }, { "class": "slave_fight", "x": 15, "y": 12 } ],
+      "place_vehicles": [ { "vehicle": "autoclave_cart", "x": 9, "y": 2, "chance": 99, "fuel": 25, "status": 25, "rotation": 0 } ]
     }
   },
   {

--- a/Vehicles/c_carts.json
+++ b/Vehicles/c_carts.json
@@ -22,5 +22,18 @@
       { "x": 0, "y": 0, "part": "small_storage_battery" },
       { "x": 0, "y": 0, "part": "surv_station_t" }
     ]
+  },
+  {
+    "id": "autoclave_cart",
+    "type": "vehicle",
+    "name": "Autoclave Station",
+    "blueprint": [ "&" ],
+    "parts": [
+      { "x": 0, "y": 0, "part": "xlframe_vertical_2" },
+      { "x": 0, "y": 0, "part": "wheel_caster" },
+      { "x": 0, "y": 0, "part": "small_storage_battery" },
+      { "x": 0, "y": 0, "part": "autoclave" }
+    ],
+    "items": [ { "x": 0, "y": 0, "chance": 90, "items": [ "pouch_autoclave" ] } ]
   }
 ]


### PR DESCRIPTION
* Updated harvest entries for bionic monsters. Now CBMs are harvested already deployed and non-sterile. They also return filthy for zombie failed bio-weapons and zombie super soldiers, but are merely non-sterile for regular failed bio-weapons and Apophis.
* Added autoclave carts in certain locations, mainly ones expected to be harvesting CBMs from corpses. That includes all the main bio-weapon-linked locations, and the recovery/disposal room of the underground arena complex. The !!science!! variant of survivor encampment is excluded since they most likely dealt with commercially-available CBMs instead.
* Also smol lint of affected files.