### PR TITLE
Prevent Vehicle ID Conflict

### DIFF
--- a/Terrain/Survivor_Holdout.json
+++ b/Terrain/Survivor_Holdout.json
@@ -113,7 +113,7 @@
       ],
       "place_vehicles": [
         { "vehicle": "bicycle_dirt", "x": 5, "y": 5, "chance": 99, "status": -1, "rotation": 270 },
-        { "vehicle": "surv_rv", "x": 10, "y": 8, "chance": 99, "fuel": 1, "status": -3, "rotation": 270 }
+        { "vehicle": "c_surv_rv_military", "x": 10, "y": 8, "chance": 99, "fuel": 1, "status": -3, "rotation": 270 }
       ]
     }
   }

--- a/Terrain/mapgen_obsolete.json
+++ b/Terrain/mapgen_obsolete.json
@@ -524,7 +524,7 @@
       ],
       "place_vehicles": [
         { "vehicle": "surv_tractor", "x": 20, "y": 11, "chance": 99, "fuel": 10, "status": -1, "rotation": 270 },
-        { "vehicle": "surv_rv", "x": 3, "y": 5, "chance": 99, "fuel": 1, "status": -3, "rotation": 270 }
+        { "vehicle": "c_surv_rv_military", "x": 3, "y": 5, "chance": 99, "fuel": 1, "status": -3, "rotation": 270 }
       ]
     }
   },

--- a/Vehicles/c_vehicle_groups.json
+++ b/Vehicles/c_vehicle_groups.json
@@ -2,23 +2,23 @@
   {
     "id": "dirtlot",
     "type": "vehicle_group",
-    "vehicles": [ [ "surv_tractor", 5 ], [ "surv_rv", 5 ], [ "surv_tachanka", 5 ] ],
+    "vehicles": [ [ "surv_tractor", 5 ], [ "c_surv_rv_military", 5 ], [ "surv_tachanka", 5 ] ],
     "//": "Low since there are not many vehicles to pick from."
   },
   {
     "id": "city_vehicles",
     "type": "vehicle_group",
-    "vehicles": [ [ "surv_rv", 5 ] ]
+    "vehicles": [ [ "c_surv_rv_military", 5 ] ]
   },
   {
     "id": "parkinglot",
     "type": "vehicle_group",
-    "vehicles": [ [ "surv_rv", 5 ] ]
+    "vehicles": [ [ "c_surv_rv_military", 5 ] ]
   },
   {
     "id": "highway",
     "type": "vehicle_group",
-    "vehicles": [ [ "surv_rv", 5 ] ]
+    "vehicles": [ [ "c_surv_rv_military", 5 ] ]
   },
   {
     "id": "highway",

--- a/Vehicles/c_vehicles.json
+++ b/Vehicles/c_vehicles.json
@@ -1,8 +1,8 @@
 [
   {
-    "id": "surv_rv",
+    "id": "c_surv_rv_military",
     "type": "vehicle",
-    "name": "Survivor's RV",
+    "name": "Survivor's Militarized RV",
     "parts": [
       { "x": 1, "y": -1, "parts": [ "hdframe_nw", "reinforced_windshield", "omnicam", "plating_hard" ] },
       { "x": 1, "y": 0, "parts": [ "hdframe_horizontal", "reinforced_windshield", "storage_battery", "headlight_reinforced", "plating_hard" ] },


### PR DESCRIPTION
* Changed ID "surv_rv" to "c_surv_rv_military" due to https://github.com/CleverRaven/Cataclysm-DDA/pull/38927 using the same ID in their newer vehicle addition.
* Also renamed the Survivior's RV to "Survivor's Militarized RV" to ensue clarity.

Tested to ensure that this wouldn't break old saves.

The ID and name made me suspect it was copied from Cata++ at first, but with visual comparison it's easier to tell that the new vehicle is a direct edit of the vanilla luxury RV, whereas the older Cata++ RV has undergone more extensive changes over time:
![image](https://user-images.githubusercontent.com/11582235/77236414-39f25e00-6b8c-11ea-8e51-5e4f28cf0d72.png)