### PR TITLE
More fixes for DDA version

### DIFF
--- a/nocts_cata_mod_DDA/Monsters/c_monster_override.json
+++ b/nocts_cata_mod_DDA/Monsters/c_monster_override.json
@@ -62,7 +62,7 @@
     ],
     "special_when_hit": [ "RETURN_FIRE", 100 ],
     "death_drops": {  },
-    "death_function": [ "BROKEN" ],
+    "death_function": { "corpse_type": "BROKEN" },
     "flags": [ "SEES", "NOHEAD", "ELECTRONIC", "COLDPROOF", "IMMOBILE", "NO_BREATHE" ],
     "anger_triggers": [ "PLAYER_CLOSE", "HURT", "FRIEND_ATTACKED", "FRIEND_DIED" ]
   },

--- a/nocts_cata_mod_DDA/Monsters/c_monsters.json
+++ b/nocts_cata_mod_DDA/Monsters/c_monsters.json
@@ -36,7 +36,7 @@
     "anger_triggers": [ "FRIEND_DIED", "FRIEND_ATTACKED", "HURT", "STALK", "PLAYER_CLOSE" ],
     "fear_triggers": [ "FIRE" ],
     "death_drops": "wild_bio_weapom_item",
-    "death_function": [ "ACID", "NORMAL" ],
+    "death_function": { "message": "The %s's body leaks acid.", "effect": { "id": "death_acid", "hit_self": true } },
     "flags": [
       "SEES",
       "HEARS",
@@ -91,7 +91,7 @@
     "anger_triggers": [ "FRIEND_DIED", "FRIEND_ATTACKED", "HURT", "STALK", "PLAYER_CLOSE" ],
     "placate_triggers": [ "FIRE" ],
     "death_drops": "wild_bio_weapom_item",
-    "death_function": [ "ACID", "NORMAL" ],
+    "death_function": { "message": "The %s's body leaks acid.", "effect": { "id": "death_acid", "hit_self": true } },
     "flags": [ "SEES", "HEARS", "SMELLS", "WARM", "HUMAN", "ELECTRIC", "BASHES", "PUSH_VEH", "PATH_AVOID_DANGER_1" ]
   },
   {
@@ -155,7 +155,7 @@
     ],
     "special_when_hit": [ "ZAPBACK", 75 ],
     "death_drops": "apophis_bio_weapom_item",
-    "death_function": [ "ACID", "NORMAL", "EXPLODE" ],
+    "death_function": { "message": "%s leaks acid and explodes!", "effect": { "id": "c_death_explosion_hulk_weapon", "hit_self": true } },
     "flags": [
       "SEES",
       "HEARS",
@@ -218,7 +218,10 @@
     "fear_triggers": [ "FIRE" ],
     "placate_triggers": [ "PLAYER_WEAK" ],
     "death_drops": "mon_fungus_failed_weapon_death_drops",
-    "death_function": [ "ACID", "FUNGUS", "NORMAL" ],
+    "death_function": {
+      "message": "%s leaks acid and a cloud of spores!",
+      "effect": { "id": "c_death_explosion_mon_fungus_failed_weapon", "hit_self": true }
+    },
     "flags": [ "SEES", "HEARS", "SMELLS", "STUMBLES", "ELECTRIC", "ATTACKMON", "BASHES", "PUSH_MON", "PUSH_VEH", "FILTHY" ]
   },
   {
@@ -259,7 +262,6 @@
     "anger_triggers": [ "FRIEND_DIED", "FRIEND_ATTACKED", "HURT", "STALK", "PLAYER_CLOSE" ],
     "placate_triggers": [ "PLAYER_WEAK" ],
     "death_drops": "mon_zombie_bio_dormant_unarmed_death_drops",
-    "death_function": [ "NORMAL" ],
     "upgrades": { "half_life": 28, "into": "mon_zombie_bio_knife" },
     "flags": [ "SEES", "HEARS", "SMELLS", "POISON", "NO_BREATHE", "FILTHY", "STUMBLES", "BASHES" ]
   },
