### PR TITLE
Bugfixes for scout's tool

### DIFF
--- a/nocts_cata_mod_BN/Surv_help/c_tools.json
+++ b/nocts_cata_mod_BN/Surv_help/c_tools.json
@@ -603,6 +603,7 @@
     "to_hit": -1,
     "ammo": "battery",
     "charges_per_use": 250,
+    "max_charges": 250,
     "use_action": { "type": "cast_spell", "spell_id": "c_topographical_scan", "no_fail": true, "level": 0 },
     "artifact_data": { "charge_type": "ARTC_SOLAR" },
     "flags": [ "WATCH", "ALARMCLOCK", "RECHARGE", "NO_RELOAD", "NO_UNLOAD" ],

--- a/nocts_cata_mod_DDA/Surv_help/c_tools.json
+++ b/nocts_cata_mod_DDA/Surv_help/c_tools.json
@@ -626,7 +626,7 @@
     "use_action": { "type": "cast_spell", "spell_id": "c_topographical_scan", "no_fail": true, "level": 0 },
     "relic_data": { "charge_info": { "recharge_type": "solar_sunny", "time": "10 m", "regenerate_ammo": true } },
     "pocket_data": [ { "pocket_type": "MAGAZINE", "ammo_restriction": { "battery": 250 } } ],
-    "flags": [ "WATCH", "ALARMCLOCK", "RECHARGE" ],
+    "flags": [ "WATCH", "ALARMCLOCK", "RECHARGE", "NO_UNLOAD", "NO_RELOAD" ],
     "encumbrance": 1,
     "coverage": 1,
     "phase": "solid"


### PR DESCRIPTION
* Fixed the scout tool not charging in the BN version due to somehow having `max_charges` removed during a previous rework.
* Fixed accidentally forgetting `NO_RELOAD` and `NO_UNLOAD` for the scout's tool in the DDA version at some point.