### PR TITLE
Fix survivor ammo belts in DDA version

### DIFF
--- a/nocts_cata_mod_DDA/Weapons/c_magazines.json
+++ b/nocts_cata_mod_DDA/Weapons/c_magazines.json
@@ -151,7 +151,7 @@
     "pocket_data": [ { "pocket_type": "MAGAZINE", "ammo_restriction": { "223": 80 } } ],
     "capacity": 80,
     "reload_time": 200,
-    "armor_data": { "covers": [ "torso" ], "coverage": 5, "encumbrance": 10 },
+    "armor_data": { "armor": [ { "encumbrance": 10, "coverage": 5, "covers": [ "torso" ] } ] },
     "flags": [ "BELTED", "OVERSIZE" ]
   },
   {
@@ -168,7 +168,7 @@
     "pocket_data": [ { "pocket_type": "MAGAZINE", "ammo_restriction": { "762": 80 } } ],
     "capacity": 80,
     "reload_time": 200,
-    "armor_data": { "covers": [ "torso" ], "coverage": 5, "encumbrance": 10 },
+    "armor_data": { "armor": [ { "encumbrance": 10, "coverage": 5, "covers": [ "torso" ] } ] },
     "flags": [ "BELTED", "OVERSIZE" ]
   },
   {
@@ -185,7 +185,7 @@
     "pocket_data": [ { "pocket_type": "MAGAZINE", "ammo_restriction": { "308": 80 } } ],
     "capacity": 80,
     "reload_time": 200,
-    "armor_data": { "covers": [ "torso" ], "coverage": 5, "encumbrance": 10 },
+    "armor_data": { "armor": [ { "encumbrance": 10, "coverage": 5, "covers": [ "torso" ] } ] },
     "flags": [ "BELTED", "OVERSIZE" ]
   },
   {
@@ -203,7 +203,7 @@
     "pocket_data": [ { "pocket_type": "MAGAZINE", "ammo_restriction": { "762R": 80 } } ],
     "capacity": 80,
     "reload_time": 200,
-    "armor_data": { "covers": [ "torso" ], "coverage": 5, "encumbrance": 10 },
+    "armor_data": { "armor": [ { "encumbrance": 10, "coverage": 5, "covers": [ "torso" ] } ] },
     "flags": [ "BELTED", "OVERSIZE" ]
   },
   {


### PR DESCRIPTION
I forgot how it's supposed to define armor_data it seems, in the last fix. Odd since I could've sworn it loaded with no errors, but a comment in the commit mentioned an error cropping up somewhere. This time made sure that it loaded in, spawned in, and could be worn with no issue.