### PR TITLE
Gives fungal augmented abominations a separate monsterdrop itemgroup

### DIFF
--- a/nocts_cata_mod_BN/Monsters/c_monster_drops.json
+++ b/nocts_cata_mod_BN/Monsters/c_monster_drops.json
@@ -13,6 +13,27 @@
     ]
   },
   {
+    "id": "mon_fungus_failed_weapon_death_drops",
+    "type": "item_group",
+    "//": "Drops for fungal augmented abominations, secondary source of Marloss items.",
+    "subtype": "collection",
+    "entries": [
+      { "group": "weapon_hat", "damage": [ 1, 4 ] },
+      { "group": "weapon_suit", "damage": [ 1, 4 ] },
+      { "group": "weapon_badge", "damage": [ 0, 0 ] },
+      { "group": "weapom_feet", "damage": [ 1, 4 ] },
+      { "group": "bio_weapon_power", "damage": [ 0, 1 ], "prob": 25 },
+      {
+        "distribution": [
+          { "item": "marloss_berry", "prob": 50 },
+          { "item": "marloss_seed", "prob": 25 },
+          { "item": "marloss_gel", "prob": 25 }
+        ],
+        "prob": 25
+      }
+    ]
+  },
+  {
     "id": "apophis_bio_weapom_item",
     "type": "item_group",
     "//": "items of bio-weapon apophis",

--- a/nocts_cata_mod_BN/Monsters/c_monsters.json
+++ b/nocts_cata_mod_BN/Monsters/c_monsters.json
@@ -90,17 +90,7 @@
     "placate_triggers": [ "FIRE" ],
     "death_drops": "wild_bio_weapom_item",
     "death_function": [ "ACID", "NORMAL" ],
-    "flags": [
-      "SEES",
-      "HEARS",
-      "SMELLS",
-      "WARM",
-      "HUMAN",
-      "ELECTRIC",
-      "BASHES",
-      "PUSH_VEH",
-      "PATH_AVOID_DANGER_1"
-    ]
+    "flags": [ "SEES", "HEARS", "SMELLS", "WARM", "HUMAN", "ELECTRIC", "BASHES", "PUSH_VEH", "PATH_AVOID_DANGER_1" ]
   },
   {
     "id": "hulk_weapon",
@@ -223,20 +213,9 @@
     "anger_triggers": [ "FRIEND_DIED", "FRIEND_ATTACKED", "HURT", "STALK", "PLAYER_CLOSE" ],
     "fear_triggers": [ "FIRE" ],
     "placate_triggers": [ "PLAYER_WEAK" ],
-    "death_drops": "wild_bio_weapom_item",
+    "death_drops": "mon_fungus_failed_weapon_death_drops",
     "death_function": [ "ACID", "FUNGUS", "NORMAL" ],
-    "flags": [
-      "SEES",
-      "HEARS",
-      "SMELLS",
-      "STUMBLES",
-      "ELECTRIC",
-      "ATTACKMON",
-      "BASHES",
-      "PUSH_MON",
-      "PUSH_VEH",
-      "FILTHY"
-    ]
+    "flags": [ "SEES", "HEARS", "SMELLS", "STUMBLES", "ELECTRIC", "ATTACKMON", "BASHES", "PUSH_MON", "PUSH_VEH", "FILTHY" ]
   },
   {
     "id": "mon_zombie_bio_dormant_unarmed",
@@ -271,9 +250,7 @@
     "regenerates": 1,
     "regen_morale": true,
     "harvest": "CBM_SOLDAT_ZOMBIE_GENERIC",
-    "special_attacks": [
-      [ "GRAB", 10 ]
-    ],
+    "special_attacks": [ [ "GRAB", 10 ] ],
     "special_when_hit": [ "ZAPBACK", 60 ],
     "anger_triggers": [ "FRIEND_DIED", "FRIEND_ATTACKED", "HURT", "STALK", "PLAYER_CLOSE" ],
     "placate_triggers": [ "PLAYER_WEAK" ],
@@ -315,9 +292,7 @@
     "regenerates": 1,
     "regen_morale": true,
     "harvest": "CBM_SOLDAT_ZOMBIE_GENERIC",
-    "special_attacks": [
-      [ "GRAB", 10 ]
-    ],
+    "special_attacks": [ [ "GRAB", 10 ] ],
     "special_when_hit": [ "ZAPBACK", 60 ],
     "anger_triggers": [ "FRIEND_DIED", "FRIEND_ATTACKED", "HURT", "STALK", "PLAYER_CLOSE" ],
     "placate_triggers": [ "PLAYER_WEAK" ],
@@ -345,11 +320,7 @@
     "path_settings": { "max_dist": 20 },
     "vision_night": 20,
     "regenerates": 1,
-    "special_attacks": [
-      [ "GRAB", 10 ],
-      [ "BIO_OP_TAKEDOWN", 30 ],
-      [ "LUNGE", 20 ]
-    ],
+    "special_attacks": [ [ "GRAB", 10 ], [ "BIO_OP_TAKEDOWN", 30 ], [ "LUNGE", 20 ] ],
     "death_drops": "mon_zombie_bio_knife_death_drops",
     "flags": [ "SEES", "HEARS", "SMELLS", "POISON", "NO_BREATHE", "FILTHY", "PATH_AVOID_DANGER_1", "BLEED" ],
     "delete": { "upgrades": { "half_life": 28, "into": "mon_zombie_bio_knife" } }
@@ -617,7 +588,7 @@
       },
       [ "GRAB_DRAG", 10 ],
       [ "SMASH", 30 ],
