### PR TITLE
Some assorted item ideas

### DIFF
--- a/nocts_cata_mod_BN/Recipe/c_recipes.json
+++ b/nocts_cata_mod_BN/Recipe/c_recipes.json
@@ -2114,5 +2114,55 @@
     "book_learn": [ [ "textbook_fabrication", 1 ], [ "recipe_surv", 1 ] ],
     "using": [ [ "c_metal_molding_standard", 1 ], [ "steel_standard", 12 ], [ "forging_standard", 48 ] ],
     "tools": [ [ [ "makeshift_crowbar", -1 ] ] ]
+  },
+  {
+    "type": "recipe",
+    "result": "shot_crafted_suppressor",
+    "category": "CC_WEAPON",
+    "subcategory": "CSC_WEAPON_MODS",
+    "skill_used": "mechanics",
+    "skills_required": [ "gun", 2 ],
+    "difficulty": 4,
+    "time": "20 m",
+    "autolearn": true,
+    "qualities": [ { "id": "SAW_M_FINE", "level": 1 } ],
+    "using": [ [ "soldering_standard", 5 ] ],
+    "components": [ [ [ "rag", 4 ], [ "plastic_chunk", 4 ], [ "felt_patch", 4 ], [ "leather", 4 ] ], [ [ "pipe", 1 ] ], [ [ "scrap", 1 ] ] ]
+  },
+  {
+    "type": "recipe",
+    "result": "shot_suppressor",
+    "category": "CC_WEAPON",
+    "subcategory": "CSC_WEAPON_MODS",
+    "skill_used": "mechanics",
+    "skills_required": [ "gun", 2 ],
+    "difficulty": 9,
+    "time": "1 h",
+    "book_learn": [ [ "manual_shotgun", 4 ] ],
+    "using": [ [ "soldering_standard", 5 ] ],
+    "tools": [ [ [ "small_repairkit", 150 ], [ "large_repairkit", 150 ] ] ],
+    "components": [ [ [ "scrap", 1 ] ], [ [ "pipe", 2 ] ], [ [ "wire", 1 ] ] ]
+  },
+  {
+    "type": "recipe",
+    "result": "autoclave_makeshift",
+    "category": "CC_ELECTRONIC",
+    "subcategory": "CSC_ELECTRONIC_TOOLS",
+    "skill_used": "fabrication",
+    "skills_required": [ [ "mechanics", 4 ], [ "firstaid", 4 ] ],
+    "difficulty": 6,
+    "time": "3 h",
+    "book_learn": [ [ "recipe_augs", 7 ], [ "recipe_mil_augs", 7 ], [ "recipe_lab_elec", 6 ] ],
+    "using": [ [ "welding_standard", 50 ] ],
+    "qualities": [ { "id": "HAMMER", "level": 3 }, { "id": "WRENCH", "level": 2 }, { "id": "SAW_M", "level": 2 } ],
+    "components": [
+      [ [ "pressure_cooker", 1 ] ],
+      [ [ "i6_diesel", 1 ], [ "v6_diesel", 1 ] ],
+      [ [ "metal_tank", 1 ] ],
+      [ [ "pump_complex", 1 ] ],
+      [ [ "hose", 2 ] ],
+      [ [ "cu_pipe", 4 ] ],
+      [ [ "thermometer", 1 ] ]
+    ]
   }
 ]

--- a/nocts_cata_mod_BN/Surv_help/c_tools.json
+++ b/nocts_cata_mod_BN/Surv_help/c_tools.json
@@ -904,5 +904,26 @@
     "use_action": [ "HAMMER", "CROWBAR" ],
     "techniques": [ "WBLOCK_1" ],
     "flags": [ "BELT_CLIP", "FRAGILE_MELEE" ]
+  },
+  {
+    "id": "autoclave_makeshift",
+    "type": "TOOL",
+    "name": { "str": "makeshift autoclave" },
+    "description": "This oversized pressure cooker uses diesel or other readily-available fuels to power a high-pressure sterilization chamber.  Less efficient than a commercial battery-powered autoclave and incompatible with a vehicle power grid, it does the job if nothing else is available.",
+    "weight": "200 kg",
+    "volume": "80 L",
+    "price": 80000,
+    "price_postapoc": 2000,
+    "to_hit": -6,
+    "bashing": 12,
+    "material": [ "steel" ],
+    "symbol": "A",
+    "color": "yellow",
+    "use_action": [ "AUTOCLAVE" ],
+    "flags": [ "ALLOWS_REMOTE_USE" ],
+    "power_draw": 2000000,
+    "looks_like": "autoclave",
+    "ammo": [ "diesel", "lamp_oil", "motor_oil", "jp8" ],
+    "max_charges": 60000
   }
 ]

