### PR TITLE
Assorted fixes found while preparing thr BN version

### DIFF
--- a/Monsters/c_monstergroups.json
+++ b/Monsters/c_monstergroups.json
@@ -67,8 +67,8 @@
     "override": false,
     "auto_total": true,
     "monsters": [
-      { "monster": "mon_zombie_bio_dormant_unarmed", "freq": 20, "cost_multiplier": 15, "starts": 168 },
-      { "monster": "mon_zombie_bio_dormant_armed", "freq": 20, "cost_multiplier": 15, "starts": 168 }
+      { "monster": "mon_zombie_bio_dormant_unarmed", "freq": 20, "cost_multiplier": 15, "starts": 72 },
+      { "monster": "mon_zombie_bio_dormant_armed", "freq": 20, "cost_multiplier": 15, "starts": 72 }
     ]
   },
   {
@@ -97,8 +97,8 @@
     "override": false,
     "auto_total": true,
     "monsters": [
-      { "monster": "mon_zombie_bio_dormant_unarmed", "freq": 15, "cost_multiplier": 15, "starts": 336 },
-      { "monster": "mon_zombie_bio_dormant_armed", "freq": 15, "cost_multiplier": 15, "starts": 336 }
+      { "monster": "mon_zombie_bio_dormant_unarmed", "freq": 15, "cost_multiplier": 15, "starts": 72 },
+      { "monster": "mon_zombie_bio_dormant_armed", "freq": 15, "cost_multiplier": 15, "starts": 72 }
     ]
   },
   {
@@ -147,8 +147,8 @@
     "override": false,
     "auto_total": true,
     "monsters": [
-      { "monster": "mon_zombie_bio_dormant_unarmed", "freq": 25, "cost_multiplier": 15, "starts": 336 },
-      { "monster": "mon_zombie_bio_dormant_armed", "freq": 25, "cost_multiplier": 15, "starts": 336 }
+      { "monster": "mon_zombie_bio_dormant_unarmed", "freq": 25, "cost_multiplier": 15 },
+      { "monster": "mon_zombie_bio_dormant_armed", "freq": 25, "cost_multiplier": 15 }
     ]
   },
   {

--- a/Surv_help/c_armor.json
+++ b/Surv_help/c_armor.json
@@ -233,6 +233,7 @@
   },
   {
     "id": "c_stealth_cloak",
+    "//": "This is obsolete and only retained here for the benefit of old saves, delete this once 0.F comes out.",
     "type": "enchantment",
     "has": "WORN",
     "condition": "ALWAYS",
@@ -262,7 +263,20 @@
     "warmth": 15,
     "material_thickness": 1,
     "environmental_protection": 4,
-    "relic_data": { "passive_effects": [ { "id": "c_stealth_cloak" } ] },
+    "relic_data": {
+      "passive_effects": [
+        {
+          "has": "WORN",
+          "condition": "ALWAYS",
+          "values": [
+            { "value": "SPEED", "add": -20 },
+            { "value": "STRENGTH", "add": -4 },
+            { "value": "DEXTERITY", "add": -4 }
+          ],
+          "ench_effects": [ { "effect": "invisibility", "intensity": 1 } ]
+        }
+      ]
+    },
     "flags": [ "OVERSIZE", "HOOD", "WATERPROOF", "OUTER", "VARSIZE" ]
   },
   {

--- a/Surv_help/c_effects.json
+++ b/Surv_help/c_effects.json
@@ -43,9 +43,9 @@
     "apply_message": "You feel your muscles tensing up with a surge of abnormal energy!",
     "remove_message": "The tension in your body finally fades back to some degree of normalcy.",
     "decay_messages": [ [ "The pain in your muscles goes back to just a dull tension.", "good" ] ],
-    "max_duration": "2 h",
+    "max_duration": "3 h",
     "max_intensity": 2,
-    "int_dur_factor": "61 m",
+    "int_dur_factor": "121 m",
     "base_mods": {
       "speed_mod": [ 10 ],
       "str_mod": [ 1 ],

--- a/Surv_help/c_martialarts.json
+++ b/Surv_help/c_martialarts.json
@@ -124,14 +124,14 @@
     "copy-from": "style_fencing",
     "type": "martial_art",
     "name": "Fencing",
-    "extend": { "weapons": [ "unbio_sword_weapon", "flesh_blade", "flesh_blade_on" ] }
+    "extend": { "weapons": [ "unbio_sword_weapon", "flesh_blade" ] }
   },
   {
     "id": "style_swordsmanship",
     "copy-from": "style_swordsmanship",
     "type": "martial_art",
     "name": "Medieval Swordsmanship",
-    "extend": { "weapons": [ "unbio_sword_weapon", "flesh_blade", "flesh_blade_on" ] }
+    "extend": { "weapons": [ "unbio_sword_weapon", "flesh_blade" ] }
   },
   {
     "id": "style_ninjutsu",
@@ -146,8 +146,7 @@
         "unbio_bladed_weapon",
         "unbio_sword_weapon",
         "flesh_knife",
-        "flesh_blade",
-        "flesh_blade_on"
+        "flesh_blade"
       ]
     }
   },

