### PR TITLE
Metal molding updates, and molded crowbars

### DIFF
--- a/Recipe/c_recipes.json
+++ b/Recipe/c_recipes.json
@@ -1,19 +1,19 @@
 [
   {
-    "result": "bearing",
     "type": "recipe",
+    "result": "bearing",
     "id_suffix": "alt_creation",
     "category": "CC_AMMO",
     "subcategory": "CSC_AMMO_OTHER",
     "skill_used": "fabrication",
+    "skills_required": [ "gun", 4 ],
     "difficulty": 3,
-    "time": "10 m",
+    "time": "30 m",
+    "batch_time_factors": [ 80, 4 ],
     "autolearn": true,
-    "book_learn": [ [ "recipe_surv", 2 ] ],
-    "//": "Doesn't use c_metal_molding_standard because metal and charcoal usage is non-standard.",
-    "qualities": [ { "id": "HAMMER", "level": 2 } ],
-    "tools": [ [ [ "can_forge", -1 ] ], [ [ "material_sand", -1 ], [ "clay_lump", -1 ] ], [ [ "bearing", -1 ], [ "marble", -1 ] ] ],
-    "components": [ [ [ "scrap", 1 ] ], [ [ "charcoal", 30 ], [ "charcoal", 30 ] ] ]
+    "book_learn": [ [ "textbook_fabrication", 2 ], [ "recipe_surv", 2 ] ],
+    "using": [ [ "c_metal_molding_standard", 1 ], [ "steel_tiny", 2 ], [ "forging_standard", 2 ] ],
+    "tools": [ [ [ "bearing", -1 ], [ "marble", -1 ] ] ]
   },
   {
     "result": "surcan",
@@ -71,10 +71,11 @@
     "skill_used": "fabrication",
     "difficulty": 4,
     "skills_required": [ [ "survival", 1 ] ],
-    "time": "20 m",
+    "time": "30 m",
+    "batch_time_factors": [ 80, 4 ],
     "autolearn": true,
     "book_learn": [ [ "recipe_surv", 3 ] ],
-    "using": [ [ "c_metal_molding_standard", 2 ] ],
+    "using": [ [ "c_metal_molding_standard", 1 ], [ "steel_standard", 2 ], [ "forging_standard", 8 ] ],
     "tools": [ [ [ "primitive_hammer", -1 ], [ "makeshift_hammer", -1 ] ] ]
   },
   {
@@ -88,7 +89,7 @@
     "time": "100 m",
     "autolearn": true,
     "book_learn": [ [ "recipe_surv", 5 ] ],
-    "using": [ [ "c_metal_molding_standard", 10 ] ],
+    "using": [ [ "c_metal_molding_standard", 1 ], [ "steel_standard", 10 ], [ "forging_standard", 40 ] ],
     "tools": [ [ [ "primitive_axe", -1 ], [ "copper_ax", -1 ] ] ]
   },
   {
@@ -99,10 +100,10 @@
     "skill_used": "fabrication",
     "difficulty": 4,
     "skills_required": [ [ "survival", 1 ] ],
-    "time": "10 m",
+    "time": "30 m",
     "autolearn": true,
     "book_learn": [ [ "recipe_surv", 3 ] ],
-    "using": [ [ "c_metal_molding_standard", 1 ] ],
+    "using": [ [ "c_metal_molding_standard", 1 ], [ "steel_standard", 1 ], [ "forging_standard", 4 ] ],
     "tools": [ [ [ "primitive_knife", -1 ], [ "makeshift_knife", -1 ], [ "copper_knife", -1 ] ] ]
   },
   {
@@ -116,7 +117,7 @@
     "time": "140 m",
     "autolearn": true,
     "book_learn": [ [ "recipe_surv", 3 ] ],
-    "using": [ [ "c_metal_molding_standard", 14 ] ],
+    "using": [ [ "c_metal_molding_standard", 14 ], [ "steel_standard", 14 ], [ "forging_standard", 56 ] ],
     "tools": [ [ [ "primitive_shovel", -1 ] ] ]
   },
   {
@@ -127,12 +128,12 @@
     "skill_used": "fabrication",
     "difficulty": 2,
     "skills_required": [ [ "survival", 1 ] ],
-    "time": "20 m",
+    "time": "30 m",
     "reversible": false,
     "autolearn": true,
     "book_learn": [ [ "recipe_surv", 1 ] ],
-    "using": [ [ "c_metal_molding_standard", 2 ] ],
-    "tools": [ [ [ "rock_pot", -1 ] ] ]
+    "using": [ [ "c_metal_molding_standard", 1 ], [ "steel_standard", 2 ], [ "forging_standard", 8 ] ],
+    "tools": [ [ [ "pot_makeshift", -1 ], [ "pot_makeshift_copper", -1 ] ] ]
   },
   {
     "result": "charcoal",
@@ -2039,5 +2040,65 @@
     ],
     "tools": [ [ [ "small_repairkit", 50 ], [ "large_repairkit", 50 ] ], [ [ "45_casing", -1 ] ] ],
     "components": [ [ [ "m1911", 1 ], [ "m1911_MEU", 1 ], [ "usp_45", 1 ], [ "mk23", 1 ] ], [ [ "plastic_chunk", 1 ] ] ]
+  },
+  {
+    "type": "recipe",
+    "result": "rebar",
+    "id_suffix": "alt_creation",
+    "category": "CC_OTHER",
+    "subcategory": "CSC_OTHER_MATERIALS",
+    "skill_used": "fabrication",
+    "difficulty": 3,
+    "time": "30 m",
+    "batch_time_factors": [ 80, 4 ],
+    "autolearn": true,
+    "book_learn": [ [ "textbook_fabrication", 2 ], [ "recipe_surv", 2 ] ],
+    "using": [ [ "c_metal_molding_standard", 1 ], [ "steel_tiny", 1 ], [ "forging_standard", 4 ] ],
+    "tools": [ [ [ "rebar", -1 ], [ "pipe", -1 ] ] ]
+  },
+  {
+    "type": "recipe",
+    "result": "nail",
+    "id_suffix": "alt_creation",
+    "category": "CC_OTHER",
+    "subcategory": "CSC_OTHER_MATERIALS",
+    "skill_used": "fabrication",
+    "difficulty": 2,
+    "time": "30 m",
+    "batch_time_factors": [ 80, 4 ],
+    "autolearn": true,
+    "book_learn": [ [ "textbook_fabrication", 1 ], [ "recipe_surv", 1 ] ],
+    "using": [ [ "c_metal_molding_standard", 1 ], [ "steel_tiny", 1 ], [ "forging_standard", 4 ] ],
+    "tools": [ [ [ "nail", -1 ] ] ]
+  },
+  {
+    "type": "recipe",
+    "result": "blade",
+    "id_suffix": "alt_creation",
+    "category": "CC_OTHER",
+    "subcategory": "CSC_OTHER_TOOLS",
+    "skill_used": "fabrication",
+    "difficulty": 3,
+    "time": "30 h",
+    "autolearn": true,
+    "book_learn": [ [ "textbook_fabrication", 1 ], [ "recipe_surv", 1 ] ],
+    "using": [ [ "c_metal_molding_standard", 1 ], [ "steel_tiny", 1 ], [ "forging_standard", 4 ] ],
+    "qualities": [
+      { "id": "CUT", "level": 1 }
+    ]
+  },
+  {
+    "type": "recipe",
+    "result": "molded_crowbar",
+    "category": "CC_OTHER",
+    "subcategory": "CSC_OTHER_MATERIALS",
+    "skill_used": "fabrication",
+    "difficulty": 4,
+    "time": "120 m",
+    "batch_time_factors": [ 80, 4 ],
+    "autolearn": true,
+    "book_learn": [ [ "textbook_fabrication", 1 ], [ "recipe_surv", 1 ] ],
+    "using": [ [ "c_metal_molding_standard", 1 ], [ "steel_standard", 12 ], [ "forging_standard", 48 ] ],
+    "tools": [ [ [ "makeshift_crowbar", -1 ] ] ]
   }
 ]