--- a/nocts_cata_mod_BN/Weapons/c_mods.json
+++ b/nocts_cata_mod_BN/Weapons/c_mods.json
@@ -164,5 +164,30 @@
     "install_time": "20 m",
     "min_skills": [ [ "weapon", 2 ], [ "gun", 1 ] ],
     "flags": [ "DISABLE_SIGHTS" ]
+  },
+  {
+    "id": "shot_crafted_suppressor",
+    "type": "GUNMOD",
+    "name": { "str": "makeshift shotgun suppressor" },
+    "description": "A homemade suppressor made from a pipe and improvised baffles.  It's a lot more complex than a suppressor for a pistol or rifle, and will deteriorate quickly with use.  This suppressor is large and, when attached, will interfere with your ability to aim down the base sights of the gun.",
+    "weight": "920 g",
+    "volume": "750 ml",
+    "price": 900,
+    "price_postapoc": 350,
+    "install_time": "30 s",
+    "to_hit": 1,
+    "bashing": 3,
+    "material": [ "steel" ],
+    "symbol": ":",
+    "color": "dark_gray",
+    "location": "muzzle",
+    "mod_targets": [ "shotgun" ],
+    "consume_chance": 15,
+    "consume_divisor": 80,
+    "damage_modifier": { "damage_type": "stab", "amount": -5 },
+    "dispersion_modifier": 40,
+    "handling_modifier": 2,
+    "loudness_modifier": -20,
+    "flags": [ "DISABLE_SIGHTS", "CONSUMABLE" ]
   }
 ]

--- a/nocts_cata_mod_DDA/Recipe/c_recipes.json
+++ b/nocts_cata_mod_DDA/Recipe/c_recipes.json
@@ -2270,5 +2270,58 @@
     "book_learn": [ [ "textbook_fabrication", 1 ], [ "recipe_surv", 1 ] ],
     "using": [ [ "c_metal_molding_standard", 1 ], [ "steel_standard", 12 ], [ "forging_standard", 48 ] ],
     "tools": [ [ [ "makeshift_crowbar", -1 ] ] ]
+  },
+  {
+    "type": "recipe",
+    "activity_level": "MODERATE_EXERCISE",
+    "result": "shot_crafted_suppressor",
+    "category": "CC_WEAPON",
+    "subcategory": "CSC_WEAPON_MODS",
+    "skill_used": "mechanics",
+    "skills_required": [ "gun", 2 ],
+    "difficulty": 4,
+    "time": "20 m",
+    "autolearn": true,
+    "qualities": [ { "id": "SAW_M_FINE", "level": 1 } ],
+    "using": [ [ "soldering_standard", 5 ] ],
+    "components": [ [ [ "rag", 4 ], [ "plastic_chunk", 4 ], [ "felt_patch", 4 ], [ "leather", 4 ] ], [ [ "pipe", 1 ] ], [ [ "scrap", 1 ] ] ]
+  },
+  {
+    "type": "recipe",
+    "activity_level": "LIGHT_EXERCISE",
+    "result": "shot_suppressor",
+    "category": "CC_WEAPON",
+    "subcategory": "CSC_WEAPON_MODS",
+    "skill_used": "mechanics",
+    "skills_required": [ "gun", 2 ],
+    "difficulty": 9,
+    "time": "1 h",
+    "book_learn": [ [ "manual_shotgun", 4 ] ],
+    "using": [ [ "soldering_standard", 5 ] ],
+    "tools": [ [ [ "small_repairkit", 150 ], [ "large_repairkit", 150 ] ] ],
+    "components": [ [ [ "scrap", 1 ] ], [ [ "pipe", 2 ] ], [ [ "wire", 1 ] ] ]
+  },
+  {
+    "type": "recipe",
+    "result": "autoclave_makeshift",
+    "activity_level": "MODERATE_EXERCISE",
+    "category": "CC_ELECTRONIC",
+    "subcategory": "CSC_ELECTRONIC_TOOLS",
+    "skill_used": "fabrication",
+    "skills_required": [ [ "mechanics", 4 ], [ "firstaid", 4 ] ],
+    "difficulty": 6,
+    "time": "3 h",
+    "book_learn": [ [ "recipe_augs", 7 ], [ "recipe_mil_augs", 7 ], [ "recipe_lab_elec", 6 ] ],
+    "using": [ [ "welding_standard", 50 ] ],
+    "qualities": [ { "id": "HAMMER", "level": 3 }, { "id": "WRENCH", "level": 2 }, { "id": "SAW_M", "level": 2 } ],
+    "components": [
+      [ [ "pressure_cooker", 1 ] ],
+      [ [ "i6_diesel", 1 ], [ "v6_diesel", 1 ] ],
+      [ [ "metal_tank", 1 ] ],
+      [ [ "pump_complex", 1 ] ],
+      [ [ "hose", 2 ] ],
+      [ [ "cu_pipe", 4 ] ],
+      [ [ "thermometer", 1 ] ]
+    ]
   }
 ]

