### PR TITLE
Update references to obsoleted anesthesia item

### DIFF
--- a/Surv_help/c_item_groups.json
+++ b/Surv_help/c_item_groups.json
@@ -434,7 +434,7 @@
       [ "omnitech_weapon_ups_manual", 2 ],
       [ "blood_m", 2 ],
       [ "blood_p", 2 ],
-      [ "anesthesia", 2 ],
+      [ "anesthetic_kit", 2 ],
       { "group": "ammo_atomic_batteries", "prob": 10 }
     ]
   },
@@ -530,7 +530,7 @@
   {
     "type": "item_group",
     "id": "ambulance_equipment",
-    "items": [ [ "anesthesia", 5 ] ]
+    "items": [ [ "anesthetic_kit", 5 ] ]
   },
   {
     "id": "sketchy_cabin_weapons",

--- a/Terrain/Bio_Weapon_Lab.json
+++ b/Terrain/Bio_Weapon_Lab.json
@@ -227,7 +227,7 @@
         { "item": "mccmap", "x": 12, "y": 12 },
         { "item": "laser_rifle", "x": 1, "y": 8 },
         { "item": "goggles_welding", "x": 1, "y": 9 },
-        { "item": "anesthesia", "x": [ 11, 12 ], "y": 22, "chance": 50, "repeat": 3 }
+        { "item": "anesthetic_kit", "x": [ 11, 12 ], "y": 22, "chance": 50, "repeat": 3 }
       ],
       "place_npcs": [ { "class": "bio_hunter", "x": 13, "y": 2 } ],
       "place_monster": [

--- a/Terrain/Unknown_Lab.json
+++ b/Terrain/Unknown_Lab.json
@@ -491,7 +491,7 @@
         { "group": "bionics_mil", "x": 20, "y": [ 3, 7 ], "chance": 75, "repeat": 5 },
         { "group": "bionics_sci", "x": 20, "y": [ 3, 7 ], "chance": 75, "repeat": 5 },
         { "item": "cbm_rtg_inductor", "x": 20, "y": [ 3, 7 ] },
-        { "item": "anesthesia", "x": [ 7, 8 ], "y": 4, "chance": 75, "repeat": 2 },
+        { "item": "anesthetic_kit", "x": [ 7, 8 ], "y": 4, "chance": 75, "repeat": 2 },
         { "group": "map_extra_military", "x": 8, "y": 11, "chance": 95 },
         { "group": "map_extra_military", "x": 12, "y": 9, "chance": 95 },
         { "group": "map_extra_military", "x": 4, "y": 12, "chance": 95 },

--- a/Terrain/mapgen_obsolete.json
+++ b/Terrain/mapgen_obsolete.json
@@ -204,7 +204,7 @@
         { "item": "mccmap", "x": 12, "y": 12 },
         { "item": "laser_rifle", "x": 12, "y": 11 },
         { "item": "goggles_welding", "x": 4, "y": 20, "repeat": 1 },
-        { "item": "anesthesia", "x": [ 11, 12 ], "y": 19, "chance": 50, "repeat": 3 }
+        { "item": "anesthetic_kit", "x": [ 11, 12 ], "y": 19, "chance": 50, "repeat": 3 }
       ],
       "place_npcs": [ { "class": "bio_hunter", "x": 5, "y": 21 } ],
       "place_vehicles": [
@@ -732,7 +732,7 @@
         { "item": "UPS_off", "x": 1, "y": 18 },
         { "item": "megamap", "x": 1, "y": 18 },
         { "item": "acs_74_stealth_cloak_off", "x": 1, "y": 18 },
-        { "item": "anesthesia", "x": 9, "y": 22, "chance": 50, "repeat": [ 1, 3 ] }
+        { "item": "anesthetic_kit", "x": 9, "y": 22, "chance": 50, "repeat": [ 1, 3 ] }
       ],
       "place_monster": [
         { "monster": "mon_failed_weapon", "x": 7, "y": 4 },


### PR DESCRIPTION
* Replaces all Cata++ spawns of now-removed `anesthesia` with the newer`anesthetic_kit`.

Closes https://github.com/Noctifer-de-Mortem/nocts_cata_mod/issues/182

Old saves that have existing instances of this item *might* still break because I'm not sure if they implemented migration entries.