### PR TITLE
Buff Encumberance on Scout Suits

### DIFF
--- a/nocts_cata_mod_DDA/Surv_help/c_armor.json
+++ b/nocts_cata_mod_DDA/Surv_help/c_armor.json
@@ -41,7 +41,7 @@
     "color": "brown",
     "covers": [ "leg_l", "leg_r", "torso", "arm_l", "arm_r", "hand_l", "hand_r", "foot_l", "foot_r", "head" ],
     "coverage": 100,
-    "encumbrance": 35,
+    "encumbrance": 25,
     "pocket_data": [
       { "pocket_type": "CONTAINER", "max_contains_volume": "2 L", "max_contains_weight": "6 kg", "moves": 80 },
       { "pocket_type": "CONTAINER", "max_contains_volume": "2 L", "max_contains_weight": "6 kg", "moves": 80 },
@@ -101,7 +101,7 @@
     "color": "brown",
     "covers": [ "leg_l", "leg_r", "torso", "arm_l", "arm_r", "hand_l", "hand_r", "foot_l", "foot_r", "head" ],
     "coverage": 100,
-    "encumbrance": 45,
+    "encumbrance": 35,
     "pocket_data": [
       { "pocket_type": "CONTAINER", "max_contains_volume": "2 L", "max_contains_weight": "6 kg", "moves": 80 },
       { "pocket_type": "CONTAINER", "max_contains_volume": "2 L", "max_contains_weight": "6 kg", "moves": 80 },


### PR DESCRIPTION
Based on my math, the Survivor scout suit is still 3 times as encumbering as the AEP suit, the Survivor Armored Scout is as encumbering as the ANBC suit, and both are about about 5 times as encumbering when full of items. I think this makes more sense in vanilla balance, and allows the suits to be melee viable. I look forward to hearing any sort of response to this proposal.