### PR TITLE
Makeshift thermal lance

### DIFF
--- a/Recipe/c_recipes.json
+++ b/Recipe/c_recipes.json
@@ -1897,5 +1897,37 @@
     "qualities": [ { "id": "CHEM", "level": 2 }, { "id": "PRESSURIZATION", "level": 1 } ],
     "tools": [ [ [ "electrolysis_kit", 1750 ] ] ],
     "components": [ [ [ "water_clean", 1 ], [ "water", 1 ] ] ]
+  },
+  {
+    "type": "recipe",
+    "result": "thermal_lance_makeshift",
+    "category": "CC_OTHER",
+    "subcategory": "CSC_OTHER_TOOLS",
+    "skill_used": "mechanics",
+    "skills_required": [ "fabrication", 3 ],
+    "difficulty": 3,
+    "time": "45 m",
+    "autolearn": [ [ "mechanics", 4 ], [ "fabrication", 4 ] ],
+    "book_learn": [ [ "manual_mechanics", 4 ], [ "textbook_mechanics", 3 ], [ "welding_book", 2 ] ],
+    "qualities": [ { "id": "SCREW", "level": 1 } ],
+    "tools": [ [ [ "smoxygen_tank", 12 ], [ "oxygen_tank", 12 ], [ "oxygen_cylinder", 100 ] ] ],
+    "components": [
+      [ [ "pipe", 1 ] ],
+      [ [ "hose", 1 ] ],
+      [ [ "canister_empty", 1 ] ],
+      [ [ "pilot_light", 1 ] ],
+      [ [ "magnesium", 50 ], [ "incendiary", 50 ] ]
+    ]
+  },
+  {
+    "result": "thermal_lance_makeshift",
+    "type": "uncraft",
+    "time": "2 m",
+    "qualities": [ { "id": "SCREW", "level": 1 } ],
+    "components": [
+      [ [ "canister_empty", 1 ] ],
+      [ [ "hose", 1 ] ],
+      [ [ "scrap", 1 ] ]
+    ]
   }
 ]

--- a/Surv_help/c_tools.json
+++ b/Surv_help/c_tools.json
@@ -928,9 +928,9 @@
     "material": [ "steel", "plastic" ],
     "symbol": ";",
     "color": "red",
-    "max_charges": 20,
-    "initial_charges": 20,
-    "charges_per_use": 5,
+    "max_charges": 30,
+    "initial_charges": 30,
+    "charges_per_use": 1,
     "use_action": "OXYTORCH",
     "qualities": [ [ "WELD", 1 ] ],
     "flags": [ "ALLOWS_REMOTE_USE" ]

--- a/Surv_help/c_tools.json
+++ b/Surv_help/c_tools.json
@@ -914,5 +914,25 @@
     "warmth": 20,
     "material_thickness": 2,
     "artifact_data": { "charge_type": "ARTC_TIME" }
+  },
+  {
+    "id": "thermal_lance_makeshift",
+    "type": "TOOL",
+    "name": "makeshift thermal lance",
+    "description": "An improvised welding tool that relies on the pyrophoric nature of steel, plus a supply of oxygen, to create a cutting tool hot enough to melt metal.  It can be used as an improvised and inefficient metalworking tool, or you can activate it to destroy metal barriers.",
+    "looks_like": "oxy_torch",
+    "sub": "oxy_torch",
+    "weight": "2000 g",
+    "volume": "1750 ml",
+    "price": 10000,
+    "material": [ "steel", "plastic" ],
+    "symbol": ";",
+    "color": "red",
+    "max_charges": 20,
+    "initial_charges": 20,
+    "charges_per_use": 5,
+    "use_action": "OXYTORCH",
+    "qualities": [ [ "WELD", 1 ] ],
+    "flags": [ "ALLOWS_REMOTE_USE" ]
   }
 ]


### PR DESCRIPTION
Fairly simple idea that came to mind, an improvised thermal lance. Seemed more fitting in Cata++ specifically. Principle relies on a metal tube connected to an oxygen supply. When provided with an initial source of sufficient heat (magnesium ignition in this case, IRL steel wool would work too but that doesn't exist in the game yet) the metal forming the lance itself provides a source of pyrophoric material to keep the reaction going.

Item has limited charges and can double as a makeshift welder (WELD quality 1), but obviously its primary focus is cutting metal terrain, as with oxy-ace torches in the game. Also provides an additional use for oxygen packs/tanks, of course. Overall use is about half that of a small welding tank (30 charges vs 60).