### PR TITLE
Fixes plus re-rebalancing of sentinel professions

### DIFF
--- a/nocts_cata_mod_BN/Char_creation/c_classes_bw.json
+++ b/nocts_cata_mod_BN/Char_creation/c_classes_bw.json
@@ -368,25 +368,27 @@
       "bio_metabolics",
       "bio_nanobots",
       "bio_painkiller",
-      "bio_flashlight",
+      "bio_night_vision",
       "bio_purifier",
       "bio_shock",
       "bio_targeting",
       "bio_ups",
       "bio_power_storage_mkII",
       "bio_power_storage_mkII",
-      "bio_power_storage_mkII",
-      "bio_power_storage_mkII"
+	  "bio_str_enhancer",
+	  "bio_dex_enhancer",
+	  "bio_eye_enhancer",
+	  "bio_int_enhancer",
+	  "bio_speed"
     ],
-    "traits": [ "SUPER_SOLDIER_MARKER", "THRESH_SUPER_SOLDIER", "SENTINEL_PERK_STR", "SENTINEL_PERK_DEX_2" ],
+    "traits": [ "SUPER_SOLDIER_MARKER", "THRESH_SUPER_SOLDIER", "SENTINEL_PERK_STR", "SENTINEL_PERK_DEX", "SENTINEL_PERK_PER", "SENTINEL_PERK_INT", "SENTINEL_STAT_STR", "SENTINEL_STAT_DEX", "SENTINEL_STAT_PER", "SENTINEL_STAT_INT" ],
     "skills": [
       { "level": 3, "name": "gun" },
       { "level": 3, "name": "rifle" },
+      { "level": 3, "name": "pistol" },
       { "level": 3, "name": "melee" },
       { "level": 3, "name": "unarmed" },
       { "level": 3, "name": "cutting" },
-      { "level": 3, "name": "stabbing" },
-      { "level": 3, "name": "bashing" },
       { "level": 3, "name": "dodge" }
     ],
     "items": {
@@ -394,8 +396,7 @@
         "items": [ "helmet_liner", "thermal_shirt", "gloves_liner", "under_armor_shorts", "socks", "mil_armor", "molle_pack" ],
         "entries": [
           { "item": "arc_laser_rifle", "ammo-item": "battery", "charges": 5000, "contents-item": "shoulder_strap" },
-          { "item": "neo_laser_pistol_ups", "container-item": "holster" },
-          { "item": "knife_combat", "container-item": "sheath" }
+          { "item": "neo_laser_pistol_ups", "container-item": "holster" }
         ]
       }
     },
@@ -415,25 +416,27 @@
       "bio_nanobots",
       "bio_night_vision",
       "bio_recycler",
+	  "bio_digestion",
       "bio_targeting",
       "bio_torsionratchet",
       "bio_ups",
       "bio_power_storage_mkII",
       "bio_power_storage_mkII",
-      "bio_power_storage_mkII",
-      "bio_power_storage_mkII"
+	  "bio_eye_enhancer",
+	  "bio_dex_enhancer"
     ],
-    "traits": [ "SUPER_SOLDIER_MARKER", "THRESH_SUPER_SOLDIER", "SENTINEL_PERK_DEX", "SENTINEL_PERK_PER_2" ],
+    "traits": [ "SUPER_SOLDIER_MARKER", "THRESH_SUPER_SOLDIER", "SENTINEL_STAT_DEX_2", "SENTINEL_STAT_PER_2", "SENTINEL_PERK_DEX", "SENTINEL_PERK_PER_2" ],
     "skills": [
       { "level": 5, "name": "gun" },
-      { "level": 5, "name": "rifle" },
-      { "level": 3, "name": "melee" },
-      { "level": 3, "name": "stabbing" },
+      { "level": 4, "name": "rifle" },
       { "level": 3, "name": "survival" },
       { "level": 3, "name": "fabrication" },
       { "level": 3, "name": "cooking" },
-      { "level": 3, "name": "tailor" },
-      { "level": 3, "name": "swimming" }
+      { "level": 2, "name": "tailor" },
+      { "level": 2, "name": "swimming" },
+      { "level": 2, "name": "pistol" },
+      { "level": 2, "name": "melee" },
+      { "level": 2, "name": "stabbing" }
     ],
     "items": {
       "both": {
@@ -471,30 +474,30 @@
     "points": 12,
     "CBMs": [
       "bio_batteries",
-      "bio_carbon",
-      "bio_ears",
       "bio_emp_armgun",
       "bio_flashlight",
       "bio_memory",
       "bio_nanobots",
+      "bio_painkiller",
       "bio_sunglasses",
       "bio_tools",
       "bio_ups",
       "bio_watch",
       "bio_power_storage_mkII",
       "bio_power_storage_mkII",
-      "bio_power_storage_mkII",
-      "bio_power_storage_mkII"
+	  "bio_eye_enhancer",
+	  "bio_int_enhancer"
     ],
-    "traits": [ "SUPER_SOLDIER_MARKER", "THRESH_SUPER_SOLDIER", "SENTINEL_PERK_PER", "SENTINEL_PERK_INT_2" ],
+    "traits": [ "SUPER_SOLDIER_MARKER", "THRESH_SUPER_SOLDIER", "SENTINEL_PERK_PER", "SENTINEL_PERK_INT", "SENTINEL_STAT_PER_2", "SENTINEL_STAT_INT_2" ],
     "skills": [
       { "level": 5, "name": "electronics" },
-      { "level": 5, "name": "mechanics" },
       { "level": 5, "name": "cooking" },
-      { "level": 5, "name": "firstaid" },
-      { "level": 5, "name": "fabrication" },
-      { "level": 3, "name": "pistol" },
-      { "level": 3, "name": "gun" }
+      { "level": 4, "name": "mechanics" },
+      { "level": 4, "name": "firstaid" },
+      { "level": 4, "name": "fabrication" },
+      { "level": 3, "name": "gun" },
+      { "level": 2, "name": "pistol" },
+      { "level": 2, "name": "smg" }
     ],
     "items": {
       "both": {
@@ -511,8 +514,7 @@
         ],
         "entries": [
           { "item": "akro_laser_smg", "ammo-item": "battery", "charges": 1000, "contents-item": "shoulder_strap" },
-          { "item": "neo_laser_pistol_ups", "container-item": "holster" },
-          { "item": "knife_combat", "container-item": "sheath" }
+          { "item": "neo_laser_pistol_ups", "container-item": "holster" }
         ]
       }
     },
@@ -535,33 +537,32 @@
       "bio_painkiller",
       "bio_power_armor_interface_mkII",
       "bio_purifier",
-      "bio_radscrubber",
       "bio_sunglasses",
+      "bio_ears",
+      "bio_carbon",
       "bio_sword",
       "bio_targeting",
       "bio_ups",
       "bio_power_storage_mkII",
       "bio_power_storage_mkII",
-      "bio_power_storage_mkII",
-      "bio_power_storage_mkII"
+	  "bio_str_enhancer",
+	  "bio_dex_enhancer"
     ],
