### PR TITLE
Failed Bio-Weapon Usage

### DIFF
--- a/Char_creation/c_classes_bw.json
+++ b/Char_creation/c_classes_bw.json
@@ -3,8 +3,8 @@
     "type": "profession",
     "ident": "failed_weapon",
     "name": "Failed Bio-Weapon",
-    "description": "From the moment you opened your eyes you knew you were a failure, a reject.  Destined to be something great but many a mistake took that away from you.  You awoke in a world of monsters, now you join them, brethren...",
-    "points": 2,
+    "description": "From the moment you opened your eyes you knew you were a failure, a reject.  Destined to be something great but many a mistake took that away from you.  You awoke in a world of monsters, but you're determined to prove you aren't one of them.",
+    "points": 4,
     "traits": [
       "PSYCHOPATH",
       "HUNGER",

--- a/Char_creation/c_scenarios.json
+++ b/Char_creation/c_scenarios.json
@@ -8,7 +8,7 @@
     "points": 0,
     "start_name": "Bio-Weapon Lab",
     "allowed_locs": [ "Bio_Weapon_Lab_l" ],
-    "professions": [ "bio_weapon_a", "bio_weapon_b", "bio_weapon_g", "bio_weapon_d" ],
+    "professions": [ "bio_weapon_a", "bio_weapon_b", "bio_weapon_g", "bio_weapon_d", "failed_weapon" ],
     "forbidden_traits": [
       "EASYSLEEPER",
       "NONADDICTIVE",
@@ -288,6 +288,18 @@
     "type": "scenario",
     "extend": { "allowed_locs": [ "surv_camp_l" ] },
     "ident": "wilderness"
+  },
+  {
+    "copy-from": "mutant",
+    "type": "scenario",
+    "ident": "mutant",
+    "extend": { "professions": [ "failed_weapon" ] }
+  },
+  {
+    "copy-from": "lab_chal",
+    "type": "scenario",
+    "ident": "lab_chal",
+    "extend": { "professions": [ "failed_weapon" ] }
   },
   {
     "copy-from": "lab_staff",


### PR DESCRIPTION
* Increased point cost of failed bio-weapon profession to 4.
* Added failed bio-weapons to Bio-Weapon Lab, Experiment, and Lab Patient scenarios. The latter two allow a degree more variation in traits since they aren't under the tightly-controlled conditions of the
Bio-Weapon Lab scenario.
* Slight tweak to failed bio-weapon's profession description.