### PR TITLE
Fixes to legacy file

### DIFF
--- a/nocts_cata_mod_DDA/legacy.json
+++ b/nocts_cata_mod_DDA/legacy.json
@@ -122,25 +122,19 @@
     "id": "stealth_cloak_f",
     "copy-from": "acs_74_stealth_cloak_on",
     "type": "ARMOR",
-    "name": "obsolete stealth cloak"
+    "name": "stealth cloak"
   },
   {
     "id": "stealth_cloak",
     "copy-from": "acs_74_stealth_cloak_on",
     "type": "ARMOR",
-    "name": "obsolete stealth cloak (on)"
-  },
-  {
-    "id": "acs_74_stealth_cloak_off",
-    "copy-from": "acs_74_stealth_cloak_on",
-    "type": "ARMOR",
-    "name": "obsolete stealth cloak (on)"
+    "name": "stealth cloak (on)"
   },
   {
     "id": "flesh_blade_on",
     "copy-from": "flesh_blade",
     "type": "ARMOR",
-    "name": "obsolete biological sword (on)"
+    "name": "biological sword"
   },
   {
     "id": "can_forge_on",


### PR DESCRIPTION
Updated the file by removing the ACS 47 stealth cloak from the legacy file and updating names for some of the items as their existence is not a bug in older versions.