-    "traits": [ "SUPER_SOLDIER_MARKER" ],
+    "traits": [ "SUPER_SOLDIER_MARKER", "THRESH_SUPER_SOLDIER", "SENTINEL_PERK_STR", "SENTINEL_PERK_DEX", "SENTINEL_STAT_STR_2", "SENTINEL_STAT_DEX_2" ],
     "skills": [
       { "level": 3, "name": "gun" },
       { "level": 3, "name": "rifle" },
-      { "level": 5, "name": "melee" },
-      { "level": 5, "name": "cutting" },
-      { "level": 5, "name": "bashing" },
-      { "level": 5, "name": "stabbing" },
-      { "level": 5, "name": "dodge" }
+      { "level": 3, "name": "melee" },
+      { "level": 3, "name": "cutting" },
+      { "level": 3, "name": "bashing" },
+      { "level": 3, "name": "stabbing" },
+      { "level": 3, "name": "dodge" }
     ],
     "items": {
       "both": {
-        "items": [ "helmet_liner", "thermal_shirt", "gloves_liner", "under_armor_shorts", "socks", "mil_armor", "vest", "dump_pouch" ],
+        "items": [ "helmet_liner", "thermal_shirt", "gloves_liner", "under_armor_shorts", "socks", "hmil_armor" ],
         "entries": [
-          { "item": "krx_laser_lmg", "ammo-item": "battery", "charges": 10000, "contents-item": "shoulder_strap" },
-          { "item": "neo_laser_pistol_ups", "container-item": "holster" },
-          { "item": "knife_combat", "container-item": "sheath" }
+          { "item": "krx_laser_lmg", "ammo-item": "battery", "charges": 10000, "contents-item": "shoulder_strap" }
         ]
       }
     },

--- a/nocts_cata_mod_BN/Char_creation/c_classes_bw.json
+++ b/nocts_cata_mod_BN/Char_creation/c_classes_bw.json
@@ -532,6 +532,7 @@
         ],
         "entries": [
           { "item": "akro_laser_smg", "ammo-item": "battery", "charges": 1000, "contents-item": "shoulder_strap" },
+          { "item": "knife_combat", "container-item": "sheath" },
           { "item": "neo_laser_pistol_ups", "container-item": "XL_holster" }
         ]
       }

--- a/nocts_cata_mod_BN/Char_creation/c_classes_bw.json
+++ b/nocts_cata_mod_BN/Char_creation/c_classes_bw.json
@@ -435,9 +435,7 @@
     "traits": [
       "SUPER_SOLDIER_MARKER",
       "THRESH_SUPER_SOLDIER",
-      "SENTINEL_STAT_DEX_2",
-      "SENTINEL_STAT_PER_2",
-      "SENTINEL_PERK_DEX",
+      "SENTINEL_PERK_DEX_2",
       "SENTINEL_PERK_PER_2"
     ],
     "skills": [

--- a/nocts_cata_mod_BN/Char_creation/c_classes_bw.json
+++ b/nocts_cata_mod_BN/Char_creation/c_classes_bw.json
@@ -403,6 +403,7 @@
         "items": [ "helmet_liner", "thermal_shirt", "gloves_liner", "under_armor_shorts", "socks", "mil_armor", "molle_pack" ],
         "entries": [
           { "item": "arc_laser_rifle", "ammo-item": "battery", "charges": 5000, "contents-item": "shoulder_strap" },
+          { "item": "knife_combat", "container-item": "sheath" },
           { "item": "neo_laser_pistol_ups", "container-item": "XL_holster" }
         ]
       }

