### PR TITLE
Fixed scout suits not covering arms in DDA version

### DIFF
--- a/nocts_cata_mod_DDA/Surv_help/c_armor.json
+++ b/nocts_cata_mod_DDA/Surv_help/c_armor.json
@@ -39,7 +39,7 @@
     "material": [ "leather", "kevlar" ],
     "symbol": "[",
     "color": "brown",
-    "covers": [ "leg_l", "leg_r", "torso", "hand_l", "hand_r", "foot_l", "foot_r", "head" ],
+    "covers": [ "leg_l", "leg_r", "torso", "arm_l", "arm_r", "hand_l", "hand_r", "foot_l", "foot_r", "head" ],
     "coverage": 100,
     "encumbrance": 35,
     "pocket_data": [
@@ -99,7 +99,7 @@
     "material": [ "kevlar", "steel" ],
     "symbol": "[",
     "color": "brown",
-    "covers": [ "leg_l", "leg_r", "torso", "hand_l", "hand_r", "foot_l", "foot_r", "head" ],
+    "covers": [ "leg_l", "leg_r", "torso", "arm_l", "arm_r", "hand_l", "hand_r", "foot_l", "foot_r", "head" ],
     "coverage": 100,
     "encumbrance": 45,
     "pocket_data": [


### PR DESCRIPTION
Whoops, easy enough to fix.

Fixes https://github.com/Noctifer-de-Mortem/nocts_cata_mod/issues/252