@@ -301,7 +303,6 @@
     "anger_triggers": [ "FRIEND_DIED", "FRIEND_ATTACKED", "HURT", "STALK", "PLAYER_CLOSE" ],
     "placate_triggers": [ "PLAYER_WEAK" ],
     "death_drops": "mon_zombie_bio_dormant_armed_death_drops",
-    "death_function": [ "NORMAL" ],
     "upgrades": { "half_life": 28, "into_group": "GROUP_ZOMBIE_SUPER_SOLDIER_UPGRADE" },
     "flags": [ "SEES", "HEARS", "SMELLS", "POISON", "NO_BREATHE", "FILTHY", "STUMBLES", "BASHES" ]
   },
@@ -394,7 +395,6 @@
     "anger_triggers": [ "FRIEND_DIED", "FRIEND_ATTACKED", "HURT", "STALK", "PLAYER_CLOSE" ],
     "placate_triggers": [ "PLAYER_WEAK" ],
     "death_drops": "wild_bio_infantry_rifle",
-    "death_function": [ "NORMAL" ],
     "flags": [ "SEES", "HEARS", "SMELLS", "POISON", "NO_BREATHE", "FILTHY", "PATH_AVOID_DANGER_1" ]
   },
   {
@@ -462,7 +462,6 @@
     "anger_triggers": [ "FRIEND_DIED", "FRIEND_ATTACKED", "HURT", "STALK", "PLAYER_CLOSE" ],
     "placate_triggers": [ "PLAYER_WEAK" ],
     "death_drops": "wild_bio_infantry_shotgun",
-    "death_function": [ "NORMAL" ],
     "flags": [ "SEES", "HEARS", "SMELLS", "POISON", "NO_BREATHE", "FILTHY", "PATH_AVOID_DANGER_1" ]
   },
   {
@@ -529,7 +528,6 @@
     "special_when_hit": [ "ZAPBACK", 60 ],
     "anger_triggers": [ "FRIEND_DIED", "HURT", "PLAYER_CLOSE", "STALK" ],
     "death_drops": "wild_bio_knight_lmg",
-    "death_function": [ "NORMAL" ],
     "flags": [ "SEES", "HEARS", "SMELLS", "POISON", "NO_BREATHE", "BONES", "FILTHY", "BASHES", "PUSH_MON", "PUSH_VEH" ]
   },
   {
@@ -597,7 +595,6 @@
     "special_when_hit": [ "ZAPBACK", 60 ],
     "anger_triggers": [ "FRIEND_DIED", "HURT", "PLAYER_CLOSE", "STALK" ],
     "death_drops": "wild_bio_knight_launcher",
-    "death_function": [ "NORMAL" ],
     "flags": [ "SEES", "HEARS", "SMELLS", "POISON", "NO_BREATHE", "BONES", "FILTHY", "BASHES", "PUSH_MON", "PUSH_VEH" ]
   },
   {
@@ -666,7 +663,6 @@
     "anger_triggers": [ "FRIEND_DIED", "HURT", "PLAYER_CLOSE", "STALK" ],
     "placate_triggers": [ "PLAYER_WEAK" ],
     "death_drops": "wild_bio_scout_sniper",
-    "death_function": [ "NORMAL" ],
     "flags": [ "SEES", "HEARS", "SMELLS", "POISON", "NO_BREATHE", "FILTHY", "PATH_AVOID_DANGER_1" ]
   },
   {
@@ -733,7 +729,6 @@
     "anger_triggers": [ "FRIEND_DIED", "FRIEND_ATTACKED", "HURT", "STALK", "PLAYER_CLOSE" ],
     "placate_triggers": [ "PLAYER_WEAK" ],
     "death_drops": "wild_bio_tool_pistol",
-    "death_function": [ "NORMAL" ],
     "flags": [ "SEES", "HEARS", "SMELLS", "POISON", "NO_BREATHE", "FILTHY", "PATH_AVOID_DANGER_2" ]
   },
   {
@@ -800,7 +795,6 @@
     "anger_triggers": [ "FRIEND_DIED", "FRIEND_ATTACKED", "HURT", "STALK", "PLAYER_CLOSE" ],
     "placate_triggers": [ "PLAYER_WEAK" ],
     "death_drops": "wild_bio_tool_smg",
-    "death_function": [ "NORMAL" ],
     "flags": [ "SEES", "HEARS", "SMELLS", "POISON", "NO_BREATHE", "FILTHY", "PATH_AVOID_DANGER_2" ]
   }
 ]