--- a/Surv_help/c_spells.json
+++ b/Surv_help/c_spells.json
@@ -101,8 +101,8 @@
     "message": "",
     "valid_targets": [ "self" ],
     "flags": [ "SILENT" ],
-    "min_duration": 360000,
-    "max_duration": 360000,
+    "min_duration": 720000,
+    "max_duration": 720000,
     "effect": "attack",
     "shape": "blast",
     "effect_str": "biostim_side_effects"

--- a/Surv_help/c_tools.json
+++ b/Surv_help/c_tools.json
@@ -1,6 +1,5 @@
 [
   {
-    "//": "The items in this file have been archived for later revival.  Right now they're obsolete as the properties that made them work are in flux for the immediate future, but will eventually be re-added.",
     "id": "solar_flashlight",
     "type": "TOOL",
     "category": "tools",
@@ -615,7 +614,7 @@
     "symbol": ";",
     "color": "green",
     "name": { "str": "scout's tool" },
-    "description": "This is a bulky electronic wrist mounted tool, designed to provide an accurate topographical map of your surroundings when used.  It also comes with digital clock and alarm features.  Requires a fairly powerful battery to sustain its suite of scanning equipment.",
+    "description": "This is a bulky electronic wrist mounted tool, designed to provide an accurate topographical map of your surroundings when used.  It also comes with digital clock and alarm features.  The battery is integral to the device, and requires sunlight or a recharging station to charge.",
     "price": 5000,
     "material": [ "steel" ],
     "weight": "230 g",
@@ -625,16 +624,8 @@
     "ammo": "battery",
     "charges_per_use": 250,
     "use_action": { "type": "cast_spell", "spell_id": "c_topographical_scan", "no_fail": true, "level": 0 },
-    "pocket_data": [
-      {
-        "pocket_type": "MAGAZINE_WELL",
-        "holster": true,
-        "rigid": true,
-        "max_contains_volume": "20 L",
-        "max_contains_weight": "20 kg",
-        "item_restriction": [ "medium_battery_cell", "medium_plus_battery_cell", "medium_atomic_battery_cell", "medium_disposable_cell" ]
-      }
-    ],
+    "relic_data": { "charge_info": { "recharge_type": "solar_sunny", "time": "10 m", "regenerate_ammo": true } },
+    "pocket_data": [ { "pocket_type": "MAGAZINE", "ammo_restriction": { "battery": 250 } } ],
     "flags": [ "WATCH", "ALARMCLOCK", "RECHARGE" ],
     "encumbrance": 1,
     "coverage": 1,
@@ -647,7 +638,7 @@
     "symbol": ">",
     "color": "red",
     "name": { "str": "bioinjector" },
-    "description": "An odd, organic-looking auto-injector that slowly secretes some sort of red, blood-like substance.  From what you can understand from the label, it's an experimental stimulant that stabilizes minor wounds and increases performance at the cost of inflicting pain.  The label additionally warns against using it more than once an hour.",
+    "description": "An odd, organic-looking auto-injector that slowly secretes some sort of red, blood-like substance.  From what you can understand from the label, it's an experimental stimulant that stabilizes minor wounds and increases performance at the cost of inflicting pain.  The label additionally warns against using it more than once every two hours.",
     "price": 5000,
     "material": [ "plastic", "flesh" ],
     "weight": "150 g",
@@ -657,7 +648,7 @@
     "flags": [ "NO_RELOAD", "NO_UNLOAD" ],
     "ammo": [ "c_bioampoule_type" ],
     "charges_per_use": 1,
-    "relic_data": { "charge_info": { "recharge_type": "periodic", "time": "30 m", "regenerate_ammo": true } },
+    "relic_data": { "charge_info": { "recharge_type": "periodic", "time": "1 h", "regenerate_ammo": true } },
     "pocket_data": [ { "pocket_type": "MAGAZINE", "ammo_restriction": { "c_bioampoule_type": 1 } } ],
     "use_action": { "type": "cast_spell", "spell_id": "c_biostim", "no_fail": true, "level": 0 }
   },
@@ -678,7 +669,7 @@
     "flags": [ "NO_RELOAD", "NO_UNLOAD" ],
     "ammo": [ "c_bioampoule_type" ],
     "charges_per_use": 1,
-    "relic_data": { "charge_info": { "recharge_type": "periodic", "time": "30 m", "regenerate_ammo": true } },
+    "relic_data": { "charge_info": { "recharge_type": "periodic", "time": "1 h", "regenerate_ammo": true } },
     "pocket_data": [ { "pocket_type": "MAGAZINE", "ammo_restriction": { "c_bioampoule_type": 1 } } ],
     "use_action": { "type": "cast_spell", "spell_id": "c_infusion", "no_fail": true, "level": 0 }
   },
