### PR TITLE
Features/updates for bio-weapon characters

### DIFF
--- a/Monsters/c_monster_override.json
+++ b/Monsters/c_monster_override.json
@@ -1,0 +1,50 @@
+[
+  {
+    "id": "mon_secubot",
+    "copy-from": "mon_secubot",
+    "type": "MONSTER",
+    "species": [ "ROBOT_MILITARY" ]
+  },
+  {
+    "id": "mon_talon_m202a1",
+    "copy-from": "mon_talon_m202a1",
+    "type": "MONSTER",
+    "species": [ "ROBOT_MILITARY" ]
+  },
+  {
+    "id": "mon_dispatch_military",
+    "copy-from": "mon_dispatch_military",
+    "type": "MONSTER",
+    "species": [ "ROBOT_MILITARY" ]
+  },
+  {
+    "id": "mon_turret_searchlight",
+    "copy-from": "mon_turret_searchlight",
+    "type": "MONSTER",
+    "species": [ "ROBOT_MILITARY" ]
+  },
+  {
+    "id": "mon_laserturret",
+    "copy-from": "mon_laserturret",
+    "type": "MONSTER",
+    "species": [ "ROBOT_MILITARY" ]
+  },
+  {
+    "id": "mon_turret_bmg",
+    "copy-from": "mon_turret_bmg",
+    "type": "MONSTER",
+    "species": [ "ROBOT_MILITARY" ]
+  },
+  {
+    "id": "mon_turret_rifle",
+    "copy-from": "mon_turret_rifle",
+    "type": "MONSTER",
+    "species": [ "ROBOT_MILITARY" ]
+  },
+  {
+    "id": "mon_crows_m240",
+    "copy-from": "mon_crows_m240",
+    "type": "MONSTER",
+    "species": [ "ROBOT_MILITARY" ]
+  }
+]

--- a/Monsters/c_monsters.json
+++ b/Monsters/c_monsters.json
@@ -66,7 +66,7 @@
     "material": [ "flesh" ],
     "symbol": "B",
     "color": "red_cyan",
-    "aggression": 100,
+    "aggression": 5,
     "morale": 100,
     "melee_skill": 6,
     "melee_dice": 4,
@@ -86,6 +86,8 @@
     "harvest": "CBM_FAILED_BIO",
     "special_attacks": [ [ "SHOCKSTORM", 15 ], [ "PARROT", 80 ] ],
     "special_when_hit": [ "ZAPBACK", 75 ],
+    "anger_triggers": [ "FRIEND_DIED", "FRIEND_ATTACKED", "HURT", "STALK", "PLAYER_CLOSE" ],
+    "placate_triggers": [ "FIRE" ],
     "death_drops": "wild_bio_weapom_item",
     "death_function": [ "ACID", "NORMAL" ],
     "flags": [

--- a/Monsters/c_species.json
+++ b/Monsters/c_species.json
@@ -10,5 +10,12 @@
     "id": "FBIO-WEAPON",
     "anger_triggers": [  ],
     "fear_triggers": [  ]
+  },
+  {
+    "type": "SPECIES",
+    "id": "ROBOT_MILITARY",
+    "description": "a robot",
+    "footsteps": "mechanical whirring.",
+    "anger_triggers": [ "PLAYER_CLOSE", "HURT", "FRIEND_ATTACKED", "FRIEND_DIED" ]
   }
 ]

--- a/Mutations/c_bio_mutation.json
+++ b/Mutations/c_bio_mutation.json
@@ -7,7 +7,9 @@
     "description": "Your genome is unique to you, this is a DNA marker identifying you as Bio-Weapon Alpha.  It may prove useful one day.",
     "valid": false,
     "purifiable": false,
-    "profession": true
+    "profession": true,
+    "fat_to_max_hp": 1.0,
+    "dodge_modifier": 1
   },
   {
     "type": "mutation",
@@ -17,7 +19,9 @@
     "description": "Your genome is unique to you, this is a DNA marker identifying you as Bio-Weapon Beta.  It may prove useful one day.",
     "valid": false,
     "purifiable": false,
-    "profession": true
+    "profession": true,
+    "stamina_regen_modifier": 0.25,
+    "bleed_resist": 1
   },
   {
     "type": "mutation",
@@ -27,7 +31,9 @@
     "description": "Your genome is unique to you, this is a DNA marker identifying you as Bio-Weapon Gamma.  It may prove useful one day.",
     "valid": false,
     "purifiable": false,
-    "profession": true
+    "profession": true,
+    "craft_skill_bonus": [ [ "computer", 2 ], [ "electronics", 2 ], [ "firstaid", 2 ] ],
+    "anger_relations": [ [ "ROBOT", -95 ] ]
   },
   {
     "type": "mutation",
@@ -37,7 +43,10 @@
     "description": "Your genome is unique to you, this is a DNA marker identifying you as Bio-Weapon Delta.  It may prove useful one day.",
     "valid": false,
     "purifiable": false,
-    "profession": true
+    "profession": true,
+    "stealth_modifier": 15,
+    "noise_modifier": 0.85,
+    "scent_modifier": 0.85
   },
   {
     "type": "mutation",
@@ -57,7 +66,8 @@
     "description": "This DNA marker serves as a reminder of what you are - another failure in this world.  It identifies you as a Failed Bio-Weapon.",
     "valid": false,
     "purifiable": false,
-    "profession": true
+    "profession": true,
+    "anger_relations": [ [ "FBIO-WEAPON", -25 ] ]
   },
   {
     "type": "mutation",


### PR DESCRIPTION
* Updated augmented abominations to be on the very edge of hostility. Makes them still noticeably more hostile than undead augmented abominations, starting at Tracking instead of Ignoring.
* Added an anger_relations property to the failed bio-weapon profession. This gives them more leeway around augmented abominations due to being one of them, but the monster version will still rapidly figure out that the PC is a renegade and turn hostile accordingly.
* Added some unique benefits to each of the four main bio-weapon professions, defined in their genetic marker mutations. Alpha gains a benefit to max HP the more they keep their ravenous hunger at bay plus a minor impact on dodging, Beta gains a boost to stamina regeneration plus bleed resist to facilitate a sustained fight, Delta gains bonuses to the assorted stealth modifiers to encourage slipping past enemies, while Gamma gains a crafting skill bonus to certain technical skills, along with an aggression modifier that makes robotic creatures less likely to notice them (since most robots have 100 aggression, it takes a very high modifier to push them down to Tracking).
* Added a overrides for military robot species, defining anger triggers so that Gamma can't exploit this reduced hostility indefinitely. Eventually you'll piss them off. The use of a separate species was to prevent non-hostile robots like cleaner bots from rapidly turning hostile, and limit Gamma's bonus to robots that are explicitly military (i.e. the CROWS turrets/bots and the upgraded grenadier bot, but not police bots, cyborgs, or non-military labsec bots).