### PR TITLE
Copy over obsoleted monster/item stuff

### DIFF
--- a/Monsters/c_monster_override.json
+++ b/Monsters/c_monster_override.json
@@ -29,9 +29,41 @@
   },
   {
     "id": "mon_laserturret",
-    "copy-from": "mon_laserturret",
+    "//": "Full override retained because this monster was obsoleted, and there's no guarantee that the monster will stay in the JSON or even remain functional long-term.",
     "type": "MONSTER",
+    "name": { "str": "laser turret" },
+    "description": "The TX-5LR Cerberus is an upgrade to its predecessors.  It features a state of the art revolving laser cannon system with three barrels that charge from solar cells embedded in its hull.",
+    "default_faction": "military",
+    "species": [ "ROBOT" ],
+    "diff": 20,
+    "volume": "30000 ml",
+    "weight": "40750 g",
+    "hp": 30,
+    "speed": 100,
+    "material": [ "steel" ],
+    "symbol": "2",
+    "color": "white",
     "aggression": 50,
+    "morale": 100,
+    "armor_bash": 14,
+    "armor_cut": 16,
+    "armor_bullet": 13,
+    "vision_day": 50,
+    "revert_to_itype": "bot_laserturret",
+    "special_attacks": [
+      {
+        "type": "gun",
+        "cooldown": 1,
+        "gun_type": "laser_cannon",
+        "fake_skills": [ [ "gun", 4 ], [ "rifle", 8 ] ],
+        "ranges": [ [ 0, 30, "DEFAULT" ] ],
+        "require_sunlight": true
+      }
+    ],
+    "special_when_hit": [ "RETURN_FIRE", 100 ],
+    "death_drops": {  },
+    "death_function": [ "BROKEN" ],
+    "flags": [ "SEES", "NOHEAD", "ELECTRONIC", "COLDPROOF", "IMMOBILE", "NO_BREATHE" ],
     "anger_triggers": [ "PLAYER_CLOSE", "HURT", "FRIEND_ATTACKED", "FRIEND_DIED" ]
   },
   {

--- a/Recipe/c_recipes.json
+++ b/Recipe/c_recipes.json
@@ -2118,6 +2118,29 @@
     "qualities": [ { "id": "CUT", "level": 1 } ]
   },
   {
+    "result": "broken_laserturret",
+    "type": "uncraft",
+    "obsolete": false,
+    "skill_used": "electronics",
+    "difficulty": 4,
+    "time": "1 h",
+    "using": [ [ "soldering_standard", 10 ] ],
+    "qualities": [ { "id": "SCREW", "level": 1 } ],
+    "components": [
+      [ [ "ai_module", 1 ] ],
+      [ [ "gun_module", 1 ] ],
+      [ [ "targeting_module", 1 ] ],
+      [ [ "identification_module", 1 ] ],
+      [ [ "sensor_module", 1 ] ],
+      [ [ "laser_cannon", 1 ] ],
+      [ [ "medium_storage_battery", 1 ] ],
+      [ [ "solar_cell", 4 ] ],
+      [ [ "power_supply", 1 ] ],
+      [ [ "robot_controls", 1 ] ],
+      [ [ "turret_chassis", 1 ] ]
+    ]
+  },
+  {
     "type": "recipe",
     "result": "molded_crowbar",
     "category": "CC_OTHER",

--- a/Surv_help/c_override.json
+++ b/Surv_help/c_override.json
@@ -105,5 +105,38 @@
     "capacity": 24,
     "looks_like": "oxygen_tank",
     "flags": [ "NO_UNLOAD" ]
+  },
+  {
+    "id": "bot_laserturret",
+    "//": "A full override for this and broken_laserturret is retained due to these items being obsolete, with no guarantee that they won't simply be removed in the future.",
+    "type": "TOOL",
+    "name": { "str": "inactive laser turret" },
+    "description": "This is an inactive laser turret.  Using this item involves turning it on and placing it on the ground, where it will attach itself.  If reprogrammed and rewired successfully the turret will identify you as a friendly, and attack all enemies with its revolving laser cannons.  It requires sunlight in order to fire.",
+    "weight": "40750 g",
+    "volume": "30 L",
+    "price": 600000,
+    "price_postapoc": 12000,
+    "to_hit": -3,
+    "bashing": 8,
+    "material": [ "steel", "plastic" ],
+    "symbol": ";",
+    "color": "white",
+    "use_action": {
+      "type": "place_monster",
+      "monster_id": "mon_laserturret",
+      "difficulty": 6,
+      "moves": 100,
+      "skill1": "electronics",
+      "skill2": "computer"
+    }
+  },
+  {
+    "type": "GENERIC",
+    "id": "broken_laserturret",
+    "symbol": ",",
+    "color": "green",
+    "name": { "str": "broken laser turret" },
+    "weight": "110 kg",
+    "copy-from": "broken_turret"
   }
 ]


### PR DESCRIPTION
Cause is https://github.com/CleverRaven/Cataclysm-DDA/pull/40695. I figured it was either this or replace all spawns of laser turrets with searchlights, but eh.

* Updated the override for laser turrets into a full copy of the monster for futureproofing reasons.
* Copied over the item definitions for the obsolete item forms as well.
* Copied over the obsoleted recipe and forcibly un-obsolete it.

Yeesh, they even stripped out part of the code so that it won't work exactly the way it used to if Aftershock tried to reclaim laser turrets...