@@ -699,7 +690,7 @@
     "flags": [ "NO_RELOAD", "NO_UNLOAD" ],
     "ammo": [ "c_bioampoule_type" ],
     "charges_per_use": 1,
-    "relic_data": { "charge_info": { "recharge_type": "periodic", "time": "30 m", "regenerate_ammo": true } },
+    "relic_data": { "charge_info": { "recharge_type": "periodic", "time": "1 h", "regenerate_ammo": true } },
     "pocket_data": [ { "pocket_type": "MAGAZINE", "ammo_restriction": { "c_bioampoule_type": 1 } } ],
     "use_action": { "type": "cast_spell", "spell_id": "c_defusion", "no_fail": true, "level": 0 }
   },
@@ -882,7 +873,7 @@
     "description": "A prototype device giving off noticeable heat, housing a compact radioisotope thermoelectric generator.  It does not seem to accept batteries or even provide a UPS hookup, instead housing an inductive charging system designed specifically for CBM power storage.  Being an unfinished design, the only way to dump power into the inductor without electrocuting yourself requires opening up part of the mechanism, exposing you to radiation.",
     "price": 1200000,
     "material": [ "plastic", "aluminum" ],
-    "covers": [ "TORSO" ],
+    "covers": [ "torso" ],
     "flags": [ "LEAK_DAM", "RADIOACTIVE", "WAIST", "OVERSIZE", "NO_RELOAD", "NO_UNLOAD" ],
     "weight": "2200 g",
     "volume": "3 L",


### PR DESCRIPTION
During the process of making and testing a Bright Nights version of Cata++ (PR will be made after https://github.com/Noctifer-de-Mortem/nocts_cata_mod/pull/214 is merged), I found some misc fixes and changes that will apply to both versions, so PRing them now.

* Set some augmented undead soldier spawns to start earlier, since they now have unevolved forms. Regular city spawsn are still heavily delayed.
* Belatedly made the scout's tool solar-powered once more.
* Updated stealth cloak's relic data to not need an explicit enchantment. Can remove the old enchant when 0.F is out, for now best to retain it for old saves.
* Reduced recharge rate of biostim and the infusors to once per hour, for consistency with the eventual BN version.
* Rebalanced biostim effect duration stuff so the hour-long recharge time still allows you to attempt to overdose.
* Fixed RTG inductor having an old uppercase bodypart reference in the DDA version.
* Belatedly removed code comment saying the solar stuff is obsolete.
* Removed references in martial art overrides to an obsoleted item ID.