### PR TITLE
Damagetype and ident updates

### DIFF
--- a/nocts_cata_mod_BN/Char_creation/c_classes_bw.json
+++ b/nocts_cata_mod_BN/Char_creation/c_classes_bw.json
@@ -1,7 +1,7 @@
 [
   {
     "type": "profession",
-    "ident": "failed_weapon",
+    "id": "failed_weapon",
     "name": "Failed Bio-Weapon",
     "description": "From the moment you opened your eyes you knew you were a failure, a reject.  Destined to be something great but many a mistake took that away from you.  You awoke in a world of monsters, but you're determined to prove you aren't one of them.",
     "points": 4,
@@ -65,7 +65,7 @@
   },
   {
     "type": "profession",
-    "ident": "mycus_weapon",
+    "id": "mycus_weapon",
     "name": "Fungus Failed Bio-Weapon",
     "description": "Assimilation process is complete, incorporation and modification of biology and bionics into our system was successful.  Protection of our new domain and brethren is our current objective.  Inability to remove previous DNA marker is but a minor setback.",
     "points": 4,
@@ -134,7 +134,7 @@
   },
   {
     "type": "profession",
-    "ident": "bio_weapon_a",
+    "id": "bio_weapon_a",
     "name": "Bio-Weapon Alpha",
     "description": "'The Predator'.  You were the first, the Alpha.  Created to sow chaos behind enemy lines, driven by hunger.  You awoke into the unknown with an appetite - good thing the world is full of prey to devour!",
     "points": 8,
@@ -189,7 +189,7 @@
   },
   {
     "type": "profession",
-    "ident": "bio_weapon_d",
+    "id": "bio_weapon_d",
     "name": "Bio-Weapon Delta",
     "description": "'The Infiltrator', created to infiltrate, scout, spy and assassinate.  Capable of taking down enemies from afar, exploring enemy territory and integrating into the local populace.  You awoke to chaos, and you plan to eliminate whoever caused it.",
     "points": 8,
@@ -253,7 +253,7 @@
   },
   {
     "type": "profession",
-    "ident": "bio_weapon_b",
+    "id": "bio_weapon_b",
     "name": "Bio-Weapon Beta",
     "description": "'The Immortal', designed to be a one-man army.  Your body is a lethal weapon, finely tuned arms and defenses ready to destroy anything standing in your way.  You awoke to a horde of enemies, so now you take them all on.",
     "points": 8,
@@ -320,7 +320,7 @@
   },
   {
     "type": "profession",
-    "ident": "bio_weapon_g",
+    "id": "bio_weapon_g",
     "name": "Bio-Weapon Gamma",
     "description": "'The Mechanic', created to sabotage, destroy, assimilate or repair bio-technology.  You are a walking, adaptive repair machine.  You awoke to the sounds of machines fighting abominations.  You could help them, or destroy them, if they get in your way.",
     "points": 8,
@@ -359,7 +359,7 @@
   },
   {
     "type": "profession",
-    "ident": "bio_infantry",
+    "id": "bio_infantry",
     "name": "Super Soldier",
     "description": "The infantry of the Super Soldier project.  You are one of many augmented soldiers to be deployed into a battle field to ensure victory.  With range and melee capabilities, you engage enemies en masse.",
     "points": 12,
@@ -405,7 +405,7 @@
   },
   {
     "type": "profession",
-    "ident": "bio_scout",
+    "id": "bio_scout",
     "name": "Super Scout",
     "description": "The sniper of the Super Soldier project.  You are one of a few augmented soldiers to be used for reconnaissance and V.I.P assassinations.  With your weapons and skills, you can eliminate key targets after living for weeks in enemy territory.",
     "points": 12,
@@ -469,7 +469,7 @@
   },
   {
     "type": "profession",
-    "ident": "bio_tool",
+    "id": "bio_tool",
     "name": "Super Bio-engineer",
     "description": "Biological and mechanical repair unit, the combat engineer of the Super Soldier project.  You are one of many augmented military mechanics to be used as a repair module.  With repair, medical and general electronic capabilities, you can maybe fix the world.",
     "points": 12,
@@ -526,7 +526,7 @@
   },
   {
     "type": "profession",
-    "ident": "bio_knight",
+    "id": "bio_knight",
     "name": "Super Juggernaut",
     "description": "The tank of the Super Soldier project. You are one of a few augmented soldiers to be used as a heavy support to infantry. With ranged, armor and regenerative capabilities, you can endure heavy damage and return it in kind.",
     "points": 12,
@@ -577,7 +577,7 @@
   },
   {
     "type": "profession",
-    "ident": "sf_blade",
+    "id": "sf_blade",
     "name": "Slave Fighter (Blade)",
     "description": "You were augmented with a blade, and enhancements to your speed and reaction time. You can hit an opponent multiple times before they land a blow.",
     "points": 6,
@@ -604,7 +604,7 @@
   },
   {
     "type": "profession",
-    "ident": "sf_claw",
+    "id": "sf_claw",
     "name": "Slave Fighter (Claws)",
     "description": "You were augmented with some claws, and enhancements to your reflexes. You deliver a powerful strike that neutralizes foes in few hits.",
     "points": 6,
@@ -636,7 +636,7 @@
   },
   {
     "type": "profession",
-    "ident": "sf_shock",
+    "id": "sf_shock",
     "name": "Slave Fighter (Shocker)",
     "description": "You were augmented with electrical generators and protection from them. You hit multiple foes with electricity, frying them until their nervous system gives up.",
     "points": 6,
@@ -662,7 +662,7 @@
   },
   {
     "type": "profession",
-    "ident": "sf_weapon",
+    "id": "sf_weapon",
     "name": "Slave Fighter (Weapon Master)",
     "description": "You have been augmented with many 'passive' combat bionics, they merely aid you but are not weapons in and of themselves. You have been trained to use all sorts of different weapons, including your fists. You can pretty much weaponize a sock.",
     "points": 6,

--- a/nocts_cata_mod_BN/Char_creation/c_classes_r.json
+++ b/nocts_cata_mod_BN/Char_creation/c_classes_r.json
@@ -1,7 +1,7 @@
 [
   {
     "type": "profession",
-    "ident": "can_sur",
+    "id": "can_sur",
     "name": "Canned Survivor",
     "description": "You were a very busy person. That's why you bought a can of survival items and called it a day. Now it's the only thing you have.",
     "points": 1,
@@ -13,7 +13,7 @@
   },
   {
     "type": "profession",
-    "ident": "prepper",
+    "id": "prepper",
     "name": "Prepper",
     "description": "You were paranoid about the world ending so you jumped on the prepper bandwagon. You read a book on survival and got yourself a gun pack and some gear. The cataclysm was not what you expected.",
     "points": 5,

--- a/nocts_cata_mod_BN/Char_creation/c_scenarios.json
+++ b/nocts_cata_mod_BN/Char_creation/c_scenarios.json
@@ -4,7 +4,7 @@
     "name": "Bio-Weapon Lab",
     "description": "You woke up, where are you?  Who are you?  What are you?!  That doesn't matter right now... you have a bad feeling...",
     "flags": [ "LONE_START", "SUR_START", "SUM_START" ],
-    "ident": "bio_weapon_lab",
+    "id": "bio_weapon_lab",
     "points": 0,
     "start_name": "Bio-Weapon Lab",
     "allowed_locs": [ "Bio_Weapon_Lab_l" ],
@@ -32,7 +32,7 @@
     "name": "Mycus B.W.M.D",
     "description": "After mycus assimilation was successful, our local system was instructed to claim more territory for the mycus. Hostile organisms are near, proceed with caution.",
     "flags": [ "LONE_START", "SUR_START", "AUT_START" ],
-    "ident": "mycus_bwmd",
+    "id": "mycus_bwmd",
     "points": 2,
     "start_name": "Fungal Territory",
     "allowed_locs": [ "sloc_forest", "sloc_field" ],
@@ -59,7 +59,7 @@
     "type": "scenario",
     "name": "Prepper Household",
     "description": "You knew something was coming, you prepared, when the dead rose, you knew what to do. With your house now barricaded, it's time to put your plan into action.",
-    "ident": "prep_house",
+    "id": "prep_house",
     "points": 2,
     "start_name": "Boarded Up House",
     "allowed_locs": [ "sloc_house_boarded" ],
@@ -70,7 +70,7 @@
     "name": "Slave Fighter's Freedom",
     "description": "All your life you have been experimented on and forced to fight others for the amusement of your masters. Never having seen the sun or the outside the cataclysm gave you a chance at freedom. Now you just have to escape from your fellow combatants...",
     "flags": [ "LONE_START", "CHALLENGE" ],
-    "ident": "house_fight_scenario",
+    "id": "house_fight_scenario",
     "points": -2,
     "start_name": "Sketchy Cabin",
     "allowed_locs": [ "house_fight_s" ],
@@ -104,7 +104,7 @@
     "type": "scenario",
     "name": "Experimental Soldier Start",
     "description": "You were part of a an advanced infantry unit, deployed to one of several 'priority sites' as part of a last-ditch effort to get the situation under control.  Delays and casualties led to you being the only one left by the time you reached the objective, and things aren't looking any better.",
-    "ident": "experiment_soldier_start",
+    "id": "experiment_soldier_start",
     "points": -2,
     "flags": [ "LONE_START", "CITY_START" ],
     "start_name": "Priority Site",
@@ -120,63 +120,63 @@
   {
     "copy-from": "alone",
     "type": "scenario",
-    "ident": "alone",
+    "id": "alone",
     "traits": [ "MARTIAL_ARTS_SURV_COM", "MARTIAL_ARTS_BIOJUTSU" ]
   },
   {
     "copy-from": "summer_advanced_start",
     "type": "scenario",
-    "ident": "summer_advanced_start",
+    "id": "summer_advanced_start",
     "traits": [ "MARTIAL_ARTS_SURV_COM", "MARTIAL_ARTS_BIOJUTSU" ],
     "extend": { "professions": [ "bio_infantry", "bio_scout", "bio_knight", "bio_tool" ] }
   },
   {
     "copy-from": "ambushed",
     "type": "scenario",
-    "ident": "ambushed",
+    "id": "ambushed",
     "traits": [ "MARTIAL_ARTS_SURV_COM", "MARTIAL_ARTS_BIOJUTSU" ],
     "extend": { "professions": [ "bio_infantry", "bio_scout", "bio_knight", "bio_tool" ] }
   },
   {
     "copy-from": "cyberpunk",
     "type": "scenario",
-    "ident": "cyberpunk",
+    "id": "cyberpunk",
     "traits": [ "MARTIAL_ARTS_BIOJUTSU" ]
   },
   {
     "copy-from": "wilderness",
     "type": "scenario",
     "extend": { "allowed_locs": [ "surv_camp_l" ] },
-    "ident": "wilderness"
+    "id": "wilderness"
   },
   {
     "copy-from": "mutant",
     "type": "scenario",
-    "ident": "mutant",
+    "id": "mutant",
     "extend": { "professions": [ "failed_weapon" ] }
   },
   {
     "copy-from": "lab_chal",
     "type": "scenario",
-    "ident": "lab_chal",
+    "id": "lab_chal",
     "extend": { "professions": [ "failed_weapon" ] }
   },
   {
     "copy-from": "lab_staff",
     "type": "scenario",
-    "ident": "lab_staff",
+    "id": "lab_staff",
     "extend": { "professions": [ "bio_infantry", "bio_scout", "bio_knight", "bio_tool" ] }
   },
   {
     "copy-from": "heli_crash",
     "type": "scenario",
-    "ident": "heli_crash",
+    "id": "heli_crash",
     "extend": { "professions": [ "bio_infantry", "bio_scout", "bio_knight", "bio_tool" ] }
   },
   {
     "copy-from": "overrun",
     "type": "scenario",
-    "ident": "overrun",
+    "id": "overrun",
     "extend": { "professions": [ "bio_infantry", "bio_scout", "bio_knight", "bio_tool" ] }
   }
 ]

--- a/nocts_cata_mod_BN/Surv_help/c_materials.json
+++ b/nocts_cata_mod_BN/Surv_help/c_materials.json
@@ -1,7 +1,7 @@
 [
   {
     "type": "material",
-    "ident": "c_superalloy_composite",
+    "id": "c_superalloy_composite",
     "name": "Superalloy Composite",
     "density": 13,
     "specific_heat_liquid": 1,

--- a/nocts_cata_mod_BN/Weapons/c_mods.json
+++ b/nocts_cata_mod_BN/Weapons/c_mods.json
@@ -17,7 +17,7 @@
     "gun_data": {
       "ammo": [ "diesel", "gasoline", "flammable", "lamp_oil", "motor_oil", "jp8", "avgas" ],
       "skill": "launcher",
-      "ranged_damage": { "damage_type": "stab", "amount": -1 },
+      "ranged_damage": { "damage_type": "heat", "amount": -1 },
       "dispersion": 600,
       "range": 2,
       "durability": 7,

--- a/nocts_cata_mod_BN/Weapons/c_ranged.json
+++ b/nocts_cata_mod_BN/Weapons/c_ranged.json
@@ -1591,7 +1591,7 @@
     "to_hit": -1,
     "bashing": 10,
     "material": [ "steel", "plastic" ],
-    "ranged_damage": { "damage_type": "stab", "amount": -1, "armor_penetration": -1 },
+    "ranged_damage": { "damage_type": "heat", "amount": -1, "armor_penetration": -1 },
     "range": 3,
     "dispersion": 450,
     "durability": 7,

--- a/nocts_cata_mod_BN/Weapons/c_ranged_override.json
+++ b/nocts_cata_mod_BN/Weapons/c_ranged_override.json
@@ -15,28 +15,5 @@
     "modes": [ [ "DEFAULT", "semi", 1 ], [ "BURST", "burst", 10 ] ],
     "ups_charges": 5,
     "valid_mod_locations": [ [ "accessories", 4 ], [ "sling", 1 ], [ "grip", 1 ], [ "sights", 1 ], [ "stock", 1 ] ]
-  },
-  {
-    "id": "laser_rifle",
-    "copy-from": "laser_rifle",
-    "type": "GUN",
-    "name": { "str": "A7 laser rifle" },
-    "relative": { "ranged_damage": { "damage_type": "stab", "armor_penetration": -10 } },
-    "dispersion": 0,
-    "ups_charges": 25
-  },
-  {
-    "id": "v29_cheap",
-    "copy-from": "v29_cheap",
-    "type": "GUN",
-    "name": { "str": "homemade laser pistol" },
-    "relative": { "ranged_damage": { "damage_type": "stab", "armor_penetration": -13 } }
-  },
-  {
-    "id": "v29",
-    "copy-from": "v29",
-    "type": "GUN",
-    "name": { "str": "V29 laser pistol" },
-    "relative": { "ranged_damage": { "damage_type": "stab", "armor_penetration": -5 } }
   }
 ]

--- a/nocts_cata_mod_BN/modinfo.json
+++ b/nocts_cata_mod_BN/modinfo.json
@@ -1,7 +1,7 @@
 [
   {
     "type": "MOD_INFO",
-    "ident": "Cata++",
+    "id": "Cata++",
     "name": "Cataclysm++",
     "authors": [ "Noctifer" ],
     "description": "The unofficial expansion mod for Cataclysm: Dark Days Ahead.",

--- a/nocts_cata_mod_DDA/Char_creation/c_classes_bw.json
+++ b/nocts_cata_mod_DDA/Char_creation/c_classes_bw.json
@@ -1,7 +1,7 @@
 [
   {
     "type": "profession",
-    "ident": "failed_weapon",
+    "id": "failed_weapon",
     "name": "Failed Bio-Weapon",
     "description": "From the moment you opened your eyes you knew you were a failure, a reject.  Destined to be something great but many a mistake took that away from you.  You awoke in a world of monsters, but you're determined to prove you aren't one of them.",
     "points": 4,
@@ -65,7 +65,7 @@
   },
   {
     "type": "profession",
-    "ident": "mycus_weapon",
+    "id": "mycus_weapon",
     "name": "Fungus Failed Bio-Weapon",
     "description": "Assimilation process is complete, incorporation and modification of biology and bionics into our system was successful.  Protection of our new domain and brethren is our current objective.  Inability to remove previous DNA marker is but a minor setback.",
     "points": 4,
@@ -134,7 +134,7 @@
   },
   {
     "type": "profession",
-    "ident": "bio_weapon_a",
+    "id": "bio_weapon_a",
     "name": "Bio-Weapon Alpha",
     "description": "'The Predator'.  You were the first, the Alpha.  Created to sow chaos behind enemy lines, driven by hunger.  You awoke into the unknown with an appetite - good thing the world is full of prey to devour!",
     "points": 8,
@@ -189,7 +189,7 @@
   },
   {
     "type": "profession",
-    "ident": "bio_weapon_d",
+    "id": "bio_weapon_d",
     "name": "Bio-Weapon Delta",
     "description": "'The Infiltrator', created to infiltrate, scout, spy and assassinate.  Capable of taking down enemies from afar, exploring enemy territory and integrating into the local populace.  You awoke to chaos, and you plan to eliminate whoever caused it.",
     "points": 8,
@@ -253,7 +253,7 @@
   },
   {
     "type": "profession",
-    "ident": "bio_weapon_b",
+    "id": "bio_weapon_b",
     "name": "Bio-Weapon Beta",
     "description": "'The Immortal', designed to be a one-man army.  Your body is a lethal weapon, finely tuned arms and defenses ready to destroy anything standing in your way.  You awoke to a horde of enemies, so now you take them all on.",
     "points": 8,
@@ -320,7 +320,7 @@
   },
   {
     "type": "profession",
-    "ident": "bio_weapon_g",
+    "id": "bio_weapon_g",
     "name": "Bio-Weapon Gamma",
     "description": "'The Mechanic', created to sabotage, destroy, assimilate or repair bio-technology.  You are a walking, adaptive repair machine.  You awoke to the sounds of machines fighting abominations.  You could help them, or destroy them, if they get in your way.",
     "points": 8,
@@ -359,7 +359,7 @@
   },
   {
     "type": "profession",
-    "ident": "bio_infantry",
+    "id": "bio_infantry",
     "name": "Super Soldier",
     "description": "The infantry of the Super Soldier project.  You are one of many augmented soldiers to be deployed into a battle field to ensure victory.  With range and melee capabilities, you engage enemies en masse.",
     "points": 12,
@@ -405,7 +405,7 @@
   },
   {
     "type": "profession",
-    "ident": "bio_scout",
+    "id": "bio_scout",
     "name": "Super Scout",
     "description": "The sniper of the Super Soldier project.  You are one of a few augmented soldiers to be used for reconnaissance and V.I.P assassinations.  With your weapons and skills, you can eliminate key targets after living for weeks in enemy territory.",
     "points": 12,
@@ -470,7 +470,7 @@
   },
   {
     "type": "profession",
-    "ident": "bio_tool",
+    "id": "bio_tool",
     "name": "Super Bio-engineer",
     "description": "Biological and mechanical repair unit, the combat engineer of the Super Soldier project.  You are one of many augmented military mechanics to be used as a repair module.  With repair, medical and general electronic capabilities, you can maybe fix the world.",
     "points": 12,
@@ -528,7 +528,7 @@
   },
   {
     "type": "profession",
-    "ident": "bio_knight",
+    "id": "bio_knight",
     "name": "Super Juggernaut",
     "description": "The tank of the Super Soldier project. You are one of a few augmented soldiers to be used as a heavy support to infantry. With ranged, armor and regenerative capabilities, you can endure heavy damage and return it in kind.",
     "points": 12,
@@ -579,7 +579,7 @@
   },
   {
     "type": "profession",
-    "ident": "sf_blade",
+    "id": "sf_blade",
     "name": "Slave Fighter (Blade)",
     "description": "You were augmented with a blade, and enhancements to your speed and reaction time. You can hit an opponent multiple times before they land a blow.",
     "points": 6,
@@ -606,7 +606,7 @@
   },
   {
     "type": "profession",
-    "ident": "sf_claw",
+    "id": "sf_claw",
     "name": "Slave Fighter (Claws)",
     "description": "You were augmented with some claws, and enhancements to your reflexes. You deliver a powerful strike that neutralizes foes in few hits.",
     "points": 6,
@@ -638,7 +638,7 @@
   },
   {
     "type": "profession",
-    "ident": "sf_shock",
+    "id": "sf_shock",
     "name": "Slave Fighter (Shocker)",
     "description": "You were augmented with electrical generators and protection from them. You hit multiple foes with electricity, frying them until their nervous system gives up.",
     "points": 6,
@@ -664,7 +664,7 @@
   },
   {
     "type": "profession",
-    "ident": "sf_weapon",
+    "id": "sf_weapon",
     "name": "Slave Fighter (Weapon Master)",
     "description": "You have been augmented with many 'passive' combat bionics, they merely aid you but are not weapons in and of themselves. You have been trained to use all sorts of different weapons, including your fists. You can pretty much weaponize a sock.",
     "points": 6,

--- a/nocts_cata_mod_DDA/Char_creation/c_classes_r.json
+++ b/nocts_cata_mod_DDA/Char_creation/c_classes_r.json
@@ -1,7 +1,7 @@
 [
   {
     "type": "profession",
-    "ident": "can_sur",
+    "id": "can_sur",
     "name": "Canned Survivor",
     "description": "You were a very busy person. That's why you bought a can of survival items and called it a day. Now it's the only thing you have.",
     "points": 1,
@@ -13,7 +13,7 @@
   },
   {
     "type": "profession",
-    "ident": "prepper",
+    "id": "prepper",
     "name": "Prepper",
     "description": "You were paranoid about the world ending so you jumped on the prepper bandwagon. You read a book on survival and got yourself a gun pack and some gear. The cataclysm was not what you expected.",
     "points": 5,

--- a/nocts_cata_mod_DDA/Char_creation/c_scenarios.json
+++ b/nocts_cata_mod_DDA/Char_creation/c_scenarios.json
@@ -4,7 +4,7 @@
     "name": "Bio-Weapon Lab",
     "description": "You woke up, where are you?  Who are you?  What are you?!  That doesn't matter right now... you have a bad feeling...",
     "flags": [ "LONE_START", "SUR_START", "SUM_START" ],
-    "ident": "bio_weapon_lab",
+    "id": "bio_weapon_lab",
     "points": 0,
     "start_name": "Bio-Weapon Lab",
     "allowed_locs": [ "Bio_Weapon_Lab_l" ],
@@ -34,7 +34,7 @@
     "name": "Mycus B.W.M.D",
     "description": "After mycus assimilation was successful, our local system was instructed to claim more territory for the mycus. Hostile organisms are near, proceed with caution.",
     "flags": [ "LONE_START", "SUR_START", "AUT_START" ],
-    "ident": "mycus_bwmd",
+    "id": "mycus_bwmd",
     "points": 2,
     "start_name": "Fungal Territory",
     "allowed_locs": [ "sloc_forest", "sloc_field" ],
@@ -63,7 +63,7 @@
     "type": "scenario",
     "name": "Prepper Household",
     "description": "You knew something was coming, you prepared, when the dead rose, you knew what to do. With your house now barricaded, it's time to put your plan into action.",
-    "ident": "prep_house",
+    "id": "prep_house",
     "points": 2,
     "start_name": "Boarded Up House",
     "allowed_locs": [ "sloc_house_boarded" ],
@@ -74,7 +74,7 @@
     "name": "Slave Fighter's Freedom",
     "description": "All your life you have been experimented on and forced to fight others for the amusement of your masters. Never having seen the sun or the outside the cataclysm gave you a chance at freedom. Now you just have to escape from your fellow combatants...",
     "flags": [ "LONE_START", "CHALLENGE" ],
-    "ident": "house_fight_scenario",
+    "id": "house_fight_scenario",
     "points": -2,
     "start_name": "Sketchy Cabin",
     "allowed_locs": [ "house_fight_s" ],
@@ -108,7 +108,7 @@
     "type": "scenario",
     "name": "Experimental Soldier Start",
     "description": "You were part of a an advanced infantry unit, deployed to one of several 'priority sites' as part of a last-ditch effort to get the situation under control.  Delays and casualties led to you being the only one left by the time you reached the objective, and things aren't looking any better.",
-    "ident": "experiment_soldier_start",
+    "id": "experiment_soldier_start",
     "points": -2,
     "flags": [ "LONE_START", "CITY_START" ],
     "start_name": "Priority Site",
@@ -124,63 +124,63 @@
   {
     "copy-from": "alone",
     "type": "scenario",
-    "ident": "alone",
+    "id": "alone",
     "traits": [ "MARTIAL_ARTS_SURV_COM", "MARTIAL_ARTS_BIOJUTSU" ]
   },
   {
     "copy-from": "summer_advanced_start",
     "type": "scenario",
-    "ident": "summer_advanced_start",
+    "id": "summer_advanced_start",
     "traits": [ "MARTIAL_ARTS_SURV_COM", "MARTIAL_ARTS_BIOJUTSU" ],
     "extend": { "professions": [ "bio_infantry", "bio_scout", "bio_knight", "bio_tool" ] }
   },
   {
     "copy-from": "ambushed",
     "type": "scenario",
-    "ident": "ambushed",
+    "id": "ambushed",
     "traits": [ "MARTIAL_ARTS_SURV_COM", "MARTIAL_ARTS_BIOJUTSU" ],
     "extend": { "professions": [ "bio_infantry", "bio_scout", "bio_knight", "bio_tool" ] }
   },
   {
     "copy-from": "cyberpunk",
     "type": "scenario",
-    "ident": "cyberpunk",
+    "id": "cyberpunk",
     "traits": [ "MARTIAL_ARTS_BIOJUTSU" ]
   },
   {
     "copy-from": "wilderness",
     "type": "scenario",
     "extend": { "allowed_locs": [ "surv_camp_l" ] },
-    "ident": "wilderness"
+    "id": "wilderness"
   },
   {
     "copy-from": "mutant",
     "type": "scenario",
-    "ident": "mutant",
+    "id": "mutant",
     "extend": { "professions": [ "failed_weapon" ] }
   },
   {
     "copy-from": "lab_chal",
     "type": "scenario",
-    "ident": "lab_chal",
+    "id": "lab_chal",
     "extend": { "professions": [ "failed_weapon" ] }
   },
   {
     "copy-from": "lab_staff",
     "type": "scenario",
-    "ident": "lab_staff",
+    "id": "lab_staff",
     "extend": { "professions": [ "bio_infantry", "bio_scout", "bio_knight", "bio_tool" ] }
   },
   {
     "copy-from": "heli_crash",
     "type": "scenario",
-    "ident": "heli_crash",
+    "id": "heli_crash",
     "extend": { "professions": [ "bio_infantry", "bio_scout", "bio_knight", "bio_tool" ] }
   },
   {
     "copy-from": "overrun",
     "type": "scenario",
-    "ident": "overrun",
+    "id": "overrun",
     "extend": { "professions": [ "bio_infantry", "bio_scout", "bio_knight", "bio_tool" ] }
   }
 ]

--- a/nocts_cata_mod_DDA/Surv_help/c_materials.json
+++ b/nocts_cata_mod_DDA/Surv_help/c_materials.json
@@ -1,7 +1,7 @@
 [
   {
     "type": "material",
-    "ident": "c_superalloy_composite",
+    "id": "c_superalloy_composite",
     "name": "Superalloy Composite",
     "density": 13,
     "specific_heat_liquid": 1,

--- a/nocts_cata_mod_DDA/Weapons/c_mods.json
+++ b/nocts_cata_mod_DDA/Weapons/c_mods.json
@@ -50,7 +50,7 @@
     "gun_data": {
       "skill": "pistol",
       "ammo": "22",
-      "ranged_damage": { "damage_type": "stab", "amount": -1 },
+      "ranged_damage": { "damage_type": "bullet", "amount": -1 },
       "dispersion": 530,
       "min_cycle_recoil": 39,
       "durability": 6,
@@ -89,7 +89,7 @@
     "gun_data": {
       "skill": "pistol",
       "ammo": "9mm",
-      "ranged_damage": { "damage_type": "stab", "amount": -1 },
+      "ranged_damage": { "damage_type": "bullet", "amount": -1 },
       "dispersion": 530,
       "min_cycle_recoil": 450,
       "durability": 5,
@@ -128,7 +128,7 @@
     "gun_data": {
       "skill": "pistol",
       "ammo": "45",
-      "ranged_damage": { "damage_type": "stab", "amount": -1 },
+      "ranged_damage": { "damage_type": "bullet", "amount": -1 },
       "dispersion": 530,
       "min_cycle_recoil": 540,
       "durability": 6,

--- a/nocts_cata_mod_DDA/Weapons/c_ranged_override.json
+++ b/nocts_cata_mod_DDA/Weapons/c_ranged_override.json
@@ -15,28 +15,5 @@
     "modes": [ [ "DEFAULT", "semi", 1 ], [ "BURST", "burst", 10 ] ],
     "ups_charges": 5,
     "valid_mod_locations": [ [ "accessories", 4 ], [ "sling", 1 ], [ "grip", 1 ], [ "sights", 1 ], [ "stock", 1 ] ]
-  },
-  {
-    "id": "laser_rifle",
-    "copy-from": "laser_rifle",
-    "type": "GUN",
-    "name": { "str": "A7 laser rifle" },
-    "relative": { "ranged_damage": { "damage_type": "heat", "armor_penetration": -10 } },
-    "dispersion": 0,
-    "ups_charges": 25
-  },
-  {
-    "id": "v29_cheap",
-    "copy-from": "v29_cheap",
-    "type": "GUN",
-    "name": { "str": "homemade laser pistol" },
-    "relative": { "ranged_damage": { "damage_type": "heat", "armor_penetration": -13 } }
-  },
-  {
-    "id": "v29",
-    "copy-from": "v29",
-    "type": "GUN",
-    "name": { "str": "V29 laser pistol" },
-    "relative": { "ranged_damage": { "damage_type": "heat", "armor_penetration": -5 } }
   }
 ]

--- a/nocts_cata_mod_DDA/modinfo.json
+++ b/nocts_cata_mod_DDA/modinfo.json
@@ -1,7 +1,7 @@
 [
   {
     "type": "MOD_INFO",
-    "ident": "Cata++",
+    "id": "Cata++",
     "name": "Cataclysm++",
     "authors": [ "Noctifer" ],
     "description": "The unofficial expansion mod for Cataclysm: Dark Days Ahead.",


### PR DESCRIPTION
* Updated flamethrowers in the BN version to use heat-type damage now that lasers and flamethrowers were updated in BN too.
* Belatedly fixed aux pistols in the DDA version not having bullet-type damage.
* Removed the overrides to lasers since heat-type with low AP is now the standard in both DDA and BN.
* Updated all uses of `ident` to `id` now that it's standard for both DDA and BN.