### PR TITLE
Mod inter-compatability additions

### DIFF
--- a/nocts_cata_mod_BN/Monsters/c_monstergroups_modcompat.json
+++ b/nocts_cata_mod_BN/Monsters/c_monstergroups_modcompat.json
@@ -1,0 +1,45 @@
+[
+  {
+    "name": "GROUP_DOOMLAB",
+    "type": "monstergroup",
+    "default": "mon_null",
+    "override": false,
+    "auto_total": true,
+    "monsters": [
+      { "monster": "mon_failed_weapon", "freq": 4, "cost_multiplier": 80 },
+      { "monster": "mon_zombie_failed_weapon", "freq": 4, "cost_multiplier": 30 },
+      { "monster": "mon_zombie_bio_dormant_unarmed", "freq": 20, "cost_multiplier": 15 },
+      { "monster": "mon_zombie_bio_dormant_armed", "freq": 20, "cost_multiplier": 15 }
+    ]
+  },
+  {
+    "name": "GROUP_SLUDGE",
+    "type": "monstergroup",
+    "default": "mon_null",
+    "override": false,
+    "auto_total": true,
+    "monsters": [
+      { "monster": "mon_failed_weapon", "freq": 20, "cost_multiplier": 20 },
+      { "monster": "mon_zombie_failed_weapon", "freq": 20, "cost_multiplier": 20 }
+    ]
+  },
+  {
+    "name": "GROUP_ZOMBIE_MID",
+    "type": "monstergroup",
+    "//": "This is obsolete in standard Cataclysm but used in PK's Rebalancing for some things.",
+    "default": "mon_null",
+    "override": false,
+    "auto_total": true,
+    "monsters": [
+      { "monster": "mon_failed_weapon", "freq": 1, "cost_multiplier": 80 },
+      { "monster": "mon_zombie_failed_weapon", "freq": 1, "cost_multiplier": 30 },
+      { "monster": "mon_zombie_bio_knife", "freq": 1, "cost_multiplier": 15 },
+      { "monster": "mon_zombie_bio_infantry_shotgun", "freq": 1, "cost_multiplier": 15 },
+      { "monster": "mon_zombie_bio_knight_lmg", "freq": 1, "cost_multiplier": 15 },
+      { "monster": "mon_zombie_bio_knight_lauhcher", "freq": 1, "cost_multiplier": 15 },
+      { "monster": "mon_zombie_bio_scout_sniper", "freq": 1, "cost_multiplier": 15 },
+      { "monster": "mon_zombie_bio_tool_pistol", "freq": 1, "cost_multiplier": 15 },
+      { "monster": "mon_zombie_bio_tool_smg", "freq": 1, "cost_multiplier": 15 }
+    ]
+  }
+]

