### PR TITLE
Fleshing out Router's missions: part one

### DIFF
--- a/Npc/TALK_MSCI.json
+++ b/Npc/TALK_MSCI.json
@@ -8,15 +8,44 @@
       "no": "Hey there!  Welcome to the Command Center."
     },
     "responses": [
-      {
-        "text": "So now what are you going to do?",
-        "condition": { "and": [ { "not": { "u_has_mission": "MISSION_PROOF_APOPHIS_DEAD" } }, { "u_has_effect": "router_mission" } ] },
-        "topic": "TALK_MSCI_NOWWHAT"
-      },
       { "text": "What is this place?", "topic": "TALK_MSCI_CC_EXPLAIN" },
       { "text": "Who are you?", "topic": "TALK_MSCI_I_AM" },
       { "text": "What are you doing here?", "topic": "TALK_MSCI_ASK_DOING" },
-      { "text": "Anything I can help with?", "topic": "TALK_MISSION_LIST" },
+      {
+        "text": "So now what are you going to do?",
+        "condition": {
+          "and": [
+            { "npc_has_var": "apophis_dead", "type": "dialogue", "context": "router", "value": "yes" },
+            { "u_has_var": "apophis_dead", "type": "dialogue", "context": "router", "value": "yes" }
+          ]
+        },
+        "switch": true,
+        "topic": "TALK_MSCI_NOWWHAT"
+      },
+      {
+        "text": "Anything I can help with?",
+        "condition": { "npc_has_var": "apophis_dead", "type": "dialogue", "context": "router", "value": "yes" },
+        "switch": true,
+        "topic": "TALK_MSCI_NOWWHAT_NEW"
+      },
+      {
+        "text": "So, what can I help you with?",
+        "condition": { "u_has_var": "proven_worthy", "type": "dialogue", "context": "router", "value": "yes" },
+        "switch": true,
+        "topic": "TALK_MISSION_LIST"
+      },
+      {
+        "text": "Any advice for dealing with a bio-weapon?",
+        "condition": { "u_has_mission": "MISSION_LOOT_BIO_LAB" },
+        "switch": true,
+        "topic": "TALK_MSCI_TIPS"
+      },
+      {
+        "text": "Anything I can help with?",
+        "switch": true,
+        "default": true,
+        "topic": "TALK_MSCI_PROOF"
+      },
       { "text": "Can I stay here?", "topic": "TALK_MSCI_ASK_STAY" },
       { "text": "Farewell.", "topic": "TALK_DONE" }
     ]
