### PR TITLE
Fix load error

### DIFF
--- a/nocts_cata_mod_DDA/Terrain/Unknown_Lab.json
+++ b/nocts_cata_mod_DDA/Terrain/Unknown_Lab.json
@@ -488,7 +488,7 @@
         { "item": "omnitech_weapon_ups_manual", "x": 1, "y": 13 },
         { "item": "blood_m", "x": 14, "y": 15 },
         { "item": "blood_p", "x": 15, "y": 15 },
-        { "item": "acs_74_stealth_cloak_off", "x": 18, "y": 7 },
+        { "item": "acs_74_stealth_cloak_on", "x": 18, "y": 7 },
         { "item": "megamap", "x": 18, "y": 7 },
         { "group": "guns_milspec", "x": [ 0, 1 ], "y": 9, "chance": 50, "repeat": 3 },
         { "group": "chem_lab", "x": 18, "y": [ 12, 14 ], "chance": 75, "repeat": 9 },


### PR DESCRIPTION
Whoops, for some reason the DDA version (but not the BN version) was set to spawn the now-removed obsolete version of the cloak.

Easy enough to fix and test it.

Closes https://github.com/Noctifer-de-Mortem/nocts_cata_mod/issues/239