### PR TITLE
Overhaul Biological Weapons: Part One

### DIFF
--- a/Surv_help/c_effects.json
+++ b/Surv_help/c_effects.json
@@ -4,5 +4,35 @@
     "id": "rtg_induction_radiation",
     "max_duration": "2 m",
     "base_mods": { "rad_min": [ 1 ] }
+  },
+  {
+    "type": "effect_type",
+    "id": "adrenaline_bioweapon",
+    "name": [ "Exertion", "Bloodlust" ],
+    "desc": [ "You feel worn out and empty inside.", "You thirst for blood!" ],
+    "apply_message": "You feel an unnatural surge of adrenaline!",
+    "rating": "good",
+    "decay_messages": [ [ "Your bloodlust wears off.  You feel AWFUL!", "bad" ] ],
+    "miss_messages": [ [ "Your weariness throws you off.", 1 ] ],
+    "max_duration": "200 s",
+    "max_intensity": 2,
+    "int_dur_factor": "180 s",
+    "removes_effects": [ "winded", "bleed" ],
+    "base_mods": {
+      "speed_mod": [ -15 ],
+      "str_mod": [ -2 ],
+      "dex_mod": [ -2 ],
+      "int_mod": [ -2 ],
+      "per_mod": [ -1 ],
+      "stamina_min": [ -2 ]
+    },
+    "scaling_mods": {
+      "speed_mod": [ 30 ],
+      "str_mod": [ 4 ],
+      "dex_mod": [ 4 ],
+      "int_mod": [ -1 ],
+      "per_mod": [ 1 ],
+      "stamina_min": [ 4 ]
+    }
   }
 ]

--- a/Surv_help/c_spells.json
+++ b/Surv_help/c_spells.json
@@ -36,5 +36,59 @@
     "effect_str": "rtg_induction_radiation",
     "min_duration": 500,
     "max_duration": 1000
+  },
+  {
+    "type": "SPELL",
+    "id": "c_flesh_hit_effect",
+    "name": "Biological Weapon Effect",
+    "description": "This effect adds bleeding to target.",
+    "valid_targets": [ "hostile" ],
+    "message": "",
+    "effect_str": "bleed",
+    "min_duration": 100,
+    "max_duration": 1000,
+    "effect": "target_attack",
+    "flags": [ "RANDOM_DURATION" ],
+    "extra_effects": [ { "id": "c_flesh_hit_effect_2", "hit_self": true } ]
+  },
+  {
+    "type": "SPELL",
+    "id": "c_flesh_hit_effect_2",
+    "name": "Biological Weapon Wonder",
+    "description": "One-third chance of applying a brief spike of adrenaline.",
+    "valid_targets": [ "self" ],
+    "message": "",
+    "effect": "none",
+    "flags": [ "WONDER", "SILENT" ],
+    "min_damage": 1,
+    "max_damage": 1,
+    "extra_effects": [
+      { "id": "c_dummy_effect" },
+      { "id": "c_dummy_effect" },
+      { "id": "c_flesh_hit_effect_3" }
+    ]
+  },
+  {
+    "id": "c_flesh_hit_effect_3",
+    "type": "SPELL",
+    "name": "Biological Weapon Adrenaline",
+    "message": "",
+    "description": "The actual adrenaline effect.  Keep the pressure up and you should be fine.",
+    "valid_targets": [ "self" ],
+    "flags": [ "SILENT", "RANDOM_DURATION" ],
+    "min_duration": 18500,
+    "max_duration": 19500,
+    "effect": "target_attack",
+    "effect_str": "adrenaline_bioweapon"
+  },
+  {
+    "type": "SPELL",
+    "id": "c_dummy_effect",
+    "name": "Sorry, Nothing",
+    "description": "Dirty hack to add RNG to spell effects.",
+    "valid_targets": [ "self" ],
+    "flags": [ "SILENT" ],
+    "message": "",
+    "effect": "target_attack"
   }
 ]

--- a/Weapons/c_melee.json
+++ b/Weapons/c_melee.json
@@ -3,6 +3,7 @@
     "type": "TOOL",
     "id": "unbio_bladed_weapon",
     "name": "monomolecular knife",
+    "category": "weapons",
     "description": "A foot-long knife made from high-tech alloy and edged with bonded nanocrystals.  A welded metal handle and handguard allow you to hold it without slicing your hand open.",
     "weight": 250,
     "to_hit": 2,
@@ -28,6 +29,7 @@
     "type": "TOOL",
     "id": "unbio_sword_weapon",
     "name": "monomolecular sword",
+    "category": "weapons",
     "description": "A yard-long sword made from high-tech alloy and edged with bonded nanocrystals.  A welded metal handle and handguard allow you to hold it without slicing your hand open.",
     "weight": 250,
     "to_hit": 2,