--- a/Recipe/c_requirements.json
+++ b/Recipe/c_requirements.json
@@ -2,19 +2,14 @@
   {
     "id": "c_metal_molding_standard",
     "type": "requirement",
-    "//": "Tools and componants for casting molded items, per 1 volume of item.",
+    "//": "Tools for casting molded items.",
     "qualities": [ { "id": "HAMMER", "level": 2 } ],
     "tools": [
-      [ [ "can_forge", -1 ] ],
       [
         [ "material_sand", -1 ],
         [ "clay_lump", -1 ],
         [ "press", -1 ]
       ]
-    ],
-    "components": [
-      [ [ "steel_standard", 1, "LIST" ] ],
-      [ [ "charcoal", 40 ], [ "charcoal", 40 ] ]
     ]
   }
 ]

--- a/Surv_help/c_tools.json
+++ b/Surv_help/c_tools.json
@@ -259,16 +259,14 @@
     "symbol": ";",
     "color": "light_gray",
     "name": { "str": "molded hammer" },
-    "//": "Only gets the nail-pulling use action because the stone hammer, for some bizarre reason, has it too.",
     "description": "This is a hammer molded from cast iron.  While a bit brittle if extensively used for combat, it holds up well enough to serve as a tool, though lacks enough of a claw to pry with.",
     "price": 500,
     "material": [ "steel" ],
     "weight": "1600 g",
     "volume": "500 ml",
     "bashing": 12,
