### PR TITLE
And add DDA version of the stuff

### DIFF
--- a/nocts_cata_mod_DDA/Surv_help/c_armor.json
+++ b/nocts_cata_mod_DDA/Surv_help/c_armor.json
@@ -548,6 +548,46 @@
     "armor": [ { "encumbrance": 36, "coverage": 100, "covers": [ "head", "eyes", "mouth" ] } ]
   },
   {
+    "id": "fancy_house_coat",
+    "type": "ARMOR",
+    "name": { "str": "designer bathrobe" },
+    "description": "An outer garment of absorbent, towel-like material traditionally worn to cover one's nakedness to and from the bath.  It makes you wish you had running water to bathe with.  This one has a golden logo of a now irrelevant fashion company sewn on.",
+    "weight": "580 g",
+    "volume": "2 L",
+    "price": 2200,
+    "price_postapoc": 50,
+    "to_hit": -1,
+    "material": [ "cotton" ],
+    "symbol": "[",
+    "looks_like": "coat_lab",
+    "color": "blue",
+    "warmth": 20,
+    "material_thickness": 2,
+    "environmental_protection": 1,
+    "flags": [ "OUTER", "OVERSIZE", "SUPER_FANCY" ],
+    "armor": [
+      { "covers": [ "torso" ], "coverage": 85, "encumbrance": [ 5, 10 ] },
+      { "covers": [ "leg_l", "leg_r" ], "coverage": 85, "encumbrance": [ 5, 5 ] },
+      { "covers": [ "arm_l", "arm_r" ], "coverage": 85, "encumbrance": [ 5, 5 ] }
+    ],
+    "pocket_data": [
+      {
+        "pocket_type": "CONTAINER",
+        "max_contains_volume": "750 ml",
+        "max_contains_weight": "2 kg",
+        "max_item_length": "13 cm",
+        "moves": 80
+      },
+      {
+        "pocket_type": "CONTAINER",
+        "max_contains_volume": "750 ml",
+        "max_contains_weight": "2 kg",
+        "max_item_length": "13 cm",
+        "moves": 80
+      }
+    ]
+  },
+  {
     "id": "fancy_bra",
     "type": "ARMOR",
     "name": { "str": "designer bra" },
@@ -581,6 +621,60 @@
     "material_thickness": 1,
     "flags": [ "VARSIZE", "SKINTIGHT", "SUPER_FANCY" ],
     "armor": [ { "encumbrance": 0, "coverage": 15, "covers": [ "legs" ] } ]
+  },
+  {
+    "id": "fancy_briefs",
+    "type": "ARMOR",
+    "name": { "str_sp": "designer briefs" },
+    "description": "A pair of designer briefs.  Comfortable and good looking underwear worn by men.",
+    "weight": "32 g",
+    "volume": "250 ml",
+    "price": "100 USD",
+    "price_postapoc": "50 cent",
+    "material": [ "cotton" ],
+    "symbol": "[",
+    "looks_like": "boxer_briefs",
+    "color": "white",
+    "warmth": 5,
+    "material_thickness": 1,
+    "flags": [ "VARSIZE", "SKINTIGHT", "SUPER_FANCY" ],
+    "armor": [ { "encumbrance": 0, "coverage": 15, "covers": [ "legs" ] } ]
+  },
+  {
+    "id": "fancy_boxer_shorts",
+    "type": "ARMOR",
+    "name": { "str_sp": "designer boxer shorts" },
+    "description": "Men's designer boxer shorts.  Much more fashionable than briefs and just as comfortable.",
+    "weight": "42 g",
+    "volume": "250 ml",
+    "price": "100 USD",
+    "price_postapoc": "50 cent",
+    "material": [ "cotton" ],
+    "symbol": "[",
+    "looks_like": "boxer_briefs",
+    "color": "light_gray",
+    "warmth": 5,
+    "material_thickness": 1,
+    "flags": [ "VARSIZE", "SKINTIGHT", "SUPER_FANCY" ],
+    "armor": [ { "encumbrance": 0, "coverage": 25, "covers": [ "legs" ] } ]
+  },
+  {
+    "id": "fancy_boxer_briefs",
+    "type": "ARMOR",
+    "name": { "str_sp": "designer boxer briefs" },
+    "description": "The age-old question, boxers or briefs?  Your answer?  Yes, the fancy kind.",
+    "weight": "37 g",
+    "volume": "250 ml",
+    "price": "100 USD",
+    "price_postapoc": "50 cent",
+    "material": [ "cotton" ],
+    "symbol": "[",
+    "looks_like": "shorts",
+    "color": "light_gray",
+    "warmth": 5,
+    "material_thickness": 1,
+    "flags": [ "VARSIZE", "SKINTIGHT", "SUPER_FANCY" ],
+    "armor": [ { "encumbrance": 0, "coverage": 20, "covers": [ "legs" ] } ]
   },
   {
     "id": "bikini_bottom_leather",

--- a/nocts_cata_mod_DDA/Surv_help/c_item_groups.json
+++ b/nocts_cata_mod_DDA/Surv_help/c_item_groups.json
@@ -372,7 +372,14 @@
   {
     "id": "traveler",
     "type": "item_group",
-    "items": [ [ "biomap", 1 ], [ "dress_skirt", 75 ], [ "microskirt", 10 ], [ "fancy_bra", 30 ], [ "thong", 30 ] ]
+    "items": [
+      [ "biomap", 1 ],
+      [ "dress_skirt", 75 ],
+      [ "microskirt", 10 ],
+      [ "fancy_bra", 30 ],
+      [ "fancy_panties", 30 ],
+      [ "thong", 30 ]
+    ]
   },
   {
     "id": "bionics",
@@ -429,17 +436,67 @@
   {
     "id": "female_underwear_top",
     "type": "item_group",
-    "items": [ [ "bra", 90 ], [ "fancy_bra", 90 ] ]
+    "items": [ [ "fancy_bra", 90 ] ]
   },
   {
     "id": "female_underwear_bottom",
     "type": "item_group",
-    "items": [ [ "panties", 70 ], [ "boy_shorts", 50 ], [ "thong", 70 ] ]
+    "items": [ [ "fancy_panties", 70 ], [ "thong", 70 ], [ "bikini_bottom_fur", 5 ], [ "bikini_bottom_leather", 7 ] ]
+  },
+  {
+    "type": "item_group",
+    "id": "male_underwear_bottom",
+    "items": [ [ "fancy_boxer_shorts", 70 ], [ "fancy_briefs", 30 ], [ "fancy_boxer_briefs", 50 ] ]
   },
   {
     "id": "allclothes",
     "type": "item_group",
-    "items": [ [ "dress_skirt", 75 ], [ "microskirt", 10 ], [ "fancy_bra", 30 ], [ "thong", 30 ] ]
+    "items": [
+      [ "dress_skirt", 75 ],
+      [ "microskirt", 10 ],
+      [ "fancy_bra", 30 ],
+      [ "fancy_panties", 30 ],
+      [ "thong", 30 ],
+      { "item": "fancy_briefs", "prob": 15 },
+      { "item": "fancy_boxer_briefs", "prob": 20 },
+      { "item": "fancy_panties", "prob": 30 },
+      { "item": "fancy_house_coat", "prob": 25 }
+    ]
+  },
+  {
+    "type": "item_group",
+    "id": "swimmer_torso",
+    "items": [ [ "bikini_top_fur", 50 ], [ "bikini_top_leather", 50 ] ]
+  },
+  {
+    "type": "item_group",
+    "id": "swimmer_pants",
+    "items": [ [ "bikini_bottom_fur", 35 ], [ "bikini_bottom_leather", 35 ] ]
+  },
+  {
+    "id": "underwear_womens",
+    "type": "item_group",
+    "//": "womens underwear.",
+    "subtype": "distribution",
+    "items": [
+      { "item": "bikini_bottom", "prob": 20 },
+      { "item": "bikini_bottom_fur", "prob": 5 },
+      { "item": "bikini_bottom_leather", "prob": 10 },
+      { "item": "fancy_bra", "prob": 60 },
+      { "item": "fancy_panties", "prob": 70 },
+      { "item": "thong", "prob": 70 }
+    ]
+  },
+  {
+    "id": "underwear_mens",
+    "type": "item_group",
+    "//": "mens underwear.",
+    "subtype": "distribution",
+    "items": [
+      { "item": "fancy_boxer_briefs", "prob": 30 },
+      { "item": "fancy_boxer_shorts", "prob": 50 },
+      { "item": "fancy_briefs", "prob": 50 }
+    ]
   },
   {
     "id": "pawn",


### PR DESCRIPTION
Same deal with https://github.com/Noctifer-de-Mortem/nocts_cata_mod/pull/311 as before, DDA data bein' weird and harder for smol birbs to work with.

Also gave the DDA version same armor data and pocket info as vanilla version.