### PR TITLE
Minor mod-compatability: tool usage

### DIFF
--- a/Recipe/c_recipes.json
+++ b/Recipe/c_recipes.json
@@ -146,7 +146,16 @@
     "autolearn": true,
     "book_learn": [ [ "recipe_surv", 1 ] ],
     "charges": 10,
-    "tools": [ [ [ "surface_heat", 10, "LIST" ] ], [ [ "can_food_unsealed", -1 ], [ "can_drink_unsealed", -1 ] ] ],
+    "tools": [
+      [ [ "surface_heat", 10, "LIST" ] ],
+      [
+        [ "can_food_unsealed", -1 ],
+        [ "canister_empty", -1 ],
+        [ "tinderbox", -1 ],
+        [ "can_drink_unsealed", -1 ],
+        [ "clay_canister", -1 ]
+      ]
+    ],
     "components": [ [ [ "splinter", 2 ], [ "bone_human", 2 ], [ "bone_tainted", 2 ], [ "pine_bough", 10 ] ] ]
   },
   {

--- a/Surv_help/c_tools.json
+++ b/Surv_help/c_tools.json
@@ -435,7 +435,7 @@
   {
     "id": "solar_torch",
     "type": "TOOL",
-    "category": "tools",
+    "sub": "torch",
     "symbol": "/",
     "color": "brown",
     "name": { "str": "solar torch", "str_pl": "solar torches" },
@@ -463,7 +463,7 @@
   {
     "id": "solar_torch_lit",
     "type": "TOOL",
-    "category": "tools",
+    "sub": "torch_lit",
     "symbol": "/",
     "color": "brown",
     "name": { "str": "solar torch (lit)", "str_pl": "solar torches (lit)" },


### PR DESCRIPTION
* Allowed canisters, clay canisters, and ember carriers to be used for making small batches of charcoal. Goes along with a chance in MST Extra allowing clay ember carriers to substitute for clay canisters.
* Allowed solar torches to substitute for normal torches, goes along with an arcana recipe using lit torches.