-    "use_action": "HAMMER",
-    "qualities": [ [ "HAMMER", 3 ], [ "HAMMER_FINE", 1 ] ],
-    "flags": [ "FRAGILE_MELEE" ]
+    "qualities": [ [ "HAMMER", 3 ] ],
+    "flags": [ "FRAGILE_MELEE", "BELT_CLIP" ]
   },
   {
     "id": "molded_knife",
@@ -340,7 +338,7 @@
     "bashing": 24,
     "cutting": 10,
     "qualities": [ [ "AXE", 2 ], [ "BUTCHER", -36 ] ],
-    "flags": [ "FRAGILE_MELEE" ]
+    "flags": [ "FRAGILE_MELEE", "SHEATH_AXE" ]
   },
   {
     "id": "solar_crude_firestarter",
@@ -576,7 +574,7 @@
     "description": "A multi-tool combing a small hammer and pair of pliers.  Small and practical, the survivor's mini-tool-kit.",
     "price": 5000,
     "material": [ "steel", "wood" ],
-    "flags": [ "STAB", "SHEATH_KNIFE" ],
+    "flags": [ "STAB", "BELT_CLIP" ],
     "weight": "820 g",
     "volume": "500 ml",
     "bashing": 8,
@@ -909,5 +907,25 @@
     "use_action": "OXYTORCH",
     "qualities": [ [ "WELD", 1 ] ],
     "flags": [ "ALLOWS_REMOTE_USE" ]
+  },
+  {
+    "id": "molded_crowbar",
+    "looks_like": "crowbar",
+    "type": "TOOL",
+    "name": { "str": "molded crowbar" },
+    "description": "This is a hefty prying tool, molded from cast iron.  A bit brittle and heavy to be extensively used as a weapon, but adequate for prying open locked doors.  Not exactly ideal, but it's an improvement over makeshift tools.",
+    "weight": "1250 g",
+    "volume": "1 L",
+    "price": 1300,
+    "to_hit": 1,
+    "bashing": 14,
+    "cutting": 1,
+    "material": "steel",
+    "symbol": ";",
+    "color": "dark_gray",
+    "qualities": [ [ "PRY", 2 ], [ "HAMMER", 1 ] ],
+    "use_action": [ "HAMMER", "CROWBAR" ],
+    "techniques": [ "WBLOCK_1" ],
+    "flags": [ "BELT_CLIP", "FRAGILE_MELEE" ]
   }
 ]


### PR DESCRIPTION
* Updated use of metal molding requirement to only specify the mold items and hammering quality, allowing the use of steel_standard or steel_tiny as needed. And crafting mechanics mean that max charges in the can forge no longer actually blocks crafting, it merely requires a
couple reloads.
* Reworked bearing recipe with the latest update to bearing crafting in mind.
* Reworked time for a few molding recipes. Basically the gist is 30 minutes or 10 minutes per lump of steel used, whichever is higher (the latter seems to be how time was already determined, just the former adds a minimum time). In exchange, batch time savings are now implemented.
* Added metal-molding recipes for rebar, nails, and blades. Blade recipe is the odd one out, needing cutting quality instead of specific items as the mold source, as it was hard to decide what exact item to base the mold off of. Whereas bearings, rebar, and nails are all "have one, need more" scenarios, blades are in the same boat as the molded tools, in that if you have one already than there is no need for the recipe, which is a bit of a problem for blade items normally (case in point, can opt to break down a serviceable machete or a *broadsword*, for something you usually only need if you're so hard up for weapons that you'd be willing to make a makeshift machete).
* Also added a molded crowbar, that lets you gain the quality needed to actually handle doors using a makeshift crowbar as the tool needed by the mold.
* Finally, belatedly reworked the molded hammer since they eventually removed prying ability from the hammers you use as a mold source.
* Added SHEATH_AXE to molded axe, replaced SHEATH_KNIFE with BELT_CLIP for molded hammer.