-      { "id": "slam" }     
+      { "id": "slam" }
     ],
     "special_when_hit": [ "ZAPBACK", 60 ],
     "anger_triggers": [ "FRIEND_DIED", "HURT", "PLAYER_CLOSE", "STALK" ],
@@ -759,7 +730,7 @@
     "placate_triggers": [ "PLAYER_WEAK" ],
     "death_drops": "wild_bio_tool_pistol",
     "death_function": [ "NORMAL" ],
-    "flags": [ "SEES", "HEARS", "SMELLS", "POISON",  "NO_BREATHE", "FILTHY", "PATH_AVOID_DANGER_2" ]
+    "flags": [ "SEES", "HEARS", "SMELLS", "POISON", "NO_BREATHE", "FILTHY", "PATH_AVOID_DANGER_2" ]
   },
   {
     "id": "mon_zombie_bio_tool_smg",

--- a/nocts_cata_mod_DDA/Monsters/c_monster_drops.json
+++ b/nocts_cata_mod_DDA/Monsters/c_monster_drops.json
@@ -13,6 +13,27 @@
     ]
   },
   {
+    "id": "mon_fungus_failed_weapon_death_drops",
+    "type": "item_group",
+    "//": "Drops for fungal augmented abominations, secondary source of Marloss items.",
+    "subtype": "collection",
+    "entries": [
+      { "group": "weapon_hat", "damage": [ 1, 4 ] },
+      { "group": "weapon_suit", "damage": [ 1, 4 ] },
+      { "group": "weapon_badge", "damage": [ 0, 0 ] },
+      { "group": "weapom_feet", "damage": [ 1, 4 ] },
+      { "group": "bio_weapon_power", "damage": [ 0, 1 ], "prob": 25 },
+      {
+        "distribution": [
+          { "item": "marloss_berry", "prob": 50 },
+          { "item": "marloss_seed", "prob": 25 },
+          { "item": "marloss_gel", "prob": 25 }
+        ],
+        "prob": 25
+      }
+    ]
+  },
+  {
     "id": "apophis_bio_weapom_item",
     "type": "item_group",
     "//": "items of bio-weapon apophis",

--- a/nocts_cata_mod_DDA/Monsters/c_monsters.json
+++ b/nocts_cata_mod_DDA/Monsters/c_monsters.json
@@ -92,17 +92,7 @@
     "placate_triggers": [ "FIRE" ],
     "death_drops": "wild_bio_weapom_item",
     "death_function": [ "ACID", "NORMAL" ],
-    "flags": [
-      "SEES",
-      "HEARS",
-      "SMELLS",
-      "WARM",
-      "HUMAN",
-      "ELECTRIC",
-      "BASHES",
-      "PUSH_VEH",
-      "PATH_AVOID_DANGER_1"
-    ]
+    "flags": [ "SEES", "HEARS", "SMELLS", "WARM", "HUMAN", "ELECTRIC", "BASHES", "PUSH_VEH", "PATH_AVOID_DANGER_1" ]
   },
   {
     "id": "hulk_weapon",
@@ -227,20 +217,9 @@
     "anger_triggers": [ "FRIEND_DIED", "FRIEND_ATTACKED", "HURT", "STALK", "PLAYER_CLOSE" ],
     "fear_triggers": [ "FIRE" ],
     "placate_triggers": [ "PLAYER_WEAK" ],
-    "death_drops": "wild_bio_weapom_item",
+    "death_drops": "mon_fungus_failed_weapon_death_drops",
     "death_function": [ "ACID", "FUNGUS", "NORMAL" ],
-    "flags": [
-      "SEES",
-      "HEARS",
-      "SMELLS",
-      "STUMBLES",
-      "ELECTRIC",
-      "ATTACKMON",
-      "BASHES",
-      "PUSH_MON",
-      "PUSH_VEH",
-      "FILTHY"
-    ]
+    "flags": [ "SEES", "HEARS", "SMELLS", "STUMBLES", "ELECTRIC", "ATTACKMON", "BASHES", "PUSH_MON", "PUSH_VEH", "FILTHY" ]
   },
   {
     "id": "mon_zombie_bio_dormant_unarmed",
@@ -275,9 +254,7 @@
     "regenerates": 1,
     "regen_morale": true,
     "harvest": "CBM_SOLDAT_ZOMBIE_GENERIC",
-    "special_attacks": [
-      [ "GRAB", 10 ]
-    ],
+    "special_attacks": [ [ "GRAB", 10 ] ],
     "special_when_hit": [ "ZAPBACK", 60 ],
     "anger_triggers": [ "FRIEND_DIED", "FRIEND_ATTACKED", "HURT", "STALK", "PLAYER_CLOSE" ],
     "placate_triggers": [ "PLAYER_WEAK" ],
@@ -319,9 +296,7 @@
     "regenerates": 1,
     "regen_morale": true,
     "harvest": "CBM_SOLDAT_ZOMBIE_GENERIC",
-    "special_attacks": [
-      [ "GRAB", 10 ]
-    ],
+    "special_attacks": [ [ "GRAB", 10 ] ],
     "special_when_hit": [ "ZAPBACK", 60 ],
     "anger_triggers": [ "FRIEND_DIED", "FRIEND_ATTACKED", "HURT", "STALK", "PLAYER_CLOSE" ],
     "placate_triggers": [ "PLAYER_WEAK" ],
@@ -349,11 +324,7 @@
     "path_settings": { "max_dist": 20 },
     "vision_night": 20,
     "regenerates": 1,
-    "special_attacks": [
-      [ "GRAB", 10 ],
-      [ "BIO_OP_TAKEDOWN", 30 ],
-      [ "LUNGE", 20 ]
-    ],
+    "special_attacks": [ [ "GRAB", 10 ], [ "BIO_OP_TAKEDOWN", 30 ], [ "LUNGE", 20 ] ],
     "death_drops": "mon_zombie_bio_knife_death_drops",
     "flags": [ "SEES", "HEARS", "SMELLS", "POISON", "NO_BREATHE", "FILTHY", "PATH_AVOID_DANGER_1" ],
     "delete": { "upgrades": { "half_life": 28, "into": "mon_zombie_bio_knife" } }
@@ -621,7 +592,7 @@
       },
       [ "GRAB_DRAG", 10 ],
       [ "SMASH", 30 ],
-      { "id": "slam" }     
+      { "id": "slam" }
     ],
     "special_when_hit": [ "ZAPBACK", 60 ],
     "anger_triggers": [ "FRIEND_DIED", "HURT", "PLAYER_CLOSE", "STALK" ],
@@ -763,7 +734,7 @@
     "placate_triggers": [ "PLAYER_WEAK" ],
     "death_drops": "wild_bio_tool_pistol",
     "death_function": [ "NORMAL" ],
-    "flags": [ "SEES", "HEARS", "SMELLS", "POISON",  "NO_BREATHE", "FILTHY", "PATH_AVOID_DANGER_2" ]
+    "flags": [ "SEES", "HEARS", "SMELLS", "POISON", "NO_BREATHE", "FILTHY", "PATH_AVOID_DANGER_2" ]
   },
   {
     "id": "mon_zombie_bio_tool_smg",


### PR DESCRIPTION
Simple change that sets fungal augmented abominations to call a different monsterdrop itemgroup than normal abominations, allowing them to spawn a random marloss item in addition to their normal gear. Also set up so that a pending PR in Arcana can inject different anomalous drops into their drops compared to the other abominations.

Also linted affected files.