--- a/nocts_cata_mod_DDA/Surv_help/c_tools.json
+++ b/nocts_cata_mod_DDA/Surv_help/c_tools.json
@@ -927,5 +927,40 @@
     "use_action": [ "HAMMER", "CROWBAR" ],
     "techniques": [ "WBLOCK_1" ],
     "flags": [ "BELT_CLIP", "FRAGILE_MELEE" ]
+  },
+  {
+    "id": "autoclave_makeshift",
+    "type": "TOOL",
+    "name": { "str": "makeshift autoclave" },
+    "description": "This oversized pressure cooker uses diesel or other readily-available fuels to power a high-pressure sterilization chamber.  Less efficient than a commercial battery-powered autoclave and incompatible with a vehicle power grid, it does the job if nothing else is available.",
+    "weight": "200 kg",
+    "volume": "80 L",
+    "price": 80000,
+    "price_postapoc": 2000,
+    "to_hit": -6,
+    "bashing": 12,
+    "material": [ "steel" ],
+    "symbol": "A",
+    "color": "yellow",
+    "use_action": [ "AUTOCLAVE" ],
+    "flags": [ "ALLOWS_REMOTE_USE" ],
+    "power_draw": 3000000,
+    "looks_like": "autoclave",
+    "ammo": [ "diesel", "lamp_oil", "motor_oil", "jp8" ],
+    "pocket_data": [
+      {
+        "pocket_type": "MAGAZINE",
+        "rigid": true,
+        "watertight": true,
+        "ammo_restriction": { "diesel": 60000, "lamp_oil": 60000, "motor_oil": 60000, "jp8": 60000 }
+      },
+      {
+        "pocket_type": "CONTAINER",
+        "holster": true,
+        "max_contains_volume": "20 L",
+        "max_contains_weight": "20 kg",
+        "flag_restriction": [ "CBM" ]
+      }
+    ]
   }
 ]

--- a/nocts_cata_mod_DDA/Weapons/c_mods.json
+++ b/nocts_cata_mod_DDA/Weapons/c_mods.json
@@ -25,6 +25,14 @@
       "clip_size": 250,
       "ammo_to_fire": 50
     },
+    "pocket_data": [
+      {
+        "pocket_type": "MAGAZINE",
+        "rigid": true,
+        "watertight": true,
+        "ammo_restriction": { "diesel": 250, "gasoline": 250, "flammable": 250, "lamp_oil": 250, "motor_oil": 250, "jp8": 250, "avgas": 250 }
+      }
+    ],
     "min_skills": [ [ "weapon", 2 ], [ "launcher", 1 ] ],
     "install_time": "30 m",
     "flags": [ "STR_RELOAD", "PUMP_RAIL_COMPATIBLE", "NON-FOULING" ]
@@ -189,5 +197,30 @@
     "install_time": "20 m",
     "min_skills": [ [ "weapon", 2 ], [ "gun", 1 ] ],
     "flags": [ "DISABLE_SIGHTS" ]
+  },
+  {
+    "id": "shot_crafted_suppressor",
+    "type": "GUNMOD",
+    "name": { "str": "makeshift shotgun suppressor" },
+    "description": "A homemade suppressor made from a pipe and improvised baffles.  It's a lot more complex than a suppressor for a pistol or rifle, and will deteriorate quickly with use.  This suppressor is large and, when attached, will interfere with your ability to aim down the base sights of the gun.",
+    "weight": "920 g",
+    "volume": "750 ml",
+    "price": 900,
+    "price_postapoc": 350,
+    "install_time": "30 s",
+    "to_hit": 1,
+    "bashing": 3,
+    "material": [ "steel" ],
+    "symbol": ":",
+    "color": "dark_gray",
+    "location": "muzzle",
+    "mod_targets": [ "shotgun" ],
+    "consume_chance": 15,
+    "consume_divisor": 80,
+    "damage_modifier": { "damage_type": "bullet", "amount": -5 },
+    "dispersion_modifier": 40,
+    "handling_modifier": 2,
+    "loudness_modifier": -20,
+    "flags": [ "DISABLE_SIGHTS", "CONSUMABLE" ]
   }
 ]


### PR DESCRIPTION
* Added a makeshift shotgun suppressor, based on the same general principles needed for shotgun suppressors. Bit more complex to make but still low-level and disposable.
* Added a recipe for making the vanilla shotgun suppressor too, at a higher level.
* Added a makeshift autoclave made using a diesel engine and other components. I considered other ideas like a less-efficient electric version or even a steam engine variant, but power usage rapidly seemed less practical with those options. Vanilla autoclaves already seem deliberately designed to be unusable without converting unless you have an atomic battery, despite letting you load batteries that'll never offer enough power.
* Fixed survivor aux flamethrower not having pocket data in the DDA version.