--- a/nocts_cata_mod_BN/Char_creation/c_classes_bw.json
+++ b/nocts_cata_mod_BN/Char_creation/c_classes_bw.json
@@ -503,10 +503,8 @@
     "traits": [
       "SUPER_SOLDIER_MARKER",
       "THRESH_SUPER_SOLDIER",
-      "SENTINEL_PERK_PER",
-      "SENTINEL_PERK_INT",
-      "SENTINEL_STAT_PER_2",
-      "SENTINEL_STAT_INT_2"
+      "SENTINEL_PERK_PER_2",
+      "SENTINEL_PERK_INT_2"
     ],
     "skills": [
       { "level": 5, "name": "electronics" },

--- a/nocts_cata_mod_BN/Char_creation/c_classes_bw.json
+++ b/nocts_cata_mod_BN/Char_creation/c_classes_bw.json
@@ -387,11 +387,7 @@
       "SENTINEL_PERK_STR",
       "SENTINEL_PERK_DEX",
       "SENTINEL_PERK_PER",
-      "SENTINEL_PERK_INT",
-      "SENTINEL_STAT_STR",
-      "SENTINEL_STAT_DEX",
-      "SENTINEL_STAT_PER",
-      "SENTINEL_STAT_INT"
+      "SENTINEL_PERK_INT"
     ],
     "skills": [
       { "level": 3, "name": "gun" },

--- a/nocts_cata_mod_BN/Char_creation/c_classes_bw.json
+++ b/nocts_cata_mod_BN/Char_creation/c_classes_bw.json
@@ -568,10 +568,8 @@
     "traits": [
       "SUPER_SOLDIER_MARKER",
       "THRESH_SUPER_SOLDIER",
-      "SENTINEL_PERK_STR",
-      "SENTINEL_PERK_DEX",
-      "SENTINEL_STAT_STR_2",
-      "SENTINEL_STAT_DEX_2"
+      "SENTINEL_PERK_STR_2",
+      "SENTINEL_PERK_DEX_2"
     ],
     "skills": [
       { "level": 3, "name": "gun" },

--- a/nocts_cata_mod_BN/Char_creation/c_classes_bw.json
+++ b/nocts_cata_mod_BN/Char_creation/c_classes_bw.json
@@ -407,7 +407,7 @@
         "items": [ "helmet_liner", "thermal_shirt", "gloves_liner", "under_armor_shorts", "socks", "mil_armor", "molle_pack" ],
         "entries": [
           { "item": "arc_laser_rifle", "ammo-item": "battery", "charges": 5000, "contents-item": "shoulder_strap" },
-          { "item": "neo_laser_pistol_ups", "container-item": "holster" }
+          { "item": "neo_laser_pistol_ups", "container-item": "XL_holster" }
         ]
       }
     },
@@ -477,7 +477,7 @@
         ],
         "entries": [
           { "item": "mx_laser_sniper", "ammo-item": "battery", "charges": 5000, "contents-item": "shoulder_strap" },
-          { "item": "neo_laser_pistol_ups", "container-item": "holster" },
+          { "item": "neo_laser_pistol_ups", "container-item": "XL_holster" },
           { "item": "knife_combat", "container-item": "sheath" }
         ]
       }
@@ -539,7 +539,7 @@
         ],
         "entries": [
           { "item": "akro_laser_smg", "ammo-item": "battery", "charges": 1000, "contents-item": "shoulder_strap" },
-          { "item": "neo_laser_pistol_ups", "container-item": "holster" }
+          { "item": "neo_laser_pistol_ups", "container-item": "XL_holster" }
         ]
       }
     },

--- a/nocts_cata_mod_BN/Char_creation/c_classes_bw.json
+++ b/nocts_cata_mod_BN/Char_creation/c_classes_bw.json
@@ -396,6 +396,7 @@
       { "level": 3, "name": "melee" },
       { "level": 3, "name": "unarmed" },
       { "level": 3, "name": "cutting" },
