### PR TITLE
Updates to regen, harvest, recipes

### DIFF
--- a/Monsters/c_monster_harvest.json
+++ b/Monsters/c_monster_harvest.json
@@ -21,9 +21,9 @@
         "flags": [ "NO_STERILE", "NO_PACKED" ],
         "faults": [ "fault_bionic_salvaged" ]
       },
-      { "drop": "human_flesh", "type": "flesh", "mass_ratio": 0.2 },
-      { "drop": "hstomach", "scale_num": [ 1, 1 ], "max": 1, "type": "offal" },
-      { "drop": "fat", "type": "flesh", "mass_ratio": 0.1 },
+      { "drop": "mutant_human_flesh", "type": "flesh", "mass_ratio": 0.2 },
+      { "drop": "hstomach_large", "scale_num": [ 1, 1 ], "max": 1, "type": "offal" },
+      { "drop": "mutant_human_fat", "type": "flesh", "mass_ratio": 0.1 },
       { "drop": "bone_human", "type": "bone", "mass_ratio": 0.12 },
       { "drop": "sinew", "type": "bone", "mass_ratio": 0.001 },
       { "drop": "raw_leather", "type": "skin", "mass_ratio": 0.01 }
@@ -96,9 +96,9 @@
         "flags": [ "NO_STERILE", "NO_PACKED" ],
         "faults": [ "fault_bionic_salvaged" ]
       },
-      { "drop": "human_flesh", "type": "flesh", "mass_ratio": 0.2 },
-      { "drop": "hstomach", "scale_num": [ 1, 1 ], "max": 1, "type": "offal" },
-      { "drop": "fat", "type": "flesh", "mass_ratio": 0.1 },
+      { "drop": "mutant_human_flesh", "type": "flesh", "mass_ratio": 0.2 },
+      { "drop": "hstomach_large", "scale_num": [ 1, 1 ], "max": 1, "type": "offal" },
+      { "drop": "mutant_human_fat", "type": "flesh", "mass_ratio": 0.1 },
       { "drop": "bone_human", "type": "bone", "mass_ratio": 0.12 },
       { "drop": "sinew", "type": "bone", "mass_ratio": 0.001 },
       { "drop": "raw_leather", "type": "skin", "mass_ratio": 0.01 }

--- a/Monsters/c_monsters.json
+++ b/Monsters/c_monsters.json
@@ -28,6 +28,7 @@
     "vision_day": 40,
     "vision_night": 3,
     "luminance": 12,
+    "regenerates": 4,
     "harvest": "CBM_FAILED_BIO_ZOMBIE",
     "special_attacks": [ [ "SHOCKSTORM", 10 ], [ "PARROT", 50 ], { "type": "bite", "cooldown": 5 } ],
     "special_when_hit": [ "ZAPBACK", 60 ],