--- a/nocts_cata_mod_DDA/Surv_help/c_spells.json
+++ b/nocts_cata_mod_DDA/Surv_help/c_spells.json
@@ -192,5 +192,34 @@
     "min_damage": -2,
     "max_damage": -5,
     "flags": [ "RANDOM_DAMAGE", "SILENT" ]
+  },
+  {
+    "id": "c_death_explosion_hulk_weapon",
+    "type": "SPELL",
+    "name": { "str": "Death Explosion Plus Acid" },
+    "valid_targets": [ "self", "ally", "hostile", "ground" ],
+    "description": "Small explosion plus acid effect, used by Apophis.",
+    "min_aoe": 8,
+    "max_aoe": 8,
+    "min_damage": 8,
+    "max_damage": 8,
+    "effect": "explosion",
+    "shape": "blast",
+    "extra_effects": [ { "id": "death_acid", "hit_self": true } ]
+  },
+  {
+    "id": "c_death_explosion_mon_fungus_failed_weapon",
+    "type": "SPELL",
+    "name": { "str": "Pouf plus Acid Effect" },
+    "description": "Fungal pouf plus acid effect, used by fungal augmented abominations.",
+    "valid_targets": [ "ground", "self" ],
+    "effect": "fungalize",
+    "flags": [ "SILENT" ],
+    "min_damage": 2500,
+    "max_damage": 2500,
+    "min_aoe": 1,
+    "max_aoe": 1,
+    "shape": "blast",
+    "extra_effects": [ { "id": "death_pouf", "hit_self": true }, { "id": "death_acid", "hit_self": true } ]
   }
 ]

--- a/nocts_cata_mod_DDA/Terrain/Mapgen_Variants.json
+++ b/nocts_cata_mod_DDA/Terrain/Mapgen_Variants.json
@@ -137,7 +137,7 @@
         { "item": "556", "x": 18, "y": [ 9, 12 ], "chance": 75, "repeat": 150 },
         { "item": "m249", "x": 20, "y": 9, "chance": 75, "repeat": 6 },
         { "item": "m240", "x": 20, "y": 9, "chance": 75, "repeat": 4 },
-        { "item": "m1014", "x": 20, "y": 10, "chance": 75, "repeat": 10 },
+        { "item": "mossberg_930", "variant": "m1014", "x": 20, "y": 10, "chance": 75, "repeat": 10 },
         { "item": "mossberg_590", "x": 20, "y": 10, "chance": 75, "repeat": 8 },
         { "item": "m2010", "x": 20, "y": 11, "magazine": 100, "chance": 75, "repeat": 2 },
         { "item": "m110a1", "x": 20, "y": 11, "magazine": 100, "chance": 75, "repeat": 8 },

--- a/nocts_cata_mod_DDA/Weapons/c_ranged.json
+++ b/nocts_cata_mod_DDA/Weapons/c_ranged.json
@@ -309,6 +309,7 @@
     "durability": 6,
     "modes": [ [ "DEFAULT", "semi", 1 ], [ "BURST", "burst", 3 ], [ "auto", "auto", 10 ] ],
     "clip_size": 100,
+    "pocket_data": [ { "pocket_type": "MAGAZINE", "ammo_restriction": { "pebble": 100 } } ],
     "reload": 6000,
     "loudness": 20,
     "valid_mod_locations": [


### PR DESCRIPTION
* Fixed the mossberg spawn that's also since been turned into a gun variant, in the DDA version
* Updated monster death functions for monsters in the DDA version. Had to write custom monster death spells for Apophis and fungal augmented abominations, since I needed to be able to combine "explode plus leak acid" and "fungus plus leak acid"
* Also fixed missing pocket data for pneumatic LMG.

Fixes https://github.com/Noctifer-de-Mortem/nocts_cata_mod/issues/283
Fixes https://github.com/Noctifer-de-Mortem/nocts_cata_mod/issues/284

Also gah, I could've sworn I created a branch instead of pushing changes into my fork's master branch. Eh.