### PR TITLE
Adds super soldiers to Overrun scenario

### DIFF
--- a/Char_creation/c_scenarios.json
+++ b/Char_creation/c_scenarios.json
@@ -300,5 +300,11 @@
     "type": "scenario",
     "ident": "heli_crash",
     "extend": { "professions": [ "bio_infantry", "bio_scout", "bio_knight", "bio_tool" ] }
+  },
+  {
+    "copy-from": "overrun",
+    "type": "scenario",
+    "ident": "overrun",
+    "extend": { "professions": [ "bio_infantry", "bio_scout", "bio_knight", "bio_tool" ] }
   }
 ]

--- a/Monsters/c_monstergroups.json
+++ b/Monsters/c_monstergroups.json
@@ -92,6 +92,36 @@
     ]
   },
   {
+    "name": "GROUP_MIL_BASE",
+    "type": "monstergroup",
+    "override": false,
+    "auto_total": true,
+    "monsters": [
+      { "monster": "mon_zombie_bio_dormant_unarmed", "freq": 10, "cost_multiplier": 15, "starts": 336 },
+      { "monster": "mon_zombie_bio_dormant_armed", "freq": 10, "cost_multiplier": 15, "starts": 336 }
+    ]
+  },
+  {
+    "name": "GROUP_MIL_BASE_CIVILIAN",
+    "type": "monstergroup",
+    "override": false,
+    "auto_total": true,
+    "monsters": [
+      { "monster": "mon_zombie_bio_dormant_unarmed", "freq": 3, "cost_multiplier": 15, "starts": 336 },
+      { "monster": "mon_zombie_bio_dormant_armed", "freq": 2, "cost_multiplier": 15, "starts": 336 }
+    ]
+  },
+  {
+    "name": "GROUP_MIL_BASE_HOSPITAL",
+    "type": "monstergroup",
+    "override": false,
+    "auto_total": true,
+    "monsters": [
+      { "monster": "mon_zombie_bio_dormant_unarmed", "freq": 3, "cost_multiplier": 15, "starts": 336 },
+      { "monster": "mon_zombie_bio_dormant_armed", "freq": 2, "cost_multiplier": 15, "starts": 336 }
+    ]
+  },
+  {
     "name": "GROUP_MIL_WEAK",
     "type": "monstergroup",
     "override": false,


### PR DESCRIPTION
* Allows super soldier professions to appear in the Overrun scenario.
* Also adds spawns of unevolved zombie super soldiers at the expected low weights and typical delay, for the military base's zed population.