### PR TITLE
JSON fixes for BN version

### DIFF
--- a/nocts_cata_mod_BN/Monsters/c_monster_override.json
+++ b/nocts_cata_mod_BN/Monsters/c_monster_override.json
@@ -47,7 +47,6 @@
     "morale": 100,
     "armor_bash": 14,
     "armor_cut": 16,
-    "armor_bullet": 13,
     "vision_day": 50,
     "revert_to_itype": "bot_laserturret",
     "special_attacks": [

--- a/nocts_cata_mod_BN/Monsters/c_monstergroups_modcompat.json
+++ b/nocts_cata_mod_BN/Monsters/c_monstergroups_modcompat.json
@@ -1,29 +1,5 @@
 [
   {
-    "name": "GROUP_DOOMLAB",
-    "type": "monstergroup",
-    "default": "mon_null",
-    "override": false,
-    "auto_total": true,
-    "monsters": [
-      { "monster": "mon_failed_weapon", "freq": 4, "cost_multiplier": 80 },
-      { "monster": "mon_zombie_failed_weapon", "freq": 4, "cost_multiplier": 30 },
-      { "monster": "mon_zombie_bio_dormant_unarmed", "freq": 20, "cost_multiplier": 15 },
-      { "monster": "mon_zombie_bio_dormant_armed", "freq": 20, "cost_multiplier": 15 }
-    ]
-  },
-  {
-    "name": "GROUP_SLUDGE",
-    "type": "monstergroup",
-    "default": "mon_null",
-    "override": false,
-    "auto_total": true,
-    "monsters": [
-      { "monster": "mon_failed_weapon", "freq": 20, "cost_multiplier": 20 },
-      { "monster": "mon_zombie_failed_weapon", "freq": 20, "cost_multiplier": 20 }
-    ]
-  },
-  {
     "name": "GROUP_ZOMBIE_MID",
     "type": "monstergroup",
     "//": "This is obsolete in standard Cataclysm but used in PK's Rebalancing for some things.",

--- a/nocts_cata_mod_BN/Mutations/c_bio_mutation.json
+++ b/nocts_cata_mod_BN/Mutations/c_bio_mutation.json
@@ -8,9 +8,7 @@
     "valid": false,
     "purifiable": false,
     "profession": true,
-    "fat_to_max_hp": 1.0,
-    "dodge_modifier": 1,
-    "stomach_size_multiplier": 2.5
+    "dodge_modifier": 1
   },
   {
     "type": "mutation",


### PR DESCRIPTION
* Had to remove the PK's Rebalancing monstergroup additions from the BN version to. My guess is the game does not actually yet support injecting monsters into a monstergroup unless it actually exists, and forcing them to count as an override would most likely break if combined with PK. Minor feature anyway, so oh well.
* Removed some JSON bits specific to the DDA version I accidentally left in the BN version.