### PR TITLE
Fix weird issue with flamethowers

### DIFF
--- a/nocts_cata_mod_BN/Weapons/c_mods.json
+++ b/nocts_cata_mod_BN/Weapons/c_mods.json
@@ -21,7 +21,7 @@
       "dispersion": 600,
       "range": 2,
       "durability": 7,
-      "reload": 500,
+      "reload": 4,
       "clip_size": 250
     },
     "min_skills": [ [ "weapon", 2 ], [ "launcher", 1 ] ],

--- a/nocts_cata_mod_BN/Weapons/c_ranged.json
+++ b/nocts_cata_mod_BN/Weapons/c_ranged.json
@@ -1596,7 +1596,7 @@
     "dispersion": 450,
     "durability": 7,
     "clip_size": 1500,
-    "reload": 2000,
+    "reload": 4,
     "valid_mod_locations": [
       [ "accessories", 1 ],
       [ "grip", 1 ],

--- a/nocts_cata_mod_DDA/Weapons/c_mods.json
+++ b/nocts_cata_mod_DDA/Weapons/c_mods.json
@@ -21,7 +21,7 @@
       "dispersion": 600,
       "range": 2,
       "durability": 7,
-      "reload": 500,
+      "reload": 4,
       "clip_size": 250,
       "ammo_to_fire": 50
     },

--- a/nocts_cata_mod_DDA/Weapons/c_ranged.json
+++ b/nocts_cata_mod_DDA/Weapons/c_ranged.json
@@ -1772,7 +1772,7 @@
         "ammo_restriction": { "diesel": 1500, "gasoline": 1500, "flammable": 1500, "lamp_oil": 1500, "motor_oil": 1500, "jp8": 1500, "avgas": 1500 }
       }
     ],
-    "reload": 2000,
+    "reload": 4,
     "valid_mod_locations": [
       [ "accessories", 1 ],
       [ "grip", 1 ],


### PR DESCRIPTION
Turns out that the survivor's flamethrowers were treating the reload time in the same way that magazines treat reload time, despite having an internal magazine. So instead of taking a fixed 20 seconds to reload the whole thing at once, its base reload rate was 20 seconds per single unit of fuel loaded, and with it holding 1500 units of fuel...

Fixed it to be only slightly slower than reloading a vanilla pressurized fuel tank, though combined with its lower capacity it'll still work out to a comparable reload rate (and retaining the disadvantage of being unable to simply swap tanks).