@@ -52,6 +54,7 @@
   {
     "type": "TOOL",
     "id": "unbio_claws_weapon",
+    "category": "weapons",
     "name": "bionic claw knuckles",
     "name_plural": "bionic claw knuckles",
     "description": "Short and sharp claws made from a high-tech metal welded to metal knuckles.  Lightweight and fast, wielding them feels as if you were bare-handed.",
@@ -70,8 +73,9 @@
   {
     "type": "TOOL",
     "id": "flesh_knife",
+    "category": "weapons",
     "name": "biological blade",
-    "description": "A foot-long knife made from metal enclosed with flesh and bone.  Its blade consists of razor sharp saw-like protrusions, with a bone handle that fits well in the hand.  Holding it makes you feel powerful, a sensation that grows stronger with time.",
+    "description": "A foot-long knife made from metal enclosed with flesh and bone.  Its blade consists of razor sharp saw-like protrusions, with a bone handle that fits well in the hand.  Holding it brings strange whispers to the back of your mind, as though it has a will of its own.",
     "weight": 220,
     "to_hit": 3,
     "color": "red",
@@ -82,24 +86,23 @@
     "volume": 2,
     "bashing": 2,
     "cutting": 18,
-    "flags": [ "NON_STUCK", "UNBREAKABLE_MELEE", "UNARMED_WEAPON" ],
+    "flags": [ "UNBREAKABLE_MELEE", "UNARMED_WEAPON", "MAGIC_FOCUS", "SHEATH_KNIFE" ],
     "price": 580000,
     "qualities": [ [ "CUT", 1 ], [ "BUTCHER", 10 ] ],
-    "use_action": [ "ARTIFACT" ],
     "artifact_data": {
-      "effects_carried": [ "AEP_ATTENTION" ],
-      "effects_wielded": [ "AEP_SICK", "AEP_EVIL", "AEP_SAP_LIFE", "AEP_MUTAGENIC" ]
+      "effects_carried": [ "AEP_SICK" ],
+      "effects_wielded": [ "AEP_SCHIZO", "AEP_SAP_LIFE" ]
     }
   },
   {
     "type": "TOOL",
     "id": "flesh_blade",
+    "category": "weapons",
     "name": "biological sword",
-    "description": "A yard-long sword of metal, enclosed in flesh and bone, including a protective hilt framed with tough sinews.  Grown from a smaller sample, holding it brings a strange sense of power beyond what it used to.  If \"fed\" properly it could have other uses.",
+    "description": "A yard-long sword of metal, enclosed in flesh and bone, including a protective hilt framed with tough sinews.  Grown from a smaller sample, holding it brings a strange sense of power beyond what it used to.  If \"fed\" properly it could be even deadlier, though you won't be able to let go of it until it runs out of power.",
     "weight": 680,
     "to_hit": 2,
     "max_charges": 10,
-    "charges_per_use": 1,
     "color": "red",
     "symbol": "/",
     "material": [ "flesh", "superalloy" ],
@@ -107,16 +110,16 @@
     "volume": 6,
     "bashing": 2,
     "cutting": 25,
-    "flags": [ "NON_STUCK", "UNBREAKABLE_MELEE", "UNARMED_WEAPON" ],
+    "flags": [ "UNBREAKABLE_MELEE", "UNARMED_WEAPON", "MAGIC_FOCUS", "SHEATH_SWORD" ],
     "price": 580000,
     "qualities": [ [ "CUT", 1 ], [ "BUTCHER", 10 ] ],
     "use_action": [
       "ARTIFACT",
       {
         "target": "flesh_blade_on",
-        "msg": "You feel a sense of decay and entrophy, as the blade's flesh solidifies into living steel.",
-        "target_charges": 10,
+        "msg": "You feel a sense of decay and entropy, as the blade's flesh solidifies into living steel and envelops your hand.",
         "active": true,
+        "need_wielding": true,
         "need_charges": 1,
         "need_charges_msg": "The blade twitches, failing to do anything.",
         "menu_text": "Let the decay take hold",
@@ -125,18 +128,17 @@
     ],
     "artifact_data": {
       "charge_type": "ARTC_HP",
-      "effects_carried": [ "AEP_ATTENTION" ],
-      "effects_wielded": [ "AEP_SICK", "AEP_EVIL", "AEP_SAP_LIFE", "AEP_MUTAGENIC" ],
-      "effects_activated": [ "AEA_BLOOD", "AEA_ATTENTION", "AEA_PAIN", "AEA_ADRENALINE", "AEA_FUN", "AEA_MUTATE" ]
+      "effects_carried": [ "AEP_SICK" ],
+      "effects_wielded": [ "AEP_SCHIZO", "AEP_SAP_LIFE" ]
     }
   },
   {
     "type": "TOOL",
     "id": "flesh_blade_on",
+    "category": "weapons",
     "name": "biological sword (active)",
     "name_plural": "biological swords (active)",
     "description": "You've activated the power of the blade.  Metal and flesh have wrapped around your hand and it won't let go.  An instinctive bloodlust lingers in the back of your mind, making it harder to focus on the thought of trying to deactivate it.",
-    "initial_charges": 10,
     "max_charges": 10,
     "turns_per_charge": 5,
     "revert_to": "flesh_blade",
@@ -149,22 +151,24 @@
     "techniques": [ "WBLOCK_2", "PRECISE", "BRUTAL" ],
     "volume": 6,
     "bashing": 2,
-    "cutting": 100,
-    "flags": [ "UNBREAKABLE_MELEE", "NO_UNWIELD", "UNARMED_WEAPON" ],
-    "price": 580000,
-    "qualities": [ [ "CUT", 1 ], [ "BUTCHER", 10 ] ],
+    "cutting": 50,
+    "flags": [ "UNBREAKABLE_MELEE", "NO_UNWIELD", "UNARMED_WEAPON", "MAGIC_FOCUS", "TRADER_AVOID" ],
+    "relic_data": {
+      "passive_effects": [ { "has": "WIELD", "condition": "ALWAYS", "hit_you_effect": [ { "id": "c_flesh_blade_hit_effect" } ] } ]
+    },
     "artifact_data": {
-      "effects_carried": [ "AEP_ATTENTION" ],
       "effects_wielded": [
         "AEP_STR_UP",
         "AEP_DEX_UP",
         "AEP_SPEED_UP",
         "AEP_ALL_DOWN",
         "AEP_SICK",
-        "AEP_EVIL",
+        "AEP_SCHIZO",
         "AEP_SAP_LIFE",
-        "AEP_MUTAGENIC",
-        "AEP_SCHIZO"
+        "AEP_THIRST",
+        "AEP_HUNGER",
+        "AEP_EVIL",
+        "AEP_MUTAGENIC"
       ]
     }
   }


### PR DESCRIPTION
Well, I was gonna do this a while back but stuff came up, then I was planning to make this a "part zero" only porting over the essential file changes that future additions would use. Then however, as my list of "hey wait I can still change this without the bug coming into play" changes got longer, I realized that the active biological sword's fake AEA hack had already been removed some unknown time ago. This eliminated my main reason to deferring those changes: I didn't want to replace a working (if hacky) mechanic with a better one that won't trigger due to a bug. But with no AEA stuff being the norm already, I can put it in and make sure it'll automatically do what it's supposed to do when the bug is fixed.

* Added custom adrenaline effect for the biological weapons to make use of. While it has the advantage of also stopping bleeding, its effective duration is much shorter than its cooldown (int_dur_factor of 180 means positives start at 3 minutes duration, max_duration of 200 means you'll only get 20 seconds of actual adrenaline), requiring continued use to stave off the comedown effects.
* Implemented custom spell-like effects that the biological weapons will make use of. The outermost effect applies bleeding to a target (will be used by active version of the sword), while beneath that are effects that have a one-third chance of granting the custom adrenaline rush, for enough seconds to continue using it with repeated effort. The adrenaline effect is planned to be used on target-hit for the sword, and called when the player is hit for the biological guns.
* Shuffled around the AEP effects for biological knife and sword. General trend is for less severe effects when inactive (AEP_SICK when carried, AEP_SCHIZO and AEP_SAP_LIFE when wielded), and removed ability to call AEA effects from the inactive version of the sword. Also removed artifact use action from the biological knife, as it's not needed for an item with no AEAs.
* Active sword still retains its "+2 str and dex, -2 int and per, +20 speed" effect, along with gaining AEP_EVIL and AEP_MUTAGENIC, but now also gains AEP_THIRST and AEP_HUNGER.
* Nerfed the cutting damage of active biological sword, halving it to 50 (which is double that of the inactive version).
* Added the "needs to be wielded" property to the biological sword's transformation.
* Set it so that activating the sword uses its actual charge level, instead of automatically setting it to 10.
* Removed NON_STUCK flag since weapon sticking has been gone for a long time, and the flag is no longer used.
* Enabled sheathing the biological knife and (inactive) sword.
* Made sure traders won't want to try and buy the active biological sword, via TRADER_AVOID flag.
* Also gave the biological melee weapons MAGIC_FOCUS for flavor.
* Added weapon category to the converted melee CBMs and to the biological knife/sword, the latter fixing their counting as artifacts.
* Couple description updates and typofixes along the way.
* Set the active version of the sword to apply the spell features, on hitting the target. Hitting an enemy with it inflicts blood loss, while granting the custom adrenaline effect to the user. This is currently not functional due to a bug, but will be up and running as soon as the bug reposible is fixed in CDDA proper.
* Also removed tool qualities from the active version as built-in use actions don't play nice with weapons that rely on revert instead of transform.

The bug in question is that relic data in general does not change properly when an item transforms, unlike the older artifact AEPs, ARTC, AEA etc (issue link: https://github.com/CleverRaven/Cataclysm-DDA/issues/38409). Hence, active versions of the biological sword will trigger the on-hit effect if debug spawned in, but biological swords obtained naturally during play will only have the AEPs.

Due to realizing I'm re-adding a feature that has been gone for a while, not replacing an extant one with one that won't yet function, I feel better about getting it up and running in a feature-complete implementation now, and simply letting CDDA updates catch up accordingly.

Part two will cover the biological guns.