+      { "level": 3, "name": "stabbing" },
       { "level": 3, "name": "dodge" }
     ],
     "items": {
@@ -515,7 +516,9 @@
       { "level": 4, "name": "fabrication" },
       { "level": 3, "name": "gun" },
       { "level": 2, "name": "pistol" },
-      { "level": 2, "name": "smg" }
+      { "level": 2, "name": "smg" },
+      { "level": 2, "name": "melee" },
+      { "level": 2, "name": "stabbing" }
     ],
     "items": {
       "both": {

--- a/nocts_cata_mod_BN/Char_creation/c_classes_bw.json
+++ b/nocts_cata_mod_BN/Char_creation/c_classes_bw.json
@@ -583,7 +583,7 @@
     "items": {
       "both": {
         "items": [ "helmet_liner", "thermal_shirt", "gloves_liner", "under_armor_shorts", "socks", "hmil_armor" ],
-        "entries": [ { "item": "krx_laser_lmg", "ammo-item": "battery", "charges": 10000, "contents-item": "shoulder_strap" } ]
+        "entries": [ { "item": "krx_laser_lmg", "ammo-item": "battery", "charges": 10000, "contents-item": "shoulder_strap" }, { "item": "knife_combat", "container-item": "sheath" } ]
       }
     },
     "flags": [ "SCEN_ONLY" ]

--- a/nocts_cata_mod_BN/Char_creation/c_classes_bw.json
+++ b/nocts_cata_mod_BN/Char_creation/c_classes_bw.json
@@ -375,13 +375,24 @@
       "bio_ups",
       "bio_power_storage_mkII",
       "bio_power_storage_mkII",
-	  "bio_str_enhancer",
-	  "bio_dex_enhancer",
-	  "bio_eye_enhancer",
-	  "bio_int_enhancer",
-	  "bio_speed"
+      "bio_str_enhancer",
+      "bio_dex_enhancer",
+      "bio_eye_enhancer",
+      "bio_int_enhancer",
+      "bio_speed"
     ],
-    "traits": [ "SUPER_SOLDIER_MARKER", "THRESH_SUPER_SOLDIER", "SENTINEL_PERK_STR", "SENTINEL_PERK_DEX", "SENTINEL_PERK_PER", "SENTINEL_PERK_INT", "SENTINEL_STAT_STR", "SENTINEL_STAT_DEX", "SENTINEL_STAT_PER", "SENTINEL_STAT_INT" ],
+    "traits": [
+      "SUPER_SOLDIER_MARKER",
+      "THRESH_SUPER_SOLDIER",
+      "SENTINEL_PERK_STR",
+      "SENTINEL_PERK_DEX",
+      "SENTINEL_PERK_PER",
+      "SENTINEL_PERK_INT",
+      "SENTINEL_STAT_STR",
+      "SENTINEL_STAT_DEX",
+      "SENTINEL_STAT_PER",
+      "SENTINEL_STAT_INT"
+    ],
     "skills": [
       { "level": 3, "name": "gun" },
       { "level": 3, "name": "rifle" },
@@ -416,16 +427,23 @@
       "bio_nanobots",
       "bio_night_vision",
       "bio_recycler",
-	  "bio_digestion",
+      "bio_digestion",
       "bio_targeting",
       "bio_torsionratchet",
       "bio_ups",
       "bio_power_storage_mkII",
       "bio_power_storage_mkII",
-	  "bio_eye_enhancer",
-	  "bio_dex_enhancer"
+      "bio_eye_enhancer",
+      "bio_dex_enhancer"
     ],
-    "traits": [ "SUPER_SOLDIER_MARKER", "THRESH_SUPER_SOLDIER", "SENTINEL_STAT_DEX_2", "SENTINEL_STAT_PER_2", "SENTINEL_PERK_DEX", "SENTINEL_PERK_PER_2" ],
+    "traits": [
+      "SUPER_SOLDIER_MARKER",
+      "THRESH_SUPER_SOLDIER",
+      "SENTINEL_STAT_DEX_2",
+      "SENTINEL_STAT_PER_2",
+      "SENTINEL_PERK_DEX",
+      "SENTINEL_PERK_PER_2"
+    ],
     "skills": [
       { "level": 5, "name": "gun" },
       { "level": 4, "name": "rifle" },
@@ -485,10 +503,17 @@
       "bio_watch",
       "bio_power_storage_mkII",
       "bio_power_storage_mkII",
-	  "bio_eye_enhancer",
-	  "bio_int_enhancer"
+      "bio_eye_enhancer",
+      "bio_int_enhancer"
     ],
-    "traits": [ "SUPER_SOLDIER_MARKER", "THRESH_SUPER_SOLDIER", "SENTINEL_PERK_PER", "SENTINEL_PERK_INT", "SENTINEL_STAT_PER_2", "SENTINEL_STAT_INT_2" ],
+    "traits": [
+      "SUPER_SOLDIER_MARKER",
+      "THRESH_SUPER_SOLDIER",
+      "SENTINEL_PERK_PER",
+      "SENTINEL_PERK_INT",
+      "SENTINEL_STAT_PER_2",
+      "SENTINEL_STAT_INT_2"
+    ],
     "skills": [
       { "level": 5, "name": "electronics" },
       { "level": 5, "name": "cooking" },
@@ -545,10 +570,17 @@
       "bio_ups",
       "bio_power_storage_mkII",
       "bio_power_storage_mkII",
-	  "bio_str_enhancer",
-	  "bio_dex_enhancer"
+      "bio_str_enhancer",
+      "bio_dex_enhancer"
     ],
-    "traits": [ "SUPER_SOLDIER_MARKER", "THRESH_SUPER_SOLDIER", "SENTINEL_PERK_STR", "SENTINEL_PERK_DEX", "SENTINEL_STAT_STR_2", "SENTINEL_STAT_DEX_2" ],
+    "traits": [
+      "SUPER_SOLDIER_MARKER",
+      "THRESH_SUPER_SOLDIER",
+      "SENTINEL_PERK_STR",
+      "SENTINEL_PERK_DEX",
+      "SENTINEL_STAT_STR_2",
+      "SENTINEL_STAT_DEX_2"
+    ],
     "skills": [
       { "level": 3, "name": "gun" },
       { "level": 3, "name": "rifle" },
@@ -561,9 +593,7 @@
     "items": {
       "both": {
         "items": [ "helmet_liner", "thermal_shirt", "gloves_liner", "under_armor_shorts", "socks", "hmil_armor" ],
-        "entries": [
-          { "item": "krx_laser_lmg", "ammo-item": "battery", "charges": 10000, "contents-item": "shoulder_strap" }
-        ]
+        "entries": [ { "item": "krx_laser_lmg", "ammo-item": "battery", "charges": 10000, "contents-item": "shoulder_strap" } ]
       }
     },
     "flags": [ "SCEN_ONLY" ]

--- a/nocts_cata_mod_DDA/Char_creation/c_classes_bw.json
+++ b/nocts_cata_mod_DDA/Char_creation/c_classes_bw.json
@@ -532,6 +532,7 @@
         ],
         "entries": [
           { "item": "akro_laser_smg", "ammo-item": "battery", "charges": 1000, "contents-item": "shoulder_strap" },
+          { "item": "knife_combat", "container-item": "sheath" },
           { "item": "neo_laser_pistol_ups", "container-item": "XL_holster" }
         ]
       }

