### PR TITLE
Update damagetype again

### DIFF
--- a/Surv_help/c_spells.json
+++ b/Surv_help/c_spells.json
@@ -138,7 +138,7 @@
     "effect": "target_attack",
     "min_damage": 10,
     "max_damage": 10,
-    "damage_type": "true"
+    "damage_type": "pure"
   },
   {
     "id": "c_defusion",


### PR DESCRIPTION
Changes use of `true` damage type to `pure` in a spell, due to yet more changes to DT IDs.