### PR TITLE
Standardized battery pistol/rifle energy efficiency

### DIFF
--- a/nocts_cata_mod_BN/Weapons/c_ranged.json
+++ b/nocts_cata_mod_BN/Weapons/c_ranged.json
@@ -388,7 +388,7 @@
     "bashing": 3,
     "to_hit": -1,
     "ammo_effects": [ "LIGHTNING" ],
-    "flags": [ "FIRE_50", "NON-FOULING", "NEEDS_NO_LUBE" ],
+    "flags": [ "FIRE_20", "NON-FOULING", "NEEDS_NO_LUBE" ],
     "ammo": [ "battery" ],
     "magazine_well": "50 ml",
     "magazines": [
@@ -406,7 +406,7 @@
       ]
     ],
     "skill": "pistol",
-    "ranged_damage": { "damage_type": "electric", "amount": 4 },
+    "ranged_damage": { "damage_type": "electric", "amount": 5 },
     "range": 10,
     "dispersion": 120,
     "recoil": 10,
@@ -429,7 +429,7 @@
     "bashing": 8,
     "to_hit": -1,
     "ammo_effects": [ "LIGHTNING" ],
-    "flags": [ "FIRE_100", "NON-FOULING", "NEEDS_NO_LUBE" ],
+    "flags": [ "FIRE_50", "NON-FOULING", "NEEDS_NO_LUBE" ],
     "ammo": [ "battery" ],
     "magazine_well": "300 ml",
     "magazines": [
@@ -439,7 +439,7 @@
       ]
     ],
     "skill": "rifle",
-    "ranged_damage": { "damage_type": "electric", "amount": 8 },
+    "ranged_damage": { "damage_type": "electric", "amount": 12 },
     "range": 15,
     "dispersion": 100,
     "recoil": 30,

--- a/nocts_cata_mod_DDA/Weapons/c_ranged.json
+++ b/nocts_cata_mod_DDA/Weapons/c_ranged.json
@@ -398,7 +398,7 @@
     "to_hit": -1,
     "ammo_effects": [ "LIGHTNING" ],
     "flags": [ "NON-FOULING", "NEEDS_NO_LUBE" ],
-    "ammo_to_fire": 50,
+    "ammo_to_fire": 20,
     "ammo": [ "battery" ],
     "pocket_data": [
       {
@@ -419,7 +419,7 @@
       }
     ],
     "skill": "pistol",
-    "ranged_damage": { "damage_type": "electric", "amount": 4 },
+    "ranged_damage": { "damage_type": "electric", "amount": 5 },
     "range": 10,
     "dispersion": 120,
     "recoil": 10,
@@ -443,7 +443,7 @@
     "to_hit": -1,
     "ammo_effects": [ "LIGHTNING" ],
     "flags": [ "NON-FOULING", "NEEDS_NO_LUBE" ],
-    "ammo_to_fire": 100,
+    "ammo_to_fire": 50,
     "ammo": [ "battery" ],
     "pocket_data": [
       {
@@ -456,7 +456,7 @@
       }
     ],
     "skill": "rifle",
-    "ranged_damage": { "damage_type": "electric", "amount": 8 },
+    "ranged_damage": { "damage_type": "electric", "amount": 12 },
     "range": 15,
     "dispersion": 100,
     "recoil": 30,


### PR DESCRIPTION
On reworking the mi-go beam weapon during the previous PR, I made note to myself of the energy-efficiency of related weapons and determined that the survivor battery weapons could perhaps be made a bit less wasteful.

* Changed battery pistol to deal 5 damage and use 20 charges, making it exactly 25% efficient (previously 4 damage for 50 charges, or 8% efficiency).
* Changed battery rifle to deal 12 damage and use 50 charges, making it 24% efficient (previously 8 damage for 100 charges, also 8% efficiency).

This still makes them low-power in exchange for being accessible due to using household batteries, but to less of an extreme than before. Most energy weapons tend to hover in the neighborhood of 50% efficiency, the mi-beam weapon at 75%, Omnitech weapons generally at 80%, and the flesh weapons having 500% efficiency (presumably since their UPS cost is token, and the bulk of their intended drawbacks are in being living weapons with a corruptive effect on the wielder).