--- a/nocts_cata_mod_DDA/Char_creation/c_classes_bw.json
+++ b/nocts_cata_mod_DDA/Char_creation/c_classes_bw.json
@@ -435,9 +435,7 @@
     "traits": [
       "SUPER_SOLDIER_MARKER",
       "THRESH_SUPER_SOLDIER",
-      "SENTINEL_STAT_DEX_2",
-      "SENTINEL_STAT_PER_2",
-      "SENTINEL_PERK_DEX",
+      "SENTINEL_PERK_DEX_2",
       "SENTINEL_PERK_PER_2"
     ],
     "skills": [

--- a/nocts_cata_mod_DDA/Char_creation/c_classes_bw.json
+++ b/nocts_cata_mod_DDA/Char_creation/c_classes_bw.json
@@ -403,6 +403,7 @@
         "items": [ "helmet_liner", "thermal_shirt", "gloves_liner", "under_armor_shorts", "socks", "mil_armor", "molle_pack" ],
         "entries": [
           { "item": "arc_laser_rifle", "ammo-item": "battery", "charges": 5000, "contents-item": "shoulder_strap" },
+          { "item": "knife_combat", "container-item": "sheath" },
           { "item": "neo_laser_pistol_ups", "container-item": "XL_holster" }
         ]
       }

--- a/nocts_cata_mod_DDA/Char_creation/c_classes_bw.json
+++ b/nocts_cata_mod_DDA/Char_creation/c_classes_bw.json
@@ -503,10 +503,8 @@
     "traits": [
       "SUPER_SOLDIER_MARKER",
       "THRESH_SUPER_SOLDIER",
-      "SENTINEL_PERK_PER",
-      "SENTINEL_PERK_INT",
-      "SENTINEL_STAT_PER_2",
-      "SENTINEL_STAT_INT_2"
+      "SENTINEL_PERK_PER_2",
+      "SENTINEL_PERK_INT_2"
     ],
     "skills": [
       { "level": 5, "name": "electronics" },

--- a/nocts_cata_mod_DDA/Char_creation/c_classes_bw.json
+++ b/nocts_cata_mod_DDA/Char_creation/c_classes_bw.json
@@ -368,34 +368,35 @@
       "bio_metabolics",
       "bio_nanobots",
       "bio_painkiller",
-      "bio_flashlight",
+      "bio_night_vision",
       "bio_purifier",
       "bio_shock",
       "bio_targeting",
       "bio_ups",
       "bio_power_storage_mkII",
       "bio_power_storage_mkII",
-      "bio_power_storage_mkII",
-      "bio_power_storage_mkII"
+	  "bio_str_enhancer",
+	  "bio_dex_enhancer",
+	  "bio_eye_enhancer",
+	  "bio_int_enhancer",
+	  "bio_speed"
     ],
-    "traits": [ "SUPER_SOLDIER_MARKER", "THRESH_SUPER_SOLDIER", "SENTINEL_PERK_STR", "SENTINEL_PERK_DEX_2" ],
+    "traits": [ "SUPER_SOLDIER_MARKER", "THRESH_SUPER_SOLDIER", "SENTINEL_PERK_STR", "SENTINEL_PERK_DEX", "SENTINEL_PERK_PER", "SENTINEL_PERK_INT", "SENTINEL_STAT_STR", "SENTINEL_STAT_DEX", "SENTINEL_STAT_PER", "SENTINEL_STAT_INT" ],
     "skills": [
       { "level": 3, "name": "gun" },
       { "level": 3, "name": "rifle" },
+      { "level": 3, "name": "pistol" },
       { "level": 3, "name": "melee" },
       { "level": 3, "name": "unarmed" },
       { "level": 3, "name": "cutting" },
-      { "level": 3, "name": "stabbing" },
-      { "level": 3, "name": "bashing" },
       { "level": 3, "name": "dodge" }
     ],
     "items": {
       "both": {
-        "items": [ "helmet_liner", "thermal_shirt", "gloves_liner", "under_armor_shorts", "socks", "mil_armor", "molle_pack", "ifak" ],
+        "items": [ "helmet_liner", "thermal_shirt", "gloves_liner", "under_armor_shorts", "socks", "mil_armor", "molle_pack" ],
         "entries": [
           { "item": "arc_laser_rifle", "ammo-item": "battery", "charges": 5000, "contents-item": "shoulder_strap" },
-          { "item": "neo_laser_pistol_ups", "container-item": "holster" },
-          { "item": "knife_combat", "container-item": "sheath" }
+          { "item": "neo_laser_pistol_ups", "container-item": "holster" }
         ]
       }
     },
@@ -415,25 +416,27 @@
       "bio_nanobots",
       "bio_night_vision",
       "bio_recycler",
+	  "bio_digestion",
       "bio_targeting",
       "bio_torsionratchet",
       "bio_ups",
       "bio_power_storage_mkII",
       "bio_power_storage_mkII",
-      "bio_power_storage_mkII",
-      "bio_power_storage_mkII"
+	  "bio_eye_enhancer",
+	  "bio_dex_enhancer"
     ],
