### PR TITLE
Monster flag and attack tweaks

### DIFF
--- a/Monsters/c_monsters.json
+++ b/Monsters/c_monsters.json
@@ -47,6 +47,8 @@
       "GROUP_BASH",
       "NO_BREATHE",
       "REVIVES",
+      "PUSH_MON",
+      "PUSH_VEH",
       "FILTHY"
     ]
   },
@@ -94,7 +96,7 @@
       "HUMAN",
       "ELECTRIC",
       "BASHES",
-      "GROUP_BASH",
+      "PUSH_VEH",
       "PATH_AVOID_DANGER_2"
     ]
   },
@@ -115,9 +117,9 @@
     "aggression": 100,
     "morale": 100,
     "melee_skill": 10,
-    "melee_dice": 10,
+    "melee_dice": 8,
     "melee_dice_sides": 10,
-    "melee_cut": 10,
+    "melee_cut": 20,
     "dodge": 2,
     "armor_bash": 35,
     "armor_cut": 40,
@@ -166,11 +168,10 @@
       "WARM",
       "HUMAN",
       "PUSH_MON",
+      "PUSH_VEH",
       "ELECTRIC",
       "GRABS",
       "BASHES",
-      "GROUP_BASH",
-      "DESTROYS",
       "PATH_AVOID_DANGER_2",
       "PRIORITIZE_TARGETS"
     ]
@@ -229,8 +230,8 @@
       "ELECTRIC",
       "ATTACKMON",
       "BASHES",
-      "GROUP_BASH",
       "PUSH_MON",
+      "PUSH_VEH",
       "FILTHY"
     ]
   },
@@ -291,8 +292,8 @@
         "description": "The super soldier fires its ARC rifle!",
         "no_ammo_sound": "beep-beep-beep!"
       },
-      [ "GRAB", 5 ],
-      [ "SMASH", 20 ]
+      [ "GRAB", 10 ],
+      [ "BIO_OP_TAKEDOWN", 30 ]
     ],
     "special_when_hit": [ "ZAPBACK", 60 ],
     "anger_triggers": [ "FRIEND_DIED", "FRIEND_ATTACKED", "HURT", "STALK", "PLAYER_CLOSE" ],
@@ -358,8 +359,8 @@
         "description": "The super soldier fires its XARM scattergun!",
         "no_ammo_sound": "beep-beep-beep!"
       },
-      [ "GRAB", 5 ],
-      [ "SMASH", 20 ]
+      [ "GRAB", 10 ],
+      [ "BIO_OP_TAKEDOWN", 30 ]
     ],
     "special_when_hit": [ "ZAPBACK", 60 ],
     "anger_triggers": [ "FRIEND_DIED", "FRIEND_ATTACKED", "HURT", "STALK", "PLAYER_CLOSE" ],
@@ -424,16 +425,15 @@
         "description": "The super soldier fires its LMG!",
         "no_ammo_sound": "beep-beep-beep!"
       },
-      [ "GRAB", 5 ],
+      [ "GRAB_DRAG", 10 ],
       [ "SMASH", 30 ],
-      [ "BIO_OP_TAKEDOWN", 20 ],
-      [ "GRAB_DRAG", 10 ]
+      { "id": "slam" }
     ],
     "special_when_hit": [ "ZAPBACK", 60 ],
     "anger_triggers": [ "FRIEND_DIED", "HURT", "PLAYER_CLOSE", "STALK" ],
     "death_drops": "wild_bio_knight_lmg",
     "death_function": [ "NORMAL" ],
-    "flags": [ "SEES", "HEARS", "SMELLS", "POISON", "NO_BREATHE", "BONES", "FILTHY" ]
+    "flags": [ "SEES", "HEARS", "SMELLS", "POISON", "NO_BREATHE", "BONES", "FILTHY", "BASHES", "PUSH_MON", "PUSH_VEH" ]
   },
   {
     "id": "mon_zombie_bio_knight_lauhcher",
@@ -492,23 +492,22 @@
         "description": "The super soldier fires its launcher!",
         "no_ammo_sound": "beep-beep-beep!"
       },
-      [ "GRAB", 5 ],
+      [ "GRAB_DRAG", 10 ],
       [ "SMASH", 30 ],