@@ -24,15 +53,194 @@
   {
     "id": "TALK_MSCI_NOWWHAT",
     "type": "talk_topic",
-    "//": "The player has most likely completed the quest if this line becomes available.  Or terminally screwed up the quest on a different character, which isn't much better than vanilla's poor quest handling.",
-    "dynamic_line": "Survival, and eventually research.  We'll manage given time.  Keep an eye on Sigma and Lambda while you'e at it... talk to them maybe?  I've been busy working on repairs almost constantly, and they're both likely to go stir-crazy if they have nothing to do but sit around all day.  Might help them figure out for themselves what to do.",
+    "//": "This line will now only show up if you've actually turned in the mission, so Router can be fairly certain you haven't somehow beefed it.",
+    "dynamic_line": "Survival, and eventually research.  We'll manage given time.  Keep an eye on Sigma and Lambda while you're at it... talk to them maybe?  I've been busy working on repairs almost constantly, and they're both likely to go stir-crazy if they have nothing to do but sit around all day.  Might help them figure out for themselves what to do.",
     "responses": [
       {
         "text": "We'll see what I can do.",
         "topic": "TALK_MSCI",
-        "effect": [ { "u_add_effect": "router_suggestion", "duration": "PERMANENT" }, { "npc_add_effect": "router_suggestion", "duration": "PERMANENT" } ]
+        "effect": [
+          { "u_add_effect": "router_suggestion", "duration": "PERMANENT" },
+          { "npc_add_effect": "router_suggestion", "duration": "PERMANENT" }
+        ]
       }
     ]
+  },
+  {
+    "id": "TALK_MSCI_NOWWHAT_NEW",
+    "type": "talk_topic",
+    "//": "This should reasonably check for new players who stumble upon the location after a previous player killed Apophis.",
+    "dynamic_line": "I don't have any jobs for you, I'm afraid.  If you see Sigma or Lambda, maybe speak with them.  I've been busy working on repairs almost constantly, and they're both likely to go stir-crazy if they have nothing to do but sit around all day.  Might help them figure out for themselves what to do.",
+    "responses": [
+      {
+        "text": "Oh, okay.",
+        "topic": "TALK_MSCI",
+        "effect": [
+          { "u_add_effect": "router_suggestion", "duration": "PERMANENT" },
+          { "npc_add_effect": "router_suggestion", "duration": "PERMANENT" }
+        ]
+      }
+    ]
+  },
+  {
+    "id": "TALK_MSCI_TIPS",
+    "type": "talk_topic",
+    "//": "This is really just flavor for when the player should be skipping the 'prove yourself' dialogue, but shouldn't yet advance to the NPC's real mission list.",
+    "dynamic_line": [
+      "If you have access to any sort of protection against electricity, use it.  Most of them have electric discharge weaponry implanted in them, and those that don't have been known to mutilate their power generation augmentations to improvise.",
+      "Even with how much they've been through, their medical implants are usually still operational.  If you commit to an attack, keep up the pressure.  If you have to break contact, they'll have likely regenerated by the time you next run into them.",
+      "I'd recommend against taking them on in close combat, unless you're likewise fairly well-enhanced.  Keep a safe distance and pour a high volume of fire into them.  Only a few of the completed bio-weapons had any integrated ranged weaponry, so it'll be safer than going toe-to-toe with them.",
+      "If you can deliver effective fire with something high-caliber, or even explosive, you should have good odds of taking one out in a single shot.  Be prepared for the chance they might limp away from it though, these things are tougher than the look.",
+      "It's a bit like fighting some of the nastier undead out there, if you get caught in close combat with more than one of them, you're not going to last long.  Be careful too, even with all those bionic malfunctions they might outpace you.",
+      "I'm sure they can tell the living apart from the dead, but that doesn't make them any friend of the zombies.  The undead seem to regard them with the same hostility as any other living human."
+    ],
+    "responses": [ { "text": "...", "topic": "TALK_MSCI" } ]
+  },
+  {
+    "id": "TALK_MSCI_PROOF",
+    "type": "talk_topic",
+    "dynamic_line": {
+      "u_is_wearing": "badge_bio_weapon",
+      "yes": "Well, you know that bio-weapon badge you're wearing?  I'd like to ask first, how you got your hands on that.  I have some rather dangerous work that needs to be done, but I need confirmation that you can handle it.",
+      "no": "I have some important work that needs to be done, but I'm not sure if you're cut out for it.  Have you ever run into a bio-weapon before?  Rather dangerous, heavily augmented and mutated.  I don't want to put someone inexperienced in these things in necessary danger."
+    },
+    "responses": [
+      {
+        "text": "I'm one of them, actually.",
+        "condition": {
+          "and": [
+            {
+              "u_has_any_trait": [ "BIO_WEAPON_ALPHA", "BIO_WEAPON_BETA", "BIO_WEAPON_DELTA", "BIO_WEAPON_GAMMA", "BIO_WEAPON_FAILED" ]
+            },
+            { "u_is_wearing": "badge_bio_weapon" }
+          ]
+        },
+        "switch": true,
+        "topic": "TALK_MSCI_PROOF_BIO"
+      },
+      {
+        "text": "I'm one of them, I wasn't wearing the badge.",
+        "condition": {
+          "u_has_any_trait": [ "BIO_WEAPON_ALPHA", "BIO_WEAPON_BETA", "BIO_WEAPON_DELTA", "BIO_WEAPON_GAMMA", "BIO_WEAPON_FAILED" ]
+        },
+        "switch": true,
+        "topic": "TALK_MSCI_PROOF_BIO"
+      },
+      {
+        "text": "I'm a member of the super soldier project, I can handle it.",
+        "condition": { "u_has_trait": "SUPER_SOLDIER_MARKER" },
+        "switch": true,
+        "topic": "TALK_MSCI_PROOF_SOLDIER"
+      },
+      {
+        "text": "I found it along the way.  What needs to be done?",
+        "condition": { "u_is_wearing": "badge_bio_weapon" },
+        "switch": true,
+        "topic": "TALK_MSCI_PROOF_LOOTER"
+      },
+      {
+        "text": "I have one of those emblems they wear actually, right here.",
+        "condition": { "u_has_item": "badge_bio_weapon" },
+        "switch": true,
+        "topic": "TALK_MSCI_PROOF_LOOTER"
+      },
+      {
+        "text": "I'm willing to try, what can I do?",
+        "switch": true,
+        "default": true,
+        "topic": "TALK_MSCI_PROOF_TRY"
+      },
+      { "text": "Er, nevermind then.", "topic": "TALK_MSCI" }
+    ]
+  },
+  {
+    "id": "TALK_MSCI_PROOF_BIO",
+    "type": "talk_topic",
+    "dynamic_line": {
+      "u_is_wearing": "badge_bio_weapon",
+      "yes": "That would explain it then.  That you're here and not hostile at least confirms you're still on humanity's side.  We're here because of Apophis.  He was built to exterminate the Bio-Weapon Project, along with every person involved in your creation.  Somehow he's attracted several failed bio-weapons to his cause as well.  We need to gather intel and make allies, more people like you.  I'm willing to trust you with this, if you're prepared for some hard fights ahead.",
+      "no": "Huh.  Looking at you, I'm willing to give you the benefit of the doubt.  Plenty of reasons to want to be more discreet.  Then you should know that the project left a lot of unfinished business, a lot of problems for you and I to clean up.  If you think you're ready, I should have something for you."
+    },
+    "responses": [
+      {
+        "text": "We'll see what I can do.",
+        "topic": "TALK_MSCI",
+        "effect": { "u_add_var": "proven_worthy", "type": "dialogue", "context": "router", "value": "yes" }
+      }
+    ]
+  },
+  {
+    "id": "TALK_MSCI_PROOF_SOLDIER",
+    "type": "talk_topic",
+    "dynamic_line": {
+      "u_is_wearing": "badge_bio_weapon",
+      "yes": "Good.  We're going to need all the help we can get.  We've been gathering information on a renegade bio-weapon, Apophis.  I have a few leads on useful intel that may give us a shot at taking it down.  Come talk to me when you're ready.",
+      "no": "Hmm, I suppose I'll give you the benefit of the doubt.  You did find us, after all.  I have some intel on locations that might help us take down a major threat to the region.  When you think you're ready, speak to me and I'll see what we can do."
+    },
+    "responses": [
+      {
+        "text": "Okay.",
+        "topic": "TALK_MSCI",
+        "effect": { "u_add_var": "proven_worthy", "type": "dialogue", "context": "router", "value": "yes" }
+      }
+    ]
+  },
+  {
+    "id": "TALK_MSCI_PROOF_LOOTER",
+    "type": "talk_topic",
+    "dynamic_line": {
+      "u_is_wearing": "badge_bio_weapon",
+      "yes": "Well, you've most likely learned by now how dangerous those things can be.  If you're able to handle yourself well enough out there to get your hands on something like that, then hopefully you can be trusted with more dangerous work.  I have something I'd like to ask of you, when you get the chance.",
+      "no": "Ah, I see.  Well then, you should likely be familiar with how dangerous these things are.  You'll likely run into a lot more of these things, but the work I need done will be a major help for those surviving out there in the region.  Come see me when you're ready."
+    },
+    "responses": [
+      {
+        "text": "We'll see.",
+        "topic": "TALK_MSCI",
+        "effect": { "u_add_var": "proven_worthy", "type": "dialogue", "context": "router", "value": "yes" }
+      }
+    ]
+  },
+  {
+    "id": "TALK_MSCI_PROOF_TRY",
+    "type": "talk_topic",
+    "dynamic_line": "I'd like for you to go scout out a small lab installation, associated with the project that made many of these bio-weapons.  Recently there was a security breach logged on what's left of the laboratory network, and I have reason to believe that these failed bio-weapons might be involved.  If you can reach that place and bring back one of the badges those things wear, I'll be willing to trust you with more complicated missions.",
+    "responses": [
+      {
+        "text": "Security breach at a bio-weapon lab... that might've been Evelynn actually, not just the bio-weapons that were there.",
+        "switch": true,
+        "condition": { "u_has_var": "searching_for_msci", "type": "dialogue", "context": "evelynn", "value": "yes" },
+        "topic": "TALK_MSCI_PROOF_EVY"
+      },
+      {
+        "text": "Okay, I'll do it.",
+        "switch": true,
+        "default": true,
+        "effect": { "add_mission": "MISSION_LOOT_BIO_LAB" },
+        "topic": "TALK_MSCI_PROOF_TRY_ACCEPT"
+      },
+      { "text": "Er, maybe another time.", "topic": "TALK_MSCI" },
+      { "text": "Maybe another time.  Bye.", "topic": "TALK_DONE" }
+    ]
+  },
+  {
+    "id": "TALK_MSCI_PROOF_EVY",
+    "type": "talk_topic",
+    "//": "Sadly the wild goose chase will still be needed for players who started Evy's mission in saves predating the addition of this dialogue, but this idiotproofs it as best as I can.",
+    "dynamic_line": "Huh?  Oh, so you have been there already, I'm guessing.  I guess that's adequate, no sense in wasting time we don't have on a wild goose chase.  If you think you can handle yourself, I still have other missions for you.",
+    "responses": [
+      {
+        "text": "We'll see.",
+        "topic": "TALK_MSCI",
+        "effect": { "u_add_var": "proven_worthy", "type": "dialogue", "context": "router", "value": "yes" }
+      }
+    ]
+  },
+  {
+    "id": "TALK_MSCI_PROOF_TRY_ACCEPT",
+    "type": "talk_topic",
+    "dynamic_line": "Alright, I'll mark the location on your map.  I want you to exercise extreme caution.  Those things are likely to still be in the area, and they're not easy to take down.  If things look too hectic there, break contact and try not to get in over your head.  I feel bad enough sending you off on a mission like this as it is, but we'll need people who can handle far bigger threats.  So please, don't get yourself killed.",
+    "responses": [ { "text": "...", "topic": "TALK_MSCI" } ]
   },
   {
     "id": "TALK_MSCI_CC_EXPLAIN",
@@ -58,7 +266,7 @@
   {
     "id": "TALK_MSCI_ASK_DOING",
     "type": "talk_topic",
-    "//": "Infinitely more idiotproof than the last way I had it rigged, but still has its flawed.",
+    "//": "Infinitely more idiotproof than the last way I had it rigged, but still has its flaws.",
     "dynamic_line": {
       "npc_has_effect": "router_suggest",
       "yes": "Well, the main reason we were hiding here was Apophis...  It was a Bio-Weapon specifically designed to eliminate every other Bio-Weapon and Bio-Weapon scientist.  Now we can try to get things fixed up eventually, and work on research that might benefit others out there.",
@@ -125,7 +333,7 @@
     "type": "talk_topic",
     "dynamic_line": {
       "u_is_wearing": "badge_bio_weapon",
-      "yes": "And that thing was created to kill you, the orginal Bio-Weapons, and anything else that gets in the way.  That's why it got the designation Apophis, pretty much opened ourselves up for that when we went with Project Mesektet for the codename.",
+      "yes": "And that thing was created to kill you, the original Bio-Weapons, and anything else that gets in the way.  That's why it got the designation Apophis, pretty much opened ourselves up for that when we went with Project Mesektet for the codename.",
       "no": "If you're really one of the super soldiers, then you should know hiding your badge won't prevent Apophis from figuring you out.  That thing was designed to hunt Bio-Weapons and Super Soldiers alike."
     },
     "responses": [ { "text": "...", "topic": "TALK_MSCI" } ]

--- a/Npc/c_mission_def.json
+++ b/Npc/c_mission_def.json
@@ -1,8 +1,32 @@
 [
   {
+    "id": "MISSION_LOOT_BIO_LAB",
+    "type": "mission_definition",
+    "name": "Find A Bio-Weapon Badge",
+    "goal": "MGOAL_FIND_ITEM",
+    "difficulty": 6,
+    "value": 60000,
+    "item": "badge_bio_weapon",
+    "start": { "assign_mission_target": { "om_terrain": "Bio_Weapon_Lab_2", "om_special": "Bio_Weapon_Lab_s", "reveal_radius": 3, "z": 0 } },
+    "end": { "effect": { "u_add_var": "proven_worthy", "type": "dialogue", "context": "router", "value": "yes" } },
+    "count": 1,
+    "origins": [ "ORIGIN_SECONDARY" ],
+    "dialogue": {
+      "describe": "If you see this, it's a bug!",
+      "offer": "Seeing this is probably also a bug.",
+      "accepted": "And seeing this is probably a bug too.",
+      "rejected": "Oi, cease with these shenanigans, ye debuggers!",
+      "advice": "In fact most of this dialogue is a bug if you run into it, as this mission is started purely through dialogue.",
+      "inquire": "Any luck so far?",
+      "success": "Good.  I hope that it wasn't too harrowing an experience, but we're dealing with some extremely dangerous threats, and it's only going to get worse from there.  Come see me when you're ready, I've got more important tasks that need taking care of.",
+      "success_lie": "Somehow I doubt that... in fact seeing this is probably another bug, given you can't really bluff your way out of this mission.",
+      "failure": "Pretty certain seeing this is a bug too, since you'd have to die to fail this."
+    }
+  },
+  {
     "id": "MISSION_PROOF_APOPHIS_DEAD",
     "type": "mission_definition",
-    "name": "Kill Bio Weapoon Apophis",
+    "name": "Kill Bio-Weapon Apophis",
     "goal": "MGOAL_FIND_ITEM",
     "difficulty": 10,
     "value": 100000,
@@ -11,11 +35,17 @@
       "effect": { "u_add_effect": "router_mission", "duration": "PERMANENT" },
       "assign_mission_target": { "om_terrain": "Unknown_Lab_4", "om_special": "Unknown_Lab_s", "reveal_radius": 3, "search_range": 180, "z": 0 }
     },
+    "end": {
+      "effect": [
+        { "u_add_var": "apophis_dead", "type": "dialogue", "context": "router", "value": "yes" },
+        { "npc_add_var": "apophis_dead", "type": "dialogue", "context": "router", "value": "yes" }
+      ]
+    },
     "count": 1,
     "origins": [ "ORIGIN_SECONDARY" ],
     "dialogue": {
       "describe": "If you see this, it's a bug!",
-      "offer": "Only one thing comes to mind.  You seem like a capable person, so you might have a chance.  We have pieced together the coordinates to the laboratory Apophis uses as its base.  I want you to take it down, rid the world of Apophis!  That lab has a lot of valuable equipment left inside - if you manage to kill that thing, it's all yours.  ...I wish we could do it ourselves, but between the portal breakthroughs, the bombs and  the undead, the chance has been lost.",
+      "offer": "You seem like a capable person, so you might have a chance.  We have pieced together the coordinates to the laboratory Apophis uses as its base.  I want you to take it down, rid the world of Apophis!  That lab has a lot of valuable equipment left inside - if you manage to kill that thing, it's all yours.  ...I wish we could do it ourselves, but between the portal breakthroughs, the bombs and  the undead, the chance has been lost.",
       "accepted": "You're sure about this?  Thank you... that means a lot, you know.  Be sure to bring some proof, be creative.  I'll be waiting for your return.  I'd suggest talking to Sigma and Lambda too, before you leave.",
       "rejected": "I understand.  It's practically a lost cause at this point.  I'll keep trying to figure something out to stop it.",
       "advice": "Got some decent armor and weapons, this fight won't be easy. Assemble a team to make it easier. Ask Lambda and Sigma if they want to join you, if you want.  A single person can't take it on...",
@@ -35,7 +65,7 @@
     "origins": [ "ORIGIN_SECONDARY" ],
     "destination": "makeshift_command_center_b",
     "start": {
-      "effect": "follow",
+      "effect": [ "follow", { "u_add_var": "searching_for_msci", "type": "dialogue", "context": "evelynn", "value": "yes" } ],
       "assign_mission_target": {
         "om_terrain": "makeshift_command_center_2",
         "om_special": "makeshift_command_center_s",


### PR DESCRIPTION
* Set it up so that Router is skeptical of players who don't have a bio-weapon badge on hand, allowing the potential for a side mission that lets players find the bio-weapon lab if they've reached the command center first.
* Players who started Evy's mission first can opt to skip this, as that's the only way for the game to easily track that the player already has visited the bio-weapon lab. Sadly, it's not available to players who recruited Evy in a save predating this PR, but it's a start at least.
* Bio-weapons and super soldiers likewise outright skip the side mission, as does any player who already has a bio-weapon badge on hand.

Next part will be adding a bit more mission-wise to Router, via adding another mission before the "go kill Apophis" one. For now this sets up the framework and ensures that Router doesn't immediately trust unproven newbies with half of the command center's defenders, they have to at least put in a reasonable effort to prove they won't get themselves killed immediately. The second half of this will add a little more fleshing out to this mission chain, of course. :3