### PR TITLE
Fix save/load breaking stealth cloak in DDA version

### DIFF
--- a/nocts_cata_mod_DDA/Surv_help/c_armor.json
+++ b/nocts_cata_mod_DDA/Surv_help/c_armor.json
@@ -233,15 +233,11 @@
   },
   {
     "id": "c_stealth_cloak",
-    "//": "This is obsolete and only retained here for the benefit of old saves, delete this once 0.F comes out.",
+    "//": "Reinstated for use because it turns out ench_effects called directly from relics is broken in DDA.",
     "type": "enchantment",
     "has": "WORN",
     "condition": "ALWAYS",
-    "values": [
-      { "value": "SPEED", "add": -20 },
-      { "value": "STRENGTH", "add": -4 },
-      { "value": "DEXTERITY", "add": -4 }
-    ],
+    "values": [ { "value": "SPEED", "add": -20 }, { "value": "STRENGTH", "add": -4 }, { "value": "DEXTERITY", "add": -4 } ],
     "ench_effects": [ { "effect": "invisibility", "intensity": 1 } ]
   },
   {
@@ -263,20 +259,7 @@
     "warmth": 15,
     "material_thickness": 1,
     "environmental_protection": 4,
-    "relic_data": {
-      "passive_effects": [
-        {
-          "has": "WORN",
-          "condition": "ALWAYS",
-          "values": [
-            { "value": "SPEED", "add": -20 },
-            { "value": "STRENGTH", "add": -4 },
-            { "value": "DEXTERITY", "add": -4 }
-          ],
-          "ench_effects": [ { "effect": "invisibility", "intensity": 1 } ]
-        }
-      ]
-    },
+    "relic_data": { "passive_effects": [ { "id": "c_stealth_cloak" } ] },
     "flags": [ "OVERSIZE", "HOOD", "WATERPROOF", "OUTER", "VARSIZE" ]
   },
   {


### PR DESCRIPTION
Reinstating the old enchantment seems to work fine, it's just that defining `ench_effects` directly in `relic_data` is evidently broken in the DDA version.

BN version seems to also work fine, most likely due to Olanti's fixes to relic code.

Fixes https://github.com/Noctifer-de-Mortem/nocts_cata_mod/issues/274

Root cause is whatever broken code is behind https://github.com/CleverRaven/Cataclysm-DDA/issues/49334