-      [ "BIO_OP_TAKEDOWN", 20 ],
-      [ "GRAB_DRAG", 10 ]
+      { "id": "slam" }     
     ],
     "special_when_hit": [ "ZAPBACK", 60 ],
     "anger_triggers": [ "FRIEND_DIED", "HURT", "PLAYER_CLOSE", "STALK" ],
     "death_drops": "wild_bio_knight_launcher",
     "death_function": [ "NORMAL" ],
-    "flags": [ "SEES", "HEARS", "SMELLS", "POISON", "NO_BREATHE", "BONES", "FILTHY" ]
+    "flags": [ "SEES", "HEARS", "SMELLS", "POISON", "NO_BREATHE", "BONES", "FILTHY", "BASHES", "PUSH_MON", "PUSH_VEH" ]
   },
   {
     "id": "mon_zombie_bio_scout_sniper",
     "type": "MONSTER",
     "looks_like": "mon_zombie_bio_scout",
     "name": "zombie super scout",
-    "description": "A zombie of a former member of the military.  This one wields a particular rifle and bionics and appears to know how to use them.  For some reson it seems to just be watching you, as if waiting for you to make a move...",
+    "description": "A zombie of a former member of the military.  This one wields a particular rifle and bionics and appears to know how to use them.  For some reason it seems to just be watching you, as if waiting for you to make a move...",
     "default_faction": "super_soldat",
     "species": [ "ZOMBIE" ],
     "diff": 25,
@@ -560,8 +559,9 @@
         "description": "The super scout fires its rifle!",
         "no_ammo_sound": "beep-beep-beep!"
       },
-      [ "GRAB", 5 ],
-      [ "SMASH", 20 ]
+      [ "GRAB", 10 ],
+      [ "BIO_OP_TAKEDOWN", 30 ],
+      [ "LUNGE", 20 ]
     ],
     "special_when_hit": [ "ZAPBACK", 60 ],
     "anger_triggers": [ "FRIEND_DIED", "HURT", "PLAYER_CLOSE", "STALK" ],
@@ -626,8 +626,8 @@
         "description": "The super soldier fires its pistol!",
         "no_ammo_sound": "beep-beep-beep!"
       },
-      [ "GRAB", 5 ],
-      [ "SMASH", 10 ]
+      [ "GRAB", 10 ],
+      [ "scratch", 20 ]
     ],
     "special_when_hit": [ "ZAPBACK", 60 ],
     "anger_triggers": [ "FRIEND_DIED", "FRIEND_ATTACKED", "HURT", "STALK", "PLAYER_CLOSE" ],
@@ -692,8 +692,8 @@
         "description": "The super soldier fires its smg!",
         "no_ammo_sound": "beep-beep-beep!"
       },
-      [ "GRAB", 5 ],
-      [ "SMASH", 10 ]
+      [ "GRAB", 10 ],
+      [ "scratch", 20 ]
     ],
     "special_when_hit": [ "ZAPBACK", 60 ],
     "anger_triggers": [ "FRIEND_DIED", "FRIEND_ATTACKED", "HURT", "STALK", "PLAYER_CLOSE" ],


### PR DESCRIPTION
* Shifted some of Apophis' damage from standard melee to more cutting damage.
* Set it so failed bio-weapons and zombie super juggernauts can push vehicles around.
* Set it so that zombie and fungal bio-weapons, and zombie super juggernauts, will push monsters around. Regular bio-weapons for now only got PUSH_VEH added.
* Removed GROUP_BASH from non-zombified bio-weapons and Apophis, as they're already strong enough to have decent impact on the terrain in the Unknown Lab individually.
* Likewise removed DESTROYS from Apophis, his smash strength is way up there on its own.
* Shuffled around the special attacks of zombie super soldiers a bit, and added a wider variety to them. Bio-op takedown now goes to the more nimble regular versions and scouts, smash is now primarily the juggernaut's thing. Scouts however also get lunging, juggernauts focus on grab-drag instead of regular grab in addition to getting slam, and bio-engineers gain scratch.

I would've added SCIENCE to the bio-engineers but that attack seems to be a lot less used now. It's still used by lab robots though, so could add it if desired. Might need to define ammo for it other than manhacks, as those might be hostile to zombie super soldiers.