--- a/nocts_cata_mod_BN/Surv_help/c_item_groups_modcompat.json
+++ b/nocts_cata_mod_BN/Surv_help/c_item_groups_modcompat.json
@@ -1,0 +1,79 @@
+[
+  {
+    "id": "chalice_cult_books",
+    "type": "item_group",
+    "items": [ { "group": "encylopedias_rare", "prob": 5 } ]
+  },
+  {
+    "id": "cleansing_flame_books",
+    "type": "item_group",
+    "items": [ { "group": "encylopedias_rare", "prob": 5 } ]
+  },
+  {
+    "id": "sanguine_cult_books",
+    "type": "item_group",
+    "items": [ { "group": "encylopedias_rare", "prob": 5 } ]
+  },
+  {
+    "id": "unaligned_arcanist_books",
+    "type": "item_group",
+    "items": [ { "group": "encylopedias_rare", "prob": 5 } ]
+  },
+  {
+    "id": "reading_lights",
+    "type": "item_group",
+    "items": [ [ "solar_flashlight", 5 ] ]
+  },
+  {
+    "id": "lab_magitech_weaponry",
+    "type": "item_group",
+    "items": [ [ "flesh_knife", 2 ], [ "flesh_pistol", 2 ], [ "flesh_weapon_kit", 1 ] ]
+  },
+  {
+    "id": "lab_magitech_other",
+    "type": "item_group",
+    "items": [ { "group": "arcana_cataplus_misc_magitech", "prob": 5 } ]
+  },
+  {
+    "id": "arcana_cataplus_misc_magitech",
+    "//": "This is just to ensure that all misc anomalous Cata++ items only have acombined weight of 5 in the itemgroup they're being injected into.",
+    "type": "item_group",
+    "items": [
+      [ "megamap", 1 ],
+      [ "stim", 1 ],
+      [ "boots_stealth", 1 ],
+      [ "acs_74_stealth_cloak_on", 1 ],
+      [ "goggles_nv_clairvoyance", 1 ],
+      [ "blood_m", 1 ],
+      [ "blood_p", 1 ]
+    ]
+  },
+  {
+    "id": "pk_melee",
+    "type": "item_group",
+    "items": [ [ "elc_bld", 2 ], [ "elc_blds", 1 ] ]
+  },
+  {
+    "id": "doom_stimpack",
+    "type": "item_group",
+    "items": [ [ "stim", 1 ] ]
+  },
+  {
+    "id": "doom_lootpack",
+    "type": "item_group",
+    "items": [
+      [ "stim", 5 ],
+      [ "blood_m", 1 ],
+      [ "blood_p", 1 ],
+      [ "lmil_armor", 5 ],
+      [ "mil_armor", 5 ],
+      [ "hmil_armor", 5 ],
+      [ "acs_74_stealth_cloak_on", 1 ]
+    ]
+  },
+  {
+    "id": "doom_armor",
+    "type": "item_group",
+    "items": [ [ "lmil_armor", 5 ], [ "mil_armor", 5 ], [ "hmil_armor", 5 ] ]
+  }
+]

--- a/nocts_cata_mod_DDA/Monsters/c_monstergroups_modcompat.json
+++ b/nocts_cata_mod_DDA/Monsters/c_monstergroups_modcompat.json
@@ -1,0 +1,45 @@
+[
+  {
+    "name": "GROUP_DOOMLAB",
+    "type": "monstergroup",
+    "default": "mon_null",
+    "override": false,
+    "auto_total": true,
+    "monsters": [
+      { "monster": "mon_failed_weapon", "freq": 4, "cost_multiplier": 80 },
+      { "monster": "mon_zombie_failed_weapon", "freq": 4, "cost_multiplier": 30 },
+      { "monster": "mon_zombie_bio_dormant_unarmed", "freq": 20, "cost_multiplier": 15 },
+      { "monster": "mon_zombie_bio_dormant_armed", "freq": 20, "cost_multiplier": 15 }
+    ]
+  },
+  {
+    "name": "GROUP_SLUDGE",
+    "type": "monstergroup",
+    "default": "mon_null",
+    "override": false,
+    "auto_total": true,
+    "monsters": [
+      { "monster": "mon_failed_weapon", "freq": 20, "cost_multiplier": 20 },
+      { "monster": "mon_zombie_failed_weapon", "freq": 20, "cost_multiplier": 20 }
+    ]
+  },
+  {
+    "name": "GROUP_ZOMBIE_MID",
+    "type": "monstergroup",
+    "//": "This is obsolete in standard Cataclysm but used in PK's Rebalancing for some things.",
+    "default": "mon_null",
+    "override": false,
+    "auto_total": true,
+    "monsters": [
+      { "monster": "mon_failed_weapon", "freq": 1, "cost_multiplier": 80 },
+      { "monster": "mon_zombie_failed_weapon", "freq": 1, "cost_multiplier": 30 },
+      { "monster": "mon_zombie_bio_knife", "freq": 1, "cost_multiplier": 15 },
+      { "monster": "mon_zombie_bio_infantry_shotgun", "freq": 1, "cost_multiplier": 15 },
+      { "monster": "mon_zombie_bio_knight_lmg", "freq": 1, "cost_multiplier": 15 },
+      { "monster": "mon_zombie_bio_knight_lauhcher", "freq": 1, "cost_multiplier": 15 },
+      { "monster": "mon_zombie_bio_scout_sniper", "freq": 1, "cost_multiplier": 15 },
+      { "monster": "mon_zombie_bio_tool_pistol", "freq": 1, "cost_multiplier": 15 },
+      { "monster": "mon_zombie_bio_tool_smg", "freq": 1, "cost_multiplier": 15 }
+    ]
+  }
+]

