### PR TITLE
Remove mod-compat monstergroups from DDA version

### DIFF
--- a/nocts_cata_mod_DDA/Monsters/c_monstergroups_modcompat.json
+++ b/nocts_cata_mod_DDA/Monsters/c_monstergroups_modcompat.json
@@ -1,29 +1,5 @@
 [
   {
-    "name": "GROUP_DOOMLAB",
-    "type": "monstergroup",
-    "default": "mon_null",
-    "override": false,
-    "auto_total": true,
-    "monsters": [
-      { "monster": "mon_failed_weapon", "freq": 4, "cost_multiplier": 80 },
-      { "monster": "mon_zombie_failed_weapon", "freq": 4, "cost_multiplier": 30 },
-      { "monster": "mon_zombie_bio_dormant_unarmed", "freq": 20, "cost_multiplier": 15 },
-      { "monster": "mon_zombie_bio_dormant_armed", "freq": 20, "cost_multiplier": 15 }
-    ]
-  },
-  {
-    "name": "GROUP_SLUDGE",
-    "type": "monstergroup",
-    "default": "mon_null",
-    "override": false,
-    "auto_total": true,
-    "monsters": [
-      { "monster": "mon_failed_weapon", "freq": 20, "cost_multiplier": 20 },
-      { "monster": "mon_zombie_failed_weapon", "freq": 20, "cost_multiplier": 20 }
-    ]
-  },
-  {
     "name": "GROUP_ZOMBIE_MID",
     "type": "monstergroup",
     "//": "This is obsolete in standard Cataclysm but used in PK's Rebalancing for some things.",


### PR DESCRIPTION
As usual, we can't have nice things in DDA. Defining a non-overriding monstergroup for monstergroups only defined by other mods works fine in the BN version, but creates two skippable load errors in the DDA version.

Closes https://github.com/Noctifer-de-Mortem/nocts_cata_mod/issues/255