-    "traits": [ "SUPER_SOLDIER_MARKER", "THRESH_SUPER_SOLDIER", "SENTINEL_PERK_DEX", "SENTINEL_PERK_PER_2" ],
+    "traits": [ "SUPER_SOLDIER_MARKER", "THRESH_SUPER_SOLDIER", "SENTINEL_STAT_DEX_2", "SENTINEL_STAT_PER_2", "SENTINEL_PERK_DEX", "SENTINEL_PERK_PER_2" ],
     "skills": [
       { "level": 5, "name": "gun" },
-      { "level": 5, "name": "rifle" },
-      { "level": 3, "name": "melee" },
-      { "level": 3, "name": "stabbing" },
+      { "level": 4, "name": "rifle" },
       { "level": 3, "name": "survival" },
       { "level": 3, "name": "fabrication" },
       { "level": 3, "name": "cooking" },
-      { "level": 3, "name": "tailor" },
-      { "level": 3, "name": "swimming" }
+      { "level": 2, "name": "tailor" },
+      { "level": 2, "name": "swimming" },
+      { "level": 2, "name": "pistol" },
+      { "level": 2, "name": "melee" },
+      { "level": 2, "name": "stabbing" }
     ],
     "items": {
       "both": {
@@ -447,7 +450,7 @@
           "rucksack",
           "dump_pouch",
           "2lcanteen",
-          "ifak",
+          "mil_mess_kit",
           "e_tool",
           "mre_beef_box",
           "militarymap",
@@ -455,7 +458,6 @@
           "rollmat"
         ],
         "entries": [
-          { "item": "medium_plus_battery_cell", "ammo-item": "battery", "charges": 600, "container-item": "mil_mess_kit" },
           { "item": "mx_laser_sniper", "ammo-item": "battery", "charges": 5000, "contents-item": "shoulder_strap" },
           { "item": "neo_laser_pistol_ups", "container-item": "holster" },
           { "item": "knife_combat", "container-item": "sheath" }
@@ -472,30 +474,30 @@
     "points": 12,
     "CBMs": [
       "bio_batteries",
-      "bio_carbon",
-      "bio_ears",
       "bio_emp_armgun",
       "bio_flashlight",
       "bio_memory",
       "bio_nanobots",
+      "bio_painkiller",
       "bio_sunglasses",
       "bio_tools",
       "bio_ups",
       "bio_watch",
       "bio_power_storage_mkII",
       "bio_power_storage_mkII",
-      "bio_power_storage_mkII",
-      "bio_power_storage_mkII"
+	  "bio_eye_enhancer",
+	  "bio_int_enhancer"
     ],
-    "traits": [ "SUPER_SOLDIER_MARKER", "THRESH_SUPER_SOLDIER", "SENTINEL_PERK_PER", "SENTINEL_PERK_INT_2" ],
+    "traits": [ "SUPER_SOLDIER_MARKER", "THRESH_SUPER_SOLDIER", "SENTINEL_PERK_PER", "SENTINEL_PERK_INT", "SENTINEL_STAT_PER_2", "SENTINEL_STAT_INT_2" ],
     "skills": [
       { "level": 5, "name": "electronics" },
-      { "level": 5, "name": "mechanics" },
-      { "level": 5, "name": "chemistry" },
-      { "level": 5, "name": "firstaid" },
-      { "level": 5, "name": "fabrication" },
-      { "level": 3, "name": "pistol" },
-      { "level": 3, "name": "gun" }
+      { "level": 5, "name": "cooking" },
+      { "level": 4, "name": "mechanics" },
+      { "level": 4, "name": "firstaid" },
+      { "level": 4, "name": "fabrication" },
+      { "level": 3, "name": "gun" },
+      { "level": 2, "name": "pistol" },
+      { "level": 2, "name": "smg" }
     ],
     "items": {
       "both": {
@@ -507,14 +509,12 @@
           "socks",
           "lmil_armor",
           "molle_pack",
-          "ifak",
-          "id_science"
+          "id_science",
+          "chemistry_set"
         ],
         "entries": [
-          { "item": "medium_battery_cell", "ammo-item": "battery", "charges": 500, "container-item": "chemistry_set" },
           { "item": "akro_laser_smg", "ammo-item": "battery", "charges": 1000, "contents-item": "shoulder_strap" },
-          { "item": "neo_laser_pistol_ups", "container-item": "holster" },
-          { "item": "knife_combat", "container-item": "sheath" }
+          { "item": "neo_laser_pistol_ups", "container-item": "holster" }
         ]
       }
     },
@@ -537,43 +537,32 @@
       "bio_painkiller",
       "bio_power_armor_interface_mkII",
       "bio_purifier",
-      "bio_radscrubber",
       "bio_sunglasses",
+      "bio_ears",
+      "bio_carbon",
       "bio_sword",
       "bio_targeting",
       "bio_ups",
       "bio_power_storage_mkII",
       "bio_power_storage_mkII",
-      "bio_power_storage_mkII",
-      "bio_power_storage_mkII"
+	  "bio_str_enhancer",
+	  "bio_dex_enhancer"
     ],
-    "traits": [ "SUPER_SOLDIER_MARKER", "THRESH_SUPER_SOLDIER", "SENTINEL_PERK_STR_2", "SENTINEL_PERK_INT" ],
+    "traits": [ "SUPER_SOLDIER_MARKER", "THRESH_SUPER_SOLDIER", "SENTINEL_PERK_STR", "SENTINEL_PERK_DEX", "SENTINEL_STAT_STR_2", "SENTINEL_STAT_DEX_2" ],
     "skills": [
       { "level": 3, "name": "gun" },
       { "level": 3, "name": "rifle" },
-      { "level": 5, "name": "melee" },
-      { "level": 5, "name": "cutting" },
-      { "level": 5, "name": "bashing" },
-      { "level": 5, "name": "stabbing" },
-      { "level": 5, "name": "dodge" }
+      { "level": 3, "name": "melee" },
+      { "level": 3, "name": "cutting" },
+      { "level": 3, "name": "bashing" },
+      { "level": 3, "name": "stabbing" },
+      { "level": 3, "name": "dodge" }
     ],
     "items": {
       "both": {
-        "items": [
-          "helmet_liner",
-          "thermal_shirt",
-          "gloves_liner",
-          "under_armor_shorts",
-          "socks",
-          "mil_armor",
-          "vest",
-          "dump_pouch",
-          "ifak"
-        ],
+        "items": [ "helmet_liner", "thermal_shirt", "gloves_liner", "under_armor_shorts", "socks", "hmil_armor" ],
         "entries": [
-          { "item": "krx_laser_lmg", "ammo-item": "battery", "charges": 10000, "contents-item": "shoulder_strap" },
-          { "item": "neo_laser_pistol_ups", "container-item": "holster" },
-          { "item": "knife_combat", "container-item": "sheath" }
+          { "item": "krx_laser_lmg", "ammo-item": "battery", "charges": 10000, "contents-item": "shoulder_strap" }
         ]
       }
     },