@@ -37,7 +38,6 @@
     "death_function": [ "ACID", "NORMAL" ],
     "flags": [
       "SEES",
-      "REGENERATES_10",
       "HEARS",
       "SMELLS",
       "STUMBLES",
@@ -80,6 +80,7 @@
     "vision_night": 3,
     "path_settings": { "max_dist": 50 },
     "luminance": 14,
+    "regenerates": 5,
     "harvest": "CBM_FAILED_BIO",
     "special_attacks": [ [ "SHOCKSTORM", 15 ], [ "PARROT", 80 ] ],
     "special_when_hit": [ "ZAPBACK", 75 ],
@@ -87,7 +88,6 @@
     "death_function": [ "ACID", "NORMAL" ],
     "flags": [
       "SEES",
-      "REGENERATES_10",
       "HEARS",
       "SMELLS",
       "WARM",
@@ -128,6 +128,7 @@
     "vision_night": 30,
     "path_settings": { "max_dist": 50 },
     "luminance": 30,
+    "regenerates": 10,
     "starting_ammo": { "generic_no_ammo": 1000 },
     "harvest": "CBM_APOPHIS",
     "special_attacks": [
@@ -159,7 +160,6 @@
     "death_function": [ "ACID", "NORMAL", "EXPLODE" ],
     "flags": [
       "SEES",
-      "REGENERATES_10",
       "HEARS",
       "GOODHEARING",
       "SMELLS",
@@ -205,6 +205,7 @@
     "vision_night": 3,
     "luminance": 5,
     "harvest": "CBM_FAILED_BIO",
+    "regenerates": 4,
     "special_attacks": [
       [ "SHOCKSTORM", 10 ],
       [ "PARROT", 50 ],
@@ -222,7 +223,6 @@
     "death_function": [ "ACID", "FUNGUS", "NORMAL" ],
     "flags": [
       "SEES",
-      "REGENERATES_10",
       "HEARS",
       "SMELLS",
       "STUMBLES",
@@ -265,6 +265,8 @@
     "vision_night": 15,
     "path_settings": { "max_dist": 10 },
     "luminance": 2,
+    "regenerates": 1,
+    "regen_morale": true,
     "starting_ammo": { "battery": 5000 },
     "harvest": "CBM_SOLDAT_ZOMBIE",
     "special_attacks": [
@@ -297,7 +299,7 @@
     "placate_triggers": [ "PLAYER_WEAK" ],
     "death_drops": "wild_bio_infantry_rifle",
     "death_function": [ "NORMAL" ],
-    "flags": [ "SEES", "HEARS", "SMELLS", "POISON", "NO_BREATHE", "REGENERATES_1", "FILTHY", "PATH_AVOID_DANGER_1", "REGEN_MORALE" ]
+    "flags": [ "SEES", "HEARS", "SMELLS", "POISON", "NO_BREATHE", "FILTHY", "PATH_AVOID_DANGER_1" ]
   },
   {
     "id": "mon_zombie_bio_infantry_shotgun",
@@ -330,6 +332,8 @@
     "vision_night": 15,
     "path_settings": { "max_dist": 10 },
     "luminance": 2,
+    "regenerates": 1,
+    "regen_morale": true,
     "starting_ammo": { "battery": 5000 },
     "harvest": "CBM_SOLDAT_ZOMBIE",
     "special_attacks": [
@@ -362,7 +366,7 @@
     "placate_triggers": [ "PLAYER_WEAK" ],
     "death_drops": "wild_bio_infantry_shotgun",
     "death_function": [ "NORMAL" ],
-    "flags": [ "SEES", "HEARS", "SMELLS", "POISON", "NO_BREATHE", "REGENERATES_1", "FILTHY", "PATH_AVOID_DANGER_1", "REGEN_MORALE" ]
+    "flags": [ "SEES", "HEARS", "SMELLS", "POISON", "NO_BREATHE", "FILTHY", "PATH_AVOID_DANGER_1" ]
   },
   {
     "id": "mon_zombie_bio_knight_lmg",
@@ -395,6 +399,8 @@
     "vision_day": 40,
     "vision_night": 3,
     "luminance": 2,
+    "regenerates": 3,
+    "regen_morale": true,
     "starting_ammo": { "battery": 10000 },
     "harvest": "CBM_SOLDAT_KNIGHT_ZOMBIE",
     "special_attacks": [
@@ -427,7 +433,7 @@
     "anger_triggers": [ "FRIEND_DIED", "HURT", "PLAYER_CLOSE", "STALK" ],
     "death_drops": "wild_bio_knight_lmg",
     "death_function": [ "NORMAL" ],
-    "flags": [ "SEES", "REGENERATES_10", "HEARS", "SMELLS", "POISON", "NO_BREATHE", "BONES", "FILTHY", "REGEN_MORALE" ]
+    "flags": [ "SEES", "HEARS", "SMELLS", "POISON", "NO_BREATHE", "BONES", "FILTHY" ]
   },
   {
     "id": "mon_zombie_bio_knight_lauhcher",
@@ -460,6 +466,8 @@
     "vision_day": 40,
     "vision_night": 3,
     "luminance": 2,
+    "regenerates": 3,
+    "regen_morale": true,
     "starting_ammo": { "battery": 500 },
     "harvest": "CBM_SOLDAT_KNIGHT_ZOMBIE",
     "special_attacks": [
@@ -493,7 +501,7 @@
     "anger_triggers": [ "FRIEND_DIED", "HURT", "PLAYER_CLOSE", "STALK" ],
     "death_drops": "wild_bio_knight_launcher",
     "death_function": [ "NORMAL" ],
-    "flags": [ "SEES", "REGENERATES_10", "HEARS", "SMELLS", "POISON", "NO_BREATHE", "BONES", "FILTHY", "REGEN_MORALE" ]
+    "flags": [ "SEES", "HEARS", "SMELLS", "POISON", "NO_BREATHE", "BONES", "FILTHY" ]
   },
   {
     "id": "mon_zombie_bio_scout_sniper",
@@ -526,6 +534,8 @@
     "vision_night": 40,
     "path_settings": { "max_dist": 20 },
     "luminance": 2,
+    "regenerates": 1,
+    "regen_morale": true,
     "starting_ammo": { "battery": 5000 },
     "harvest": "CBM_SOLDAT_SNIPER_ZOMBIE",
     "special_attacks": [
@@ -558,7 +568,7 @@
     "placate_triggers": [ "PLAYER_WEAK" ],
     "death_drops": "wild_bio_scout_sniper",
     "death_function": [ "NORMAL" ],
-    "flags": [ "SEES", "HEARS", "SMELLS", "POISON", "NO_BREATHE", "REGENERATES_1", "FILTHY", "PATH_AVOID_DANGER_1", "REGEN_MORALE" ]
+    "flags": [ "SEES", "HEARS", "SMELLS", "POISON", "NO_BREATHE", "FILTHY", "PATH_AVOID_DANGER_1" ]
   },
   {
     "id": "mon_zombie_bio_tool_pistol",
@@ -591,6 +601,8 @@
     "vision_night": 15,
     "path_settings": { "max_dist": 30 },
     "luminance": 2,
+    "regenerates": 3,
+    "regen_morale": true,
     "starting_ammo": { "battery": 1000 },
     "harvest": "CBM_SOLDAT_TOOL_ZOMBIE",
     "special_attacks": [
@@ -622,7 +634,7 @@
     "placate_triggers": [ "PLAYER_WEAK" ],
     "death_drops": "wild_bio_tool_pistol",
     "death_function": [ "NORMAL" ],
-    "flags": [ "SEES", "HEARS", "SMELLS", "POISON",  "NO_BREATHE", "REGENERATES_10", "FILTHY", "PATH_AVOID_DANGER_2", "REGEN_MORALE" ]
+    "flags": [ "SEES", "HEARS", "SMELLS", "POISON",  "NO_BREATHE", "FILTHY", "PATH_AVOID_DANGER_2" ]
   },
   {
     "id": "mon_zombie_bio_tool_smg",
@@ -655,6 +667,8 @@
     "vision_night": 15,
     "path_settings": { "max_dist": 30 },
     "luminance": 2,
+    "regenerates": 3,
+    "regen_morale": true,
     "starting_ammo": { "battery": 1000 },
     "harvest": "CBM_SOLDAT_TOOL_ZOMBIE",
     "special_attacks": [
@@ -686,6 +700,6 @@
     "placate_triggers": [ "PLAYER_WEAK" ],
     "death_drops": "wild_bio_tool_smg",
     "death_function": [ "NORMAL" ],
-    "flags": [ "SEES", "HEARS", "SMELLS", "POISON", "NO_BREATHE", "REGENERATES_10", "FILTHY", "PATH_AVOID_DANGER_2", "REGEN_MORALE" ]
+    "flags": [ "SEES", "HEARS", "SMELLS", "POISON", "NO_BREATHE", "FILTHY", "PATH_AVOID_DANGER_2" ]
   }
 ]

--- a/Recipe/c_recipes.json
+++ b/Recipe/c_recipes.json
@@ -17,14 +17,8 @@
   },
   {
     "result": "surcan",
-    "type": "recipe",
-    "category": "CC_NONCRAFT",
-    "subcategory": "CSC_NONCRAFT",
-    "skill_used": "none",
-    "difficulty": 0,
-    "time": "0 m",
-    "reversible": true,
-    "autolearn": true,
+    "type": "uncraft",
+    "time": "1 m",
     "components": [
       [ [ "knife_swissarmy", 1 ] ],
       [ [ "mask_dust", 1 ] ],
@@ -1392,11 +1386,7 @@
   },
   {
     "result": "mil_surp_pack_1",
-    "type": "recipe",
-    "id_suffix": "uncraft",
-    "category": "CC_NONCRAFT",
-    "subcategory": "CSC_NONCRAFT",
-    "difficulty": 0,
+    "type": "uncraft",
     "time": "1 m",
     "components": [
       [ [ "mosin91_30", 1 ] ],
@@ -1409,11 +1399,7 @@
   },
   {
     "result": "mil_surp_pack_2",
-    "type": "recipe",
-    "id_suffix": "uncraft",
-    "category": "CC_NONCRAFT",
-    "subcategory": "CSC_NONCRAFT",
-    "difficulty": 0,
+    "type": "uncraft",
     "time": "1 m",
     "components": [
       [ [ "sks", 1 ] ],
@@ -1426,11 +1412,7 @@
   },
   {
     "result": "mil_surp_pack_3",
-    "type": "recipe",
-    "id_suffix": "uncraft",
-    "category": "CC_NONCRAFT",
-    "subcategory": "CSC_NONCRAFT",
-    "difficulty": 0,
+    "type": "uncraft",
     "time": "1 m",
     "components": [
       [ [ "m1903", 1 ] ],
@@ -1443,11 +1425,7 @@
   },
   {
     "result": "parawatch",
-    "type": "recipe",
-    "category": "CC_ARMOR",
-    "subcategory": "CSC_ARMOR_OTHER",
-    "skill_used": "fabrication",
-    "difficulty": 0,
+    "type": "uncraft",
     "time": "1 m",
     "components": [ [ [ "parabracelets", 1 ] ], [ [ "wristwatch", 1 ] ], [ [ "thermometer", 1 ] ] ],
     "flags": [ "BLIND_EASY" ]
@@ -1455,8 +1433,6 @@
   {
     "result": "parabracelets",
     "type": "uncraft",
-    "skill_used": "fabrication",
-    "difficulty": 0,
     "time": "1 m",
     "components": [ [ [ "string_36", 2 ] ] ],
     "flags": [ "BLIND_EASY" ]
@@ -1464,6 +1440,7 @@
   {
     "result": "goggles_welding",
     "type": "recipe",
+    "id_suffix": "alt_creation",
     "category": "CC_ARMOR",
     "subcategory": "CSC_ARMOR_HEAD",
     "skill_used": "mechanics",
@@ -1474,8 +1451,8 @@
     "book_learn": [ [ "textbook_fabrication", 3 ], [ "welding_book", 3 ] ],
     "tools": [ [ [ "spray_can", 1 ], [ "char_smoker", 25 ] ] ],
     "components": [
-      [ [ "goggles_ski", 1 ], [ "goggles_swim", 1 ], [ "glasses_safety", 1 ], [ "sunglasses", 1 ] ],
-      [ [ "duct_tape", 20 ], [ "medical_tape", 20 ] ]
+      [ [ "goggles_ski", 1 ], [ "goggles_swim", 1 ], [ "glasses_safety", 1 ] ],
+      [ [ "duct_tape", 40 ], [ "medical_tape", 40 ] ]
     ]
   },
   {
@@ -1494,79 +1471,6 @@
       [ [ "oxy_torch", 25 ], [ "welder", 85 ], [ "welder_crude", 180 ], [ "toolset", 180 ] ]
     ],
     "components": [ [ [ "bio_sword", 1 ] ], [ [ "steel_chunk", 3 ], [ "scrap", 9 ] ], [ [ "plastic_chunk", 3 ] ] ]
-  },
-  {
-    "result": "mutagen_alpha",
-    "type": "recipe",
-    "category": "CC_CHEM",
-    "subcategory": "CSC_CHEM_MUTAGEN",
-    "skill_used": "cooking",
-    "difficulty": 10,
-    "skills_required": [ "firstaid", 1 ],
-    "time": "20 m",
-    "book_learn": [ [ "recipe_alpha", 9 ] ],
-    "qualities": [ { "id": "CHEM", "level": 2 } ],
-    "tools": [ [ [ "surface_heat", 50, "LIST" ] ] ],
-    "components": [
-      [ [ "mutagen", 1 ] ],
-      [ [ "purifier", 1 ] ],
-      [ [ "human_flesh", 3 ], [ "dry_hflesh", 3 ], [ "fetus", 1 ], [ "arm", 1 ], [ "leg", 1 ] ],
-      [ [ "bone_human", 1 ], [ "blood", 1 ] ],
-      [ [ "ammonia", 1 ], [ "lye_powder", 100 ] ]
-    ]
-  },
-  {
-    "result": "mutagen_elfa",
-    "type": "recipe",
-    "category": "CC_CHEM",
-    "subcategory": "CSC_CHEM_MUTAGEN",
-    "skill_used": "cooking",
-    "difficulty": 10,
-    "skills_required": [ "firstaid", 1 ],
-    "time": "12 m",
-    "book_learn": [ [ "recipe_elfa", 10 ] ],
-    "qualities": [ { "id": "CHEM", "level": 2 } ],
-    "tools": [ [ [ "surface_heat", 31, "LIST" ] ] ],
-    "components": [
-      [ [ "mutagen", 1 ] ],
-      [ [ "veggy", 3 ], [ "biollante_bud", 1 ], [ "datura_seed", 16 ] ],
-      [ [ "meat", 3 ] ],
-      [ [ "ammonia", 1 ], [ "lye_powder", 100 ] ]
-    ]
-  },
-  {
-    "result": "mutagen_chimera",
-    "type": "recipe",
-    "category": "CC_CHEM",
-    "subcategory": "CSC_CHEM_MUTAGEN",
-    "skill_used": "cooking",
-    "difficulty": 10,
-    "skills_required": [ "firstaid", 1 ],
-    "time": "15 m",
-    "book_learn": [ [ "recipe_chimera", 9 ] ],
-    "qualities": [ { "id": "CHEM", "level": 2 } ],
-    "tools": [ [ [ "surface_heat", 37, "LIST" ] ] ],
-    "components": [
-      [ [ "mutagen", 1 ] ],
-      [ [ "egg_reptile", 1 ] ],
-      [ [ "egg_bird", 1 ] ],
-      [ [ "meat", 6 ] ],
-      [ [ "ammonia", 1 ], [ "lye_powder", 100 ] ]
-    ]
-  },
-  {
-    "result": "mutagen_raptor",
-    "type": "recipe",
-    "category": "CC_CHEM",
-    "subcategory": "CSC_CHEM_MUTAGEN",
-    "skill_used": "cooking",
-    "difficulty": 10,
-    "skills_required": [ "firstaid", 1 ],
-    "time": "12 m",
-    "book_learn": [ [ "recipe_raptor", 9 ] ],
-    "qualities": [ { "id": "CHEM", "level": 2 } ],
-    "tools": [ [ [ "surface_heat", 31, "LIST" ] ] ],
-    "components": [ [ [ "mutagen", 1 ] ], [ [ "egg_reptile", 1 ] ], [ [ "egg_bird", 1 ] ], [ [ "ammonia", 1 ], [ "lye_powder", 100 ] ] ]
   },
   {
     "result": "badge_bio_weapon",


### PR DESCRIPTION
* Implemented the new variable regen instead of the now-unused regeneration flags. On the plus side, this means now the super soldiers and bio-weapons can all get varying levels of regen.
* Updated harvest entries so that bio-weapons make use of mutant humanoid meat and fat, along with large human stomachs (forgot that was a thing).
* Removed overrides for mutagen as mutagen crafting has been extensively updated since then, and it was now causing load errors.
* Changed the welding goggles recipe to an alternative version using suffix, so it's no longer a full override.
* Converted disassembly recipes to uncrafts.

Todo: re-add variant recipes for the category serums that were tweaked (alpha, elf-a, chimera, raptor) via suffix, possibly using the organic infusor.