--- a/nocts_cata_mod_DDA/Surv_help/c_item_groups_modcompat.json
+++ b/nocts_cata_mod_DDA/Surv_help/c_item_groups_modcompat.json
@@ -1,0 +1,79 @@
+[
+  {
+    "id": "chalice_cult_books",
+    "type": "item_group",
+    "items": [ { "group": "encylopedias_rare", "prob": 5 } ]
+  },
+  {
+    "id": "cleansing_flame_books",
+    "type": "item_group",
+    "items": [ { "group": "encylopedias_rare", "prob": 5 } ]
+  },
+  {
+    "id": "sanguine_cult_books",
+    "type": "item_group",
+    "items": [ { "group": "encylopedias_rare", "prob": 5 } ]
+  },
+  {
+    "id": "unaligned_arcanist_books",
+    "type": "item_group",
+    "items": [ { "group": "encylopedias_rare", "prob": 5 } ]
+  },
+  {
+    "id": "reading_lights",
+    "type": "item_group",
+    "items": [ [ "solar_flashlight", 5 ] ]
+  },
+  {
+    "id": "lab_magitech_weaponry",
+    "type": "item_group",
+    "items": [ [ "flesh_knife", 2 ], [ "flesh_pistol", 2 ], [ "flesh_weapon_kit", 1 ] ]
+  },
+  {
+    "id": "lab_magitech_other",
+    "type": "item_group",
+    "items": [ { "group": "arcana_cataplus_misc_magitech", "prob": 5 } ]
+  },
+  {
+    "id": "arcana_cataplus_misc_magitech",
+    "//": "This is just to ensure that all misc anomalous Cata++ items only have acombined weight of 5 in the itemgroup they're being injected into.",
+    "type": "item_group",
+    "items": [
+      [ "megamap", 1 ],
+      [ "stim", 1 ],
+      [ "boots_stealth", 1 ],
+      [ "acs_74_stealth_cloak_on", 1 ],
+      [ "goggles_nv_clairvoyance", 1 ],
+      [ "blood_m", 1 ],
+      [ "blood_p", 1 ]
+    ]
+  },
+  {
+    "id": "pk_melee",
+    "type": "item_group",
+    "items": [ [ "elc_bld", 2 ], [ "elc_blds", 1 ] ]
+  },
+  {
+    "id": "doom_stimpack",
+    "type": "item_group",
+    "items": [ [ "stim", 1 ] ]
+  },
+  {
+    "id": "doom_lootpack",
+    "type": "item_group",
+    "items": [
+      [ "stim", 5 ],
+      [ "blood_m", 1 ],
+      [ "blood_p", 1 ],
+      [ "lmil_armor", 5 ],
+      [ "mil_armor", 5 ],
+      [ "hmil_armor", 5 ],
+      [ "acs_74_stealth_cloak_on", 1 ]
+    ]
+  },
+  {
+    "id": "doom_armor",
+    "type": "item_group",
+    "items": [ [ "lmil_armor", 5 ], [ "mil_armor", 5 ], [ "hmil_armor", 5 ] ]
+  }
+]


### PR DESCRIPTION
Adds monster and itemgroup entries that inject Cata++ items into certain parts of other third-party mods, in particular Arcana and PK's Rebalancing. For the latter especially, the monstergroup additions were weighted roughly to mimic the most recent known version of the PK/Cata++ monstergroup patch, which should thus render it no longer necessary.