### PR TITLE
Update radiation source needed for nano-mutagen

### DIFF
--- a/nocts_cata_mod_BN/Recipe/c_recipes.json
+++ b/nocts_cata_mod_BN/Recipe/c_recipes.json
@@ -2237,12 +2237,14 @@
     "qualities": [ { "id": "SCREW_FINE", "level": 1 }, { "id": "WRENCH_FINE", "level": 1 } ],
     "tools": [
       [
-        [ "light_minus_atomic_battery_cell", 100 ],
-        [ "light_atomic_battery_cell", 100 ],
-        [ "medium_atomic_battery_cell", 100 ],
-        [ "heavy_atomic_battery_cell", 100 ],
-        [ "huge_atomic_battery_cell", 100 ],
-        [ "cobalt_60", -1 ]
+        [ "plut_cell", -1 ],
+        [ "light_minus_atomic_battery_cell", -1 ],
+        [ "light_atomic_battery_cell", -1 ],
+        [ "medium_atomic_battery_cell", -1 ],
+        [ "heavy_atomic_battery_cell", -1 ],
+        [ "huge_atomic_battery_cell", -1 ],
+        [ "betavoltaic", -1 ],
+        [ "RTG_coffee", -1 ]
       ]
     ],
     "components": [ [ [ "iv_mutagen_alpha", 1 ] ], [ [ "iv_mutagen_medical", 1 ] ], [ [ "nanomaterial", 1 ], [ "bio_nanobots", 1 ] ] ],

--- a/nocts_cata_mod_DDA/Recipe/c_recipes.json
+++ b/nocts_cata_mod_DDA/Recipe/c_recipes.json
@@ -2395,12 +2395,14 @@
     "qualities": [ { "id": "SCREW_FINE", "level": 1 }, { "id": "WRENCH_FINE", "level": 1 } ],
     "tools": [
       [
-        [ "light_minus_atomic_battery_cell", 100 ],
-        [ "light_atomic_battery_cell", 100 ],
-        [ "medium_atomic_battery_cell", 100 ],
-        [ "heavy_atomic_battery_cell", 100 ],
-        [ "huge_atomic_battery_cell", 100 ],
-        [ "cobalt_60", -1 ]
+        [ "plut_cell", -1 ],
+        [ "light_minus_atomic_battery_cell", -1 ],
+        [ "light_atomic_battery_cell", -1 ],
+        [ "medium_atomic_battery_cell", -1 ],
+        [ "heavy_atomic_battery_cell", -1 ],
+        [ "huge_atomic_battery_cell", -1 ],
+        [ "betavoltaic", -1 ],
+        [ "RTG_coffee", -1 ]
       ]
     ],
     "components": [ [ [ "iv_mutagen_alpha", 1 ] ], [ [ "iv_mutagen_medical", 1 ] ], [ [ "nanomaterial", 1 ], [ "bio_nanobots", 1 ] ] ],


### PR DESCRIPTION
Changed it so that crafting nano-mutagenic serum doesn't have to eat up
charges from the plutonium batteries used as a radiation source, since
that method is buggy plus current lore is that plutonium cells aren't
powered by radiation but use it as part of superscience needed for
better power storage. So just having the cell, even a depleted one, on
hand logically should be able to provide a controlled source of
radiation.

Also changed it to allow a standard plutonium cell as an option, as well
as betavoltaic cells and RTGs. Disallowed chunks of cobalt-60 since it's
an uncontrolled source, but can re-add it (along with plutonium slurry I
guess) if anyone wants to work with uncontained radiation while making
nano-mutagenic serum.

Can maybe also revisit the other tools required, since it probably
doesn't need a full set of serum-making tools when you're coaxing
nanites to alter already-made serum.

Fixes https://github.com/Noctifer-de-Mortem/nocts_cata_mod/issues/279