--- a/nocts_cata_mod_DDA/Char_creation/c_classes_bw.json
+++ b/nocts_cata_mod_DDA/Char_creation/c_classes_bw.json
@@ -387,11 +387,7 @@
       "SENTINEL_PERK_STR",
       "SENTINEL_PERK_DEX",
       "SENTINEL_PERK_PER",
-      "SENTINEL_PERK_INT",
-      "SENTINEL_STAT_STR",
-      "SENTINEL_STAT_DEX",
-      "SENTINEL_STAT_PER",
-      "SENTINEL_STAT_INT"
+      "SENTINEL_PERK_INT"
     ],
     "skills": [
       { "level": 3, "name": "gun" },

--- a/nocts_cata_mod_DDA/Char_creation/c_classes_bw.json
+++ b/nocts_cata_mod_DDA/Char_creation/c_classes_bw.json
@@ -568,10 +568,8 @@
     "traits": [
       "SUPER_SOLDIER_MARKER",
       "THRESH_SUPER_SOLDIER",
-      "SENTINEL_PERK_STR",
-      "SENTINEL_PERK_DEX",
-      "SENTINEL_STAT_STR_2",
-      "SENTINEL_STAT_DEX_2"
+      "SENTINEL_PERK_STR_2",
+      "SENTINEL_PERK_DEX_2"
     ],
     "skills": [
       { "level": 3, "name": "gun" },

--- a/nocts_cata_mod_DDA/Char_creation/c_classes_bw.json
+++ b/nocts_cata_mod_DDA/Char_creation/c_classes_bw.json
@@ -407,7 +407,7 @@
         "items": [ "helmet_liner", "thermal_shirt", "gloves_liner", "under_armor_shorts", "socks", "mil_armor", "molle_pack" ],
         "entries": [
           { "item": "arc_laser_rifle", "ammo-item": "battery", "charges": 5000, "contents-item": "shoulder_strap" },
-          { "item": "neo_laser_pistol_ups", "container-item": "holster" }
+          { "item": "neo_laser_pistol_ups", "container-item": "XL_holster" }
         ]
       }
     },
@@ -477,7 +477,7 @@
         ],
         "entries": [
           { "item": "mx_laser_sniper", "ammo-item": "battery", "charges": 5000, "contents-item": "shoulder_strap" },
-          { "item": "neo_laser_pistol_ups", "container-item": "holster" },
+          { "item": "neo_laser_pistol_ups", "container-item": "XL_holster" },
           { "item": "knife_combat", "container-item": "sheath" }
         ]
       }
@@ -539,7 +539,7 @@
         ],
         "entries": [
           { "item": "akro_laser_smg", "ammo-item": "battery", "charges": 1000, "contents-item": "shoulder_strap" },
-          { "item": "neo_laser_pistol_ups", "container-item": "holster" }
+          { "item": "neo_laser_pistol_ups", "container-item": "XL_holster" }
         ]
       }
     },

--- a/nocts_cata_mod_DDA/Char_creation/c_classes_bw.json
+++ b/nocts_cata_mod_DDA/Char_creation/c_classes_bw.json
@@ -396,6 +396,7 @@
       { "level": 3, "name": "melee" },
       { "level": 3, "name": "unarmed" },
       { "level": 3, "name": "cutting" },
