### PR TITLE
Alter how Gamma's perk is defined

### DIFF
--- a/Monsters/c_monster_override.json
+++ b/Monsters/c_monster_override.json
@@ -3,48 +3,56 @@
     "id": "mon_secubot",
     "copy-from": "mon_secubot",
     "type": "MONSTER",
-    "species": [ "ROBOT_MILITARY" ]
+    "aggression": 50,
+    "anger_triggers": [ "PLAYER_CLOSE", "HURT", "FRIEND_ATTACKED", "FRIEND_DIED" ]
   },
   {
     "id": "mon_talon_m202a1",
     "copy-from": "mon_talon_m202a1",
     "type": "MONSTER",
-    "species": [ "ROBOT_MILITARY" ]
+    "aggression": 50,
+    "anger_triggers": [ "PLAYER_CLOSE", "HURT", "FRIEND_ATTACKED", "FRIEND_DIED" ]
   },
   {
     "id": "mon_dispatch_military",
     "copy-from": "mon_dispatch_military",
     "type": "MONSTER",
-    "species": [ "ROBOT_MILITARY" ]
+    "aggression": 50,
+    "anger_triggers": [ "PLAYER_CLOSE", "HURT", "FRIEND_ATTACKED", "FRIEND_DIED" ]
   },
   {
     "id": "mon_turret_searchlight",
     "copy-from": "mon_turret_searchlight",
     "type": "MONSTER",
-    "species": [ "ROBOT_MILITARY" ]
+    "aggression": 50,
+    "anger_triggers": [ "PLAYER_CLOSE", "HURT", "FRIEND_ATTACKED", "FRIEND_DIED" ]
   },
   {
     "id": "mon_laserturret",
     "copy-from": "mon_laserturret",
     "type": "MONSTER",
-    "species": [ "ROBOT_MILITARY" ]
+    "aggression": 50,
+    "anger_triggers": [ "PLAYER_CLOSE", "HURT", "FRIEND_ATTACKED", "FRIEND_DIED" ]
   },
   {
     "id": "mon_turret_bmg",
     "copy-from": "mon_turret_bmg",
     "type": "MONSTER",
-    "species": [ "ROBOT_MILITARY" ]
+    "aggression": 50,
+    "anger_triggers": [ "PLAYER_CLOSE", "HURT", "FRIEND_ATTACKED", "FRIEND_DIED" ]
   },
   {
     "id": "mon_turret_rifle",
     "copy-from": "mon_turret_rifle",
     "type": "MONSTER",
-    "species": [ "ROBOT_MILITARY" ]
+    "aggression": 50,
+    "anger_triggers": [ "PLAYER_CLOSE", "HURT", "FRIEND_ATTACKED", "FRIEND_DIED" ]
   },
   {
     "id": "mon_crows_m240",
     "copy-from": "mon_crows_m240",
     "type": "MONSTER",
-    "species": [ "ROBOT_MILITARY" ]
+    "aggression": 50,
+    "anger_triggers": [ "PLAYER_CLOSE", "HURT", "FRIEND_ATTACKED", "FRIEND_DIED" ]
   }
 ]

--- a/Monsters/c_species.json
+++ b/Monsters/c_species.json
@@ -10,12 +10,5 @@
     "id": "FBIO-WEAPON",
     "anger_triggers": [  ],
     "fear_triggers": [  ]
-  },
-  {
-    "type": "SPECIES",
-    "id": "ROBOT_MILITARY",
-    "description": "a robot",
-    "footsteps": "mechanical whirring.",
-    "anger_triggers": [ "PLAYER_CLOSE", "HURT", "FRIEND_ATTACKED", "FRIEND_DIED" ]
   }
 ]

--- a/Mutations/c_bio_mutation.json
+++ b/Mutations/c_bio_mutation.json
@@ -33,7 +33,7 @@
     "purifiable": false,
     "profession": true,
     "craft_skill_bonus": [ [ "computer", 2 ], [ "electronics", 2 ], [ "firstaid", 2 ] ],
-    "anger_relations": [ [ "ROBOT", -95 ] ]
+    "anger_relations": [ [ "ROBOT", -45 ] ]
   },
   {
     "type": "mutation",


### PR DESCRIPTION
* Shift anger triggers from species to the individual monster overrides, making the species overrides no longer needed.
* Added aggression overrides to those military robots, enough to still be exceedingly hostile to anything that lacks the Bio-Weapon Gamma trait.
* Reduced Gamma's anger-relation reduction so that only those altered military robots will be affected by it enough to go down to Tracking.

Closes https://github.com/Noctifer-de-Mortem/nocts_cata_mod/issues/188