### PR TITLE
Updates for blood overhaul

### DIFF
--- a/Monsters/c_monsters.json
+++ b/Monsters/c_monsters.json
@@ -355,7 +355,7 @@
       [ "LUNGE", 20 ]
     ],
     "death_drops": "mon_zombie_bio_knife_death_drops",
-    "flags": [ "SEES", "HEARS", "SMELLS", "POISON", "NO_BREATHE", "FILTHY", "PATH_AVOID_DANGER_1", "BLEED" ],
+    "flags": [ "SEES", "HEARS", "SMELLS", "POISON", "NO_BREATHE", "FILTHY", "PATH_AVOID_DANGER_1" ],
     "delete": { "upgrades": { "half_life": 28, "into": "mon_zombie_bio_knife" } }
   },
   {


### PR DESCRIPTION
* Removed obsolete `BLEED` flag from the only monster that used it, now that bleeding is based on raw cut/stab/bullet damage automatically.

Some minor thoughts for later:
1. Could give some effect-based removal of hypovolemia to the adrenaline surge caused by the active biological sword, but transformaing relics are still broken, plus I don't think it'll actually affect the vitamin-based blood loss so it would only prevent you from feeling the effects of shock for as long as the adrenaline surge holds out, which is a VERY brief period of time.
2. Could give IFAKs to the super soldiers?
3. Could give vitamin rate tweaks to Alpha and/or Beta that make them recover blood volume and red blood cells faster, but not sure which should get it. Alpha gets a lot of metabolism-based features that make them a meaty sorta tank, while Beta gets more staying-power sorts of hard-tank features.