### PR TITLE
Fix injection of traits into scenarios

### DIFF
--- a/nocts_cata_mod_BN/Char_creation/c_scenarios.json
+++ b/nocts_cata_mod_BN/Char_creation/c_scenarios.json
@@ -121,27 +121,31 @@
     "copy-from": "alone",
     "type": "scenario",
     "id": "alone",
-    "traits": [ "MARTIAL_ARTS_SURV_COM", "MARTIAL_ARTS_BIOJUTSU" ]
+    "extend": { "traits": [ "MARTIAL_ARTS_SURV_COM", "MARTIAL_ARTS_BIOJUTSU" ] }
   },
   {
     "copy-from": "summer_advanced_start",
     "type": "scenario",
     "id": "summer_advanced_start",
-    "traits": [ "MARTIAL_ARTS_SURV_COM", "MARTIAL_ARTS_BIOJUTSU" ],
-    "extend": { "professions": [ "bio_infantry", "bio_scout", "bio_knight", "bio_tool" ] }
+    "extend": {
+      "traits": [ "MARTIAL_ARTS_SURV_COM", "MARTIAL_ARTS_BIOJUTSU" ],
+      "professions": [ "bio_infantry", "bio_scout", "bio_knight", "bio_tool" ]
+    }
   },
   {
     "copy-from": "ambushed",
     "type": "scenario",
     "id": "ambushed",
-    "traits": [ "MARTIAL_ARTS_SURV_COM", "MARTIAL_ARTS_BIOJUTSU" ],
-    "extend": { "professions": [ "bio_infantry", "bio_scout", "bio_knight", "bio_tool" ] }
+    "extend": {
+      "traits": [ "MARTIAL_ARTS_SURV_COM", "MARTIAL_ARTS_BIOJUTSU" ],
+      "professions": [ "bio_infantry", "bio_scout", "bio_knight", "bio_tool" ]
+    }
   },
   {
     "copy-from": "cyberpunk",
     "type": "scenario",
     "id": "cyberpunk",
-    "traits": [ "MARTIAL_ARTS_BIOJUTSU" ]
+    "extend": { "traits": [ "MARTIAL_ARTS_BIOJUTSU" ] }
   },
   {
     "copy-from": "wilderness",

--- a/nocts_cata_mod_DDA/Char_creation/c_scenarios.json
+++ b/nocts_cata_mod_DDA/Char_creation/c_scenarios.json
@@ -125,27 +125,31 @@
     "copy-from": "alone",
     "type": "scenario",
     "id": "alone",
-    "traits": [ "MARTIAL_ARTS_SURV_COM", "MARTIAL_ARTS_BIOJUTSU" ]
+    "extend": { "traits": [ "MARTIAL_ARTS_SURV_COM", "MARTIAL_ARTS_BIOJUTSU" ] }
   },
   {
     "copy-from": "summer_advanced_start",
     "type": "scenario",
     "id": "summer_advanced_start",
-    "traits": [ "MARTIAL_ARTS_SURV_COM", "MARTIAL_ARTS_BIOJUTSU" ],
-    "extend": { "professions": [ "bio_infantry", "bio_scout", "bio_knight", "bio_tool" ] }
+    "extend": {
+      "traits": [ "MARTIAL_ARTS_SURV_COM", "MARTIAL_ARTS_BIOJUTSU" ],
+      "professions": [ "bio_infantry", "bio_scout", "bio_knight", "bio_tool" ]
+    }
   },
   {
     "copy-from": "ambushed",
     "type": "scenario",
     "id": "ambushed",
-    "traits": [ "MARTIAL_ARTS_SURV_COM", "MARTIAL_ARTS_BIOJUTSU" ],
-    "extend": { "professions": [ "bio_infantry", "bio_scout", "bio_knight", "bio_tool" ] }
+    "extend": {
+      "traits": [ "MARTIAL_ARTS_SURV_COM", "MARTIAL_ARTS_BIOJUTSU" ],
+      "professions": [ "bio_infantry", "bio_scout", "bio_knight", "bio_tool" ]
+    }
   },
   {
     "copy-from": "cyberpunk",
     "type": "scenario",
     "id": "cyberpunk",
-    "traits": [ "MARTIAL_ARTS_BIOJUTSU" ]
+    "extend": { "traits": [ "MARTIAL_ARTS_BIOJUTSU" ] }
   },
   {
     "copy-from": "wilderness",


### PR DESCRIPTION
Simple enough fix, realized that Cata++ was injecting traits into scenarios in a way that overrides mod injection of traits if it's lower on the load order.

Tested via loading up a world with both Arcana and Cata++, now the martial art traits from both show up in the proper scenarios such as Ambushed and The Next Summer.