+      { "level": 3, "name": "stabbing" },
       { "level": 3, "name": "dodge" }
     ],
     "items": {
@@ -515,7 +516,9 @@
       { "level": 4, "name": "fabrication" },
       { "level": 3, "name": "gun" },
       { "level": 2, "name": "pistol" },
-      { "level": 2, "name": "smg" }
+      { "level": 2, "name": "smg" },
+      { "level": 2, "name": "melee" },
+      { "level": 2, "name": "stabbing" }
     ],
     "items": {
       "both": {

--- a/nocts_cata_mod_DDA/Char_creation/c_classes_bw.json
+++ b/nocts_cata_mod_DDA/Char_creation/c_classes_bw.json
@@ -583,7 +583,7 @@
     "items": {
       "both": {
         "items": [ "helmet_liner", "thermal_shirt", "gloves_liner", "under_armor_shorts", "socks", "hmil_armor" ],
-        "entries": [ { "item": "krx_laser_lmg", "ammo-item": "battery", "charges": 10000, "contents-item": "shoulder_strap" } ]
+        "entries": [ { "item": "krx_laser_lmg", "ammo-item": "battery", "charges": 10000, "contents-item": "shoulder_strap" }, { "item": "knife_combat", "container-item": "sheath" } ]
       }
     },
     "flags": [ "SCEN_ONLY" ]

--- a/nocts_cata_mod_DDA/Char_creation/c_classes_bw.json
+++ b/nocts_cata_mod_DDA/Char_creation/c_classes_bw.json
@@ -375,13 +375,24 @@
       "bio_ups",
       "bio_power_storage_mkII",
       "bio_power_storage_mkII",
-	  "bio_str_enhancer",
-	  "bio_dex_enhancer",
-	  "bio_eye_enhancer",
-	  "bio_int_enhancer",
-	  "bio_speed"
+      "bio_str_enhancer",
+      "bio_dex_enhancer",
+      "bio_eye_enhancer",
+      "bio_int_enhancer",
+      "bio_speed"
     ],
-    "traits": [ "SUPER_SOLDIER_MARKER", "THRESH_SUPER_SOLDIER", "SENTINEL_PERK_STR", "SENTINEL_PERK_DEX", "SENTINEL_PERK_PER", "SENTINEL_PERK_INT", "SENTINEL_STAT_STR", "SENTINEL_STAT_DEX", "SENTINEL_STAT_PER", "SENTINEL_STAT_INT" ],
+    "traits": [
+      "SUPER_SOLDIER_MARKER",
+      "THRESH_SUPER_SOLDIER",
+      "SENTINEL_PERK_STR",
+      "SENTINEL_PERK_DEX",
+      "SENTINEL_PERK_PER",
+      "SENTINEL_PERK_INT",
+      "SENTINEL_STAT_STR",
+      "SENTINEL_STAT_DEX",
+      "SENTINEL_STAT_PER",
+      "SENTINEL_STAT_INT"
+    ],
     "skills": [
       { "level": 3, "name": "gun" },
       { "level": 3, "name": "rifle" },
@@ -416,16 +427,23 @@
       "bio_nanobots",
       "bio_night_vision",
       "bio_recycler",
-	  "bio_digestion",
+      "bio_digestion",
       "bio_targeting",
       "bio_torsionratchet",
       "bio_ups",
       "bio_power_storage_mkII",
       "bio_power_storage_mkII",
-	  "bio_eye_enhancer",
-	  "bio_dex_enhancer"
+      "bio_eye_enhancer",
+      "bio_dex_enhancer"
     ],
-    "traits": [ "SUPER_SOLDIER_MARKER", "THRESH_SUPER_SOLDIER", "SENTINEL_STAT_DEX_2", "SENTINEL_STAT_PER_2", "SENTINEL_PERK_DEX", "SENTINEL_PERK_PER_2" ],
+    "traits": [
+      "SUPER_SOLDIER_MARKER",
+      "THRESH_SUPER_SOLDIER",
+      "SENTINEL_STAT_DEX_2",
+      "SENTINEL_STAT_PER_2",
+      "SENTINEL_PERK_DEX",
+      "SENTINEL_PERK_PER_2"
+    ],
     "skills": [
       { "level": 5, "name": "gun" },
       { "level": 4, "name": "rifle" },
@@ -485,10 +503,17 @@
       "bio_watch",
       "bio_power_storage_mkII",
       "bio_power_storage_mkII",
-	  "bio_eye_enhancer",
-	  "bio_int_enhancer"
+      "bio_eye_enhancer",
+      "bio_int_enhancer"
     ],
-    "traits": [ "SUPER_SOLDIER_MARKER", "THRESH_SUPER_SOLDIER", "SENTINEL_PERK_PER", "SENTINEL_PERK_INT", "SENTINEL_STAT_PER_2", "SENTINEL_STAT_INT_2" ],
+    "traits": [
+      "SUPER_SOLDIER_MARKER",
+      "THRESH_SUPER_SOLDIER",
+      "SENTINEL_PERK_PER",
+      "SENTINEL_PERK_INT",
+      "SENTINEL_STAT_PER_2",
+      "SENTINEL_STAT_INT_2"
+    ],
     "skills": [
       { "level": 5, "name": "electronics" },
       { "level": 5, "name": "cooking" },
@@ -545,10 +570,17 @@
       "bio_ups",
       "bio_power_storage_mkII",
       "bio_power_storage_mkII",
-	  "bio_str_enhancer",
-	  "bio_dex_enhancer"
+      "bio_str_enhancer",
+      "bio_dex_enhancer"
     ],
-    "traits": [ "SUPER_SOLDIER_MARKER", "THRESH_SUPER_SOLDIER", "SENTINEL_PERK_STR", "SENTINEL_PERK_DEX", "SENTINEL_STAT_STR_2", "SENTINEL_STAT_DEX_2" ],
+    "traits": [
+      "SUPER_SOLDIER_MARKER",
+      "THRESH_SUPER_SOLDIER",
+      "SENTINEL_PERK_STR",
+      "SENTINEL_PERK_DEX",
+      "SENTINEL_STAT_STR_2",
+      "SENTINEL_STAT_DEX_2"
+    ],
     "skills": [
       { "level": 3, "name": "gun" },
       { "level": 3, "name": "rifle" },
@@ -561,9 +593,7 @@
     "items": {
       "both": {
         "items": [ "helmet_liner", "thermal_shirt", "gloves_liner", "under_armor_shorts", "socks", "hmil_armor" ],
-        "entries": [
-          { "item": "krx_laser_lmg", "ammo-item": "battery", "charges": 10000, "contents-item": "shoulder_strap" }
-        ]
+        "entries": [ { "item": "krx_laser_lmg", "ammo-item": "battery", "charges": 10000, "contents-item": "shoulder_strap" } ]
       }
     },
     "flags": [ "SCEN_ONLY" ]


### PR DESCRIPTION
What was supposed to be a small set of changes to some missing things in PR #247 turned into changing various things to ensure the point cost was justified and the professions worth picking over other stuff apart form the unique dialogue and other stuff when doing NPC missions. Various things were taken into consideration like the fact you will be locked from all mutation trees since you start post-thresh in the Sentinel category, the fact the profession is dictated by the scenario choose and the fact they are for the most part filling specific niche which outside off they are no better than any other survivor. Things changed ended up being too various to list here but general idea was giving stat boost, removing irrelevant bionics and adding relevant ones, removing some items, balancing skill points, making the professions more niche by mutation selection.