### PR TITLE
Fixes for DDA version of mod

### DIFF
--- a/nocts_cata_mod_BN/Npc/NC_GLADIATORS.json
+++ b/nocts_cata_mod_BN/Npc/NC_GLADIATORS.json
@@ -67,7 +67,8 @@
     "type": "item_group",
     "//": "Helms for Red Team.",
     "items": [
-      [ "helmet_bone", 35 ],
+      [ "helmet_chitin", 25 ],
+      [ "helmet_acidchitin", 10 ],
       [ "pot_helmet", 25 ],
       [ "helmet_football", 15 ],
       [ "helmet_motor", 15 ],
@@ -95,8 +96,8 @@
     "items": [
       [ "armguard_hard", 20 ],
       [ "2byarm_guard", 15 ],
-      [ "armguard_bone", 25 ],
-      [ "armguard_chitin", 5 ],
+      [ "armguard_acidchitin", 10 ],
+      [ "armguard_chitin", 20 ],
       [ "armguard_metal", 10 ]
     ]
   },
@@ -104,7 +105,7 @@
     "id": "NC_GLADIATOR_HEAVY_hands",
     "type": "item_group",
     "//": "Get an item 75% of the time.",
-    "items": [ [ "gauntlets_bone", 20 ], [ "gauntlets_chitin", 10 ], [ "gloves_fingerless_mod", 15 ] ]
+    "items": [ [ "gauntlets_acidchitin", 10 ], [ "gauntlets_chitin", 20 ], [ "gloves_fingerless_mod", 15 ] ]
   },
   {
     "id": "NC_GLADIATOR_HEAVY_legs",
@@ -114,7 +115,7 @@
   {
     "id": "NC_GLADIATOR_HEAVY_feet",
     "type": "item_group",
-    "items": [ [ "boots_bone", 30 ], [ "boots_chitin", 10 ], [ "boots_steel", 30 ], [ "motorbike_boots", 25 ] ]
+    "items": [ [ "boots_acidchitin", 10 ], [ "boots_chitin", 30 ], [ "boots_steel", 30 ], [ "motorbike_boots", 25 ] ]
   },
   {
     "id": "NC_GLADIATOR_LIGHT_weapon",

--- a/nocts_cata_mod_BN/Surv_help/c_item_groups.json
+++ b/nocts_cata_mod_BN/Surv_help/c_item_groups.json
@@ -589,7 +589,7 @@
       [ "bio_armor_head", 6 ],
       [ "bio_armor_legs", 8 ],
       [ "bio_armor_torso", 6 ],
-      [ "bio_blaster", 8 ],
+      [ "bio_laser_armgun", 7 ],
       [ "bio_carbon", 7 ],
       [ "bio_chain_lightning", 7 ],
       [ "bio_cqb", 3 ],

--- a/nocts_cata_mod_DDA/Npc/NC_GLADIATORS.json
+++ b/nocts_cata_mod_DDA/Npc/NC_GLADIATORS.json
@@ -67,7 +67,8 @@
     "type": "item_group",
     "//": "Helms for Red Team.",
     "items": [
-      [ "helmet_bone", 35 ],
+      [ "helmet_chitin", 25 ],
+      [ "helmet_acidchitin", 10 ],
       [ "pot_helmet", 25 ],
       [ "helmet_football", 15 ],
       [ "helmet_motor", 15 ],
@@ -95,8 +96,8 @@
     "items": [
       [ "armguard_hard", 20 ],
       [ "2byarm_guard", 15 ],
-      [ "armguard_bone", 25 ],
-      [ "armguard_chitin", 5 ],
+      [ "armguard_acidchitin", 10 ],
+      [ "armguard_chitin", 20 ],
       [ "armguard_metal", 10 ]
     ]
   },
@@ -104,7 +105,7 @@
     "id": "NC_GLADIATOR_HEAVY_hands",
     "type": "item_group",
     "//": "Get an item 75% of the time.",
-    "items": [ [ "gauntlets_bone", 20 ], [ "gauntlets_chitin", 10 ], [ "gloves_fingerless_mod", 15 ] ]
+    "items": [ [ "gauntlets_acidchitin", 10 ], [ "gauntlets_chitin", 20 ], [ "gloves_fingerless_mod", 15 ] ]
   },
   {
     "id": "NC_GLADIATOR_HEAVY_legs",
@@ -114,7 +115,7 @@
   {
     "id": "NC_GLADIATOR_HEAVY_feet",
     "type": "item_group",
-    "items": [ [ "boots_bone", 30 ], [ "boots_chitin", 10 ], [ "boots_steel", 30 ], [ "motorbike_boots", 25 ] ]
+    "items": [ [ "boots_acidchitin", 10 ], [ "boots_chitin", 30 ], [ "boots_steel", 30 ], [ "motorbike_boots", 25 ] ]
   },
   {
     "id": "NC_GLADIATOR_LIGHT_weapon",

--- a/nocts_cata_mod_DDA/Npc/NC_PREPPERS.json
+++ b/nocts_cata_mod_DDA/Npc/NC_PREPPERS.json
@@ -141,9 +141,8 @@
       {
         "distribution": [
           { "item": "sling", "prob": 20 },
-          { "item": "wristrocket", "prob": 10 },
-          { "item": "bullet_crossbow", "prob": 20 },
-          { "item": "tihar", "prob": 25 },
+          { "item": "wristrocket", "prob": 25 },
+          { "item": "bullet_crossbow", "prob": 30 },
           { "item": "sur_pnu_lmg", "prob": 25 }
         ]
       },

--- a/nocts_cata_mod_DDA/Recipe/c_recipes.json
+++ b/nocts_cata_mod_DDA/Recipe/c_recipes.json
@@ -1899,7 +1899,7 @@
       [ [ "leather", 10 ], [ "tanned_hide", 2 ] ],
       [ [ "coat_rain", 1 ], [ "jacket_windbreaker", 1 ], [ "jacket_evac", 1 ], [ "coat_gut", 1 ] ],
       [ [ "duct_tape", 300 ] ],
-      [ [ "kevlar", 1 ], [ "modularvest", 1 ], [ "swat_armor", 1 ], [ "kevlar_plate", 24 ] ]
+      [ [ "kevlar", 1 ], [ "swat_armor", 1 ], [ "kevlar_plate", 24 ] ]
     ]
   },
   {

--- a/nocts_cata_mod_DDA/Surv_help/c_item_groups.json
+++ b/nocts_cata_mod_DDA/Surv_help/c_item_groups.json
@@ -587,7 +587,7 @@
       [ "bio_armor_head", 6 ],
       [ "bio_armor_legs", 8 ],
       [ "bio_armor_torso", 6 ],
-      [ "bio_blaster", 8 ],
+      [ "bio_laser_armgun", 7 ],
       [ "bio_carbon", 7 ],
       [ "bio_chain_lightning", 7 ],
       [ "bio_cqb", 3 ],

--- a/nocts_cata_mod_DDA/Terrain/makeshift_command_center.json
+++ b/nocts_cata_mod_DDA/Terrain/makeshift_command_center.json
@@ -233,7 +233,6 @@
         { "item": "broken_manhack", "x": 4, "y": 14 },
         { "item": "broken_manhack", "x": 5, "y": 14 },
         { "item": "broken_manhack", "x": 2, "y": 15 },
-        { "item": "broken_tankbot", "x": 3, "y": 15 },
         { "item": "broken_manhack", "x": 5, "y": 15 },
         { "item": "broken_manhack", "x": 2, "y": 16 },
         { "item": "broken_manhack", "x": 5, "y": 16 },

--- a/nocts_cata_mod_DDA/Weapons/c_ranged.json
+++ b/nocts_cata_mod_DDA/Weapons/c_ranged.json
@@ -1835,7 +1835,7 @@
   },
   {
     "id": "c_mi_go_rifle_salvaged",
-    "looks_like": "tihar",
+    "looks_like": "sur_pnu_lmg",
     "type": "GUN",
     "name": { "str": "salvaged resin rifle" },
     "description": "A mi-go weapon that projects pieces of hardened alien resin at high velocities, its exotic controls stripped down and interfaced with something more fitting human anatomy.  The product of pre-cataclysm biotechnology applied to solve an outside-context problem.  Although it relies on special ammunition, it is relatively easy to mold resin into compatible projectiles, and it packs a decent punch with very little noise.",

--- a/nocts_cata_mod_DDA/Weapons/c_ranged_override.json
+++ b/nocts_cata_mod_DDA/Weapons/c_ranged_override.json
@@ -15,5 +15,43 @@
     "modes": [ [ "DEFAULT", "semi", 1 ], [ "BURST", "burst", 10 ] ],
     "ups_charges": 5,
     "valid_mod_locations": [ [ "accessories", 4 ], [ "sling", 1 ], [ "grip", 1 ], [ "sights", 1 ], [ "stock", 1 ] ]
+  },
+  {
+    "id": "laser_cannon",
+    "//": "Preserved here becuase DDA removed it and Cata++ makes some use of it.",
+    "looks_like": "ar15",
+    "type": "GUN",
+    "reload_noise_volume": 10,
+    "name": { "str": "handheld laser cannon" },
+    "description": "This is a laser cannon stripped from the barrel of a TX-5LR Cerberus laser turret that has been modified to use UPS power for firing.",
+    "weight": "5140 g",
+    "volume": "1500 ml",
+    "price": 400000,
+    "price_postapoc": 8000,
+    "to_hit": -1,
+    "bashing": 4,
+    "material": [ "steel", "plastic" ],
+    "symbol": "(",
+    "color": "magenta",
+    "skill": "rifle",
+    "range": 30,
+    "ranged_damage": { "damage_type": "heat", "amount": 10, "armor_penetration": 4 },
+    "dispersion": 90,
+    "durability": 7,
+    "loudness": 8,
+    "ups_charges": 25,
+    "reload": 200,
+    "valid_mod_locations": [
+      [ "emitter", 1 ],
+      [ "lens", 1 ],
+      [ "sling", 1 ],
+      [ "grip mount", 1 ],
+      [ "rail mount", 1 ],
+      [ "sights mount", 1 ],
+      [ "stock mount", 1 ],
+      [ "underbarrel mount", 1 ]
+    ],
+    "ammo_effects": [ "LASER", "INCENDIARY" ],
+    "flags": [ "NO_UNLOAD", "NON_FOULING", "NEEDS_NO_LUBE" ]
   }
 ]


### PR DESCRIPTION
Updates DDA version now that https://github.com/CleverRaven/Cataclysm-DDA/pull/51309 has revealed some old obsoleted stuff.

Includes new use of acidchitin armor for Red Team in both BN and DDA versions, and yoinking the laser cannon in the DDA version.

Also allows harvesting a laser minigun CBM from Apophis instead of a fusion blaster arm since that's obsolete, which also fits with an idea I was pondering doing sometime...