### PR TITLE
Update harvesting in BN, fix DDA clothes, etc

### DIFF
--- a/nocts_cata_mod_BN/Monsters/c_monster_harvest.json
+++ b/nocts_cata_mod_BN/Monsters/c_monster_harvest.json
@@ -3,126 +3,56 @@
     "id": "CBM_FAILED_BIO",
     "type": "harvest",
     "entries": [
-      {
-        "drop": "bio_power_storage_mkII",
-        "type": "bionic",
-        "flags": [ "NO_STERILE", "NO_PACKED" ],
-        "faults": [ "fault_bionic_salvaged" ]
-      },
-      {
-        "drop": "bio_power_storage_mkII",
-        "type": "bionic",
-        "flags": [ "NO_STERILE", "NO_PACKED" ],
-        "faults": [ "fault_bionic_salvaged" ]
-      },
-      {
-        "drop": "bionics_failed_bio",
-        "type": "bionic_group",
-        "flags": [ "NO_STERILE", "NO_PACKED" ],
-        "faults": [ "fault_bionic_salvaged" ]
-      },
+      { "drop": "bio_power_storage_mkII", "type": "bionic", "flags": [ "NO_STERILE", "NO_PACKED" ] },
+      { "drop": "bio_power_storage_mkII", "type": "bionic", "flags": [ "NO_STERILE", "NO_PACKED" ] },
+      { "drop": "bionics_failed_bio", "type": "bionic_group", "flags": [ "NO_STERILE", "NO_PACKED" ] },
       { "drop": "mutant_human_flesh", "type": "flesh", "mass_ratio": 0.2 },
       { "drop": "hstomach_large", "scale_num": [ 1, 1 ], "max": 1, "type": "offal" },
       { "drop": "mutant_human_fat", "type": "flesh", "mass_ratio": 0.1 },
       { "drop": "bone_human", "type": "bone", "mass_ratio": 0.12 },
       { "drop": "sinew", "type": "bone", "mass_ratio": 0.001 },
       { "drop": "raw_leather", "type": "skin", "mass_ratio": 0.01 },
-      { "drop": "alloy_sheet", "type": "skin", "mass_ratio": 0.01 }
+      { "drop": "alloy_sheet", "type": "skin", "mass_ratio": 0.015 }
     ]
   },
   {
     "id": "CBM_FAILED_BIO_ZOMBIE",
     "type": "harvest",
     "entries": [
-      {
-        "drop": "bio_power_storage_mkII",
-        "type": "bionic",
-        "flags": [ "FILTHY", "NO_STERILE", "NO_PACKED" ],
-        "faults": [ "fault_bionic_salvaged" ]
-      },
-      {
-        "drop": "bio_power_storage_mkII",
-        "type": "bionic",
-        "flags": [ "FILTHY", "NO_STERILE", "NO_PACKED" ],
-        "faults": [ "fault_bionic_salvaged" ]
-      },
-      {
-        "drop": "bionics_failed_bio",
-        "type": "bionic_group",
-        "flags": [ "FILTHY", "NO_STERILE", "NO_PACKED" ],
-        "faults": [ "fault_bionic_salvaged" ]
-      },
+      { "drop": "bio_power_storage_mkII", "type": "bionic", "flags": [ "NO_STERILE", "NO_PACKED" ] },
+      { "drop": "bio_power_storage_mkII", "type": "bionic", "flags": [ "NO_STERILE", "NO_PACKED" ] },
+      { "drop": "bionics_failed_bio", "type": "bionic_group", "flags": [ "NO_STERILE", "NO_PACKED" ] },
       { "drop": "meat_tainted", "type": "flesh", "mass_ratio": 0.25 },
       { "drop": "fat_tainted", "type": "flesh", "mass_ratio": 0.08 },
       { "drop": "bone_tainted", "type": "bone", "mass_ratio": 0.1 },
-      { "drop": "alloy_sheet", "type": "skin", "mass_ratio": 0.1 }
+      { "drop": "alloy_sheet", "type": "skin", "mass_ratio": 0.015 }
     ]
   },
   {
     "id": "CBM_APOPHIS",
     "type": "harvest",
     "entries": [
-      {
-        "drop": "bio_power_storage_mkII",
-        "type": "bionic",
-        "flags": [ "NO_STERILE", "NO_PACKED" ],
-        "faults": [ "fault_bionic_salvaged" ]
-      },
-      {
-        "drop": "bio_power_storage_mkII",
-        "type": "bionic",
-        "flags": [ "NO_STERILE", "NO_PACKED" ],
-        "faults": [ "fault_bionic_salvaged" ]
-      },
-      {
-        "drop": "bio_power_storage_mkII",
-        "type": "bionic",
-        "flags": [ "NO_STERILE", "NO_PACKED" ],
-        "faults": [ "fault_bionic_salvaged" ]
-      },
-      {
-        "drop": "bionics_apophis",
-        "type": "bionic_group",
-        "flags": [ "NO_STERILE", "NO_PACKED" ],
-        "faults": [ "fault_bionic_salvaged" ]
-      },
-      {
-        "drop": "bionics_apophis",
-        "type": "bionic_group",
-        "flags": [ "NO_STERILE", "NO_PACKED" ],
-        "faults": [ "fault_bionic_salvaged" ]
-      },
-      {
-        "drop": "bionics_apophis",
-        "type": "bionic_group",
-        "flags": [ "NO_STERILE", "NO_PACKED" ],
-        "faults": [ "fault_bionic_salvaged" ]
-      },
+      { "drop": "bio_power_storage_mkII", "type": "bionic", "flags": [ "NO_STERILE", "NO_PACKED" ] },
+      { "drop": "bio_power_storage_mkII", "type": "bionic", "flags": [ "NO_STERILE", "NO_PACKED" ] },
+      { "drop": "bio_power_storage_mkII", "type": "bionic", "flags": [ "NO_STERILE", "NO_PACKED" ] },
+      { "drop": "bionics_apophis", "type": "bionic_group", "flags": [ "NO_STERILE", "NO_PACKED" ] },
+      { "drop": "bionics_apophis", "type": "bionic_group", "flags": [ "NO_STERILE", "NO_PACKED" ] },
+      { "drop": "bionics_apophis", "type": "bionic_group", "flags": [ "NO_STERILE", "NO_PACKED" ] },
       { "drop": "mutant_human_flesh", "type": "flesh", "mass_ratio": 0.2 },
       { "drop": "hstomach_large", "scale_num": [ 1, 1 ], "max": 1, "type": "offal" },
       { "drop": "mutant_human_fat", "type": "flesh", "mass_ratio": 0.1 },
       { "drop": "bone_human", "type": "bone", "mass_ratio": 0.12 },
       { "drop": "sinew", "type": "bone", "mass_ratio": 0.001 },
       { "drop": "raw_leather", "type": "skin", "mass_ratio": 0.01 },
-      { "drop": "alloy_sheet", "type": "skin", "mass_ratio": 0.25 }
+      { "drop": "alloy_sheet", "type": "skin", "mass_ratio": 0.015 }
     ]
   },
   {
     "id": "CBM_SOLDAT_ZOMBIE_GENERIC",
     "type": "harvest",
     "entries": [
-      {
-        "drop": "bio_power_storage_mkII",
-        "type": "bionic",
-        "flags": [ "FILTHY", "NO_STERILE", "NO_PACKED" ],
-        "faults": [ "fault_bionic_salvaged" ]
-      },
-      {
-        "drop": "bionics_soldat_zombie_generic",
-        "type": "bionic_group",
-        "flags": [ "FILTHY", "NO_STERILE", "NO_PACKED" ],
-        "faults": [ "fault_bionic_salvaged" ]
-      },
+      { "drop": "bio_power_storage_mkII", "type": "bionic", "flags": [ "NO_STERILE", "NO_PACKED" ] },
+      { "drop": "bionics_soldat_zombie_generic", "type": "bionic_group", "flags": [ "NO_STERILE", "NO_PACKED" ] },
       { "drop": "meat_tainted", "type": "flesh", "mass_ratio": 0.25 },
       { "drop": "fat_tainted", "type": "flesh", "mass_ratio": 0.08 },
       { "drop": "bone_tainted", "type": "bone", "mass_ratio": 0.1 }
@@ -132,18 +62,8 @@
     "id": "CBM_SOLDAT_ZOMBIE",
     "type": "harvest",
     "entries": [
-      {
-        "drop": "bio_power_storage_mkII",
-        "type": "bionic",
-        "flags": [ "FILTHY", "NO_STERILE", "NO_PACKED" ],
-        "faults": [ "fault_bionic_salvaged" ]
-      },
-      {
-        "drop": "bionics_soldat_zombie",
-        "type": "bionic_group",
-        "flags": [ "FILTHY", "NO_STERILE", "NO_PACKED" ],
-        "faults": [ "fault_bionic_salvaged" ]
-      },
+      { "drop": "bio_power_storage_mkII", "type": "bionic", "flags": [ "NO_STERILE", "NO_PACKED" ] },
+      { "drop": "bionics_soldat_zombie", "type": "bionic_group", "flags": [ "NO_STERILE", "NO_PACKED" ] },
       { "drop": "meat_tainted", "type": "flesh", "mass_ratio": 0.25 },
       { "drop": "fat_tainted", "type": "flesh", "mass_ratio": 0.08 },
       { "drop": "bone_tainted", "type": "bone", "mass_ratio": 0.1 }
@@ -153,18 +73,8 @@
     "id": "CBM_SOLDAT_KNIGHT_ZOMBIE",
     "type": "harvest",
     "entries": [
-      {
-        "drop": "bio_power_storage_mkII",
-        "type": "bionic",
-        "flags": [ "FILTHY", "NO_STERILE", "NO_PACKED" ],
-        "faults": [ "fault_bionic_salvaged" ]
-      },
-      {
-        "drop": "bionics_soldat_knight_zombie",
-        "type": "bionic_group",
-        "flags": [ "FILTHY", "NO_STERILE", "NO_PACKED" ],
-        "faults": [ "fault_bionic_salvaged" ]
-      },
+      { "drop": "bio_power_storage_mkII", "type": "bionic", "flags": [ "NO_STERILE", "NO_PACKED" ] },
+      { "drop": "bionics_soldat_knight_zombie", "type": "bionic_group", "flags": [ "NO_STERILE", "NO_PACKED" ] },
       { "drop": "meat_tainted", "type": "flesh", "mass_ratio": 0.25 },
       { "drop": "fat_tainted", "type": "flesh", "mass_ratio": 0.08 },
       { "drop": "bone_tainted", "type": "bone", "mass_ratio": 0.1 }
@@ -174,18 +84,8 @@
     "id": "CBM_SOLDAT_SNIPER_ZOMBIE",
     "type": "harvest",
     "entries": [
-      {
-        "drop": "bio_power_storage_mkII",
-        "type": "bionic",
-        "flags": [ "FILTHY", "NO_STERILE", "NO_PACKED" ],
-        "faults": [ "fault_bionic_salvaged" ]
-      },
-      {
-        "drop": "bionics_soldat_sniper_zombie",
-        "type": "bionic_group",
-        "flags": [ "FILTHY", "NO_STERILE", "NO_PACKED" ],
-        "faults": [ "fault_bionic_salvaged" ]
-      },
+      { "drop": "bio_power_storage_mkII", "type": "bionic", "flags": [ "NO_STERILE", "NO_PACKED" ] },
+      { "drop": "bionics_soldat_sniper_zombie", "type": "bionic_group", "flags": [ "NO_STERILE", "NO_PACKED" ] },
       { "drop": "meat_tainted", "type": "flesh", "mass_ratio": 0.25 },
       { "drop": "fat_tainted", "type": "flesh", "mass_ratio": 0.08 },
       { "drop": "bone_tainted", "type": "bone", "mass_ratio": 0.1 }
@@ -195,18 +95,8 @@
     "id": "CBM_SOLDAT_TOOL_ZOMBIE",
     "type": "harvest",
     "entries": [
-      {
-        "drop": "bio_power_storage_mkII",
-        "type": "bionic",
-        "flags": [ "FILTHY", "NO_STERILE", "NO_PACKED" ],
-        "faults": [ "fault_bionic_salvaged" ]
-      },
-      {
-        "drop": "bionics_soldat_tool_zombie",
-        "type": "bionic_group",
-        "flags": [ "FILTHY", "NO_STERILE", "NO_PACKED" ],
-        "faults": [ "fault_bionic_salvaged" ]
-      },
+      { "drop": "bio_power_storage_mkII", "type": "bionic", "flags": [ "NO_STERILE", "NO_PACKED" ] },
+      { "drop": "bionics_soldat_tool_zombie", "type": "bionic_group", "flags": [ "NO_STERILE", "NO_PACKED" ] },
       { "drop": "meat_tainted", "type": "flesh", "mass_ratio": 0.25 },
       { "drop": "fat_tainted", "type": "flesh", "mass_ratio": 0.08 },
       { "drop": "bone_tainted", "type": "bone", "mass_ratio": 0.1 }

--- a/nocts_cata_mod_DDA/Monsters/c_monster_harvest.json
+++ b/nocts_cata_mod_DDA/Monsters/c_monster_harvest.json
@@ -27,7 +27,7 @@
       { "drop": "bone_human", "type": "bone", "mass_ratio": 0.12 },
       { "drop": "sinew", "type": "bone", "mass_ratio": 0.001 },
       { "drop": "raw_leather", "type": "skin", "mass_ratio": 0.01 },
-      { "drop": "alloy_sheet", "type": "skin", "mass_ratio": 0.01 }
+      { "drop": "alloy_sheet", "type": "skin", "mass_ratio": 0.015 }
     ]
   },
   {
@@ -55,7 +55,7 @@
       { "drop": "meat_tainted", "type": "flesh", "mass_ratio": 0.25 },
       { "drop": "fat_tainted", "type": "flesh", "mass_ratio": 0.08 },
       { "drop": "bone_tainted", "type": "bone", "mass_ratio": 0.1 },
-      { "drop": "alloy_sheet", "type": "skin", "mass_ratio": 0.1 }
+      { "drop": "alloy_sheet", "type": "skin", "mass_ratio": 0.015 }
     ]
   },
   {
@@ -104,7 +104,7 @@
       { "drop": "bone_human", "type": "bone", "mass_ratio": 0.12 },
       { "drop": "sinew", "type": "bone", "mass_ratio": 0.001 },
       { "drop": "raw_leather", "type": "skin", "mass_ratio": 0.01 },
-      { "drop": "alloy_sheet", "type": "skin", "mass_ratio": 0.25 }
+      { "drop": "alloy_sheet", "type": "skin", "mass_ratio": 0.015 }
     ]
   },
   {

--- a/nocts_cata_mod_DDA/Surv_help/c_armor.json
+++ b/nocts_cata_mod_DDA/Surv_help/c_armor.json
@@ -620,7 +620,7 @@
     "warmth": 5,
     "material_thickness": 1,
     "flags": [ "VARSIZE", "SKINTIGHT", "SUPER_FANCY" ],
-    "armor": [ { "encumbrance": 0, "coverage": 15, "covers": [ "legs" ] } ]
+    "armor": [ { "encumbrance": 0, "coverage": 15, "covers": [ "leg_r", "leg _l" ] } ]
   },
   {
     "id": "fancy_briefs",
@@ -638,7 +638,7 @@
     "warmth": 5,
     "material_thickness": 1,
     "flags": [ "VARSIZE", "SKINTIGHT", "SUPER_FANCY" ],
-    "armor": [ { "encumbrance": 0, "coverage": 15, "covers": [ "legs" ] } ]
+    "armor": [ { "encumbrance": 0, "coverage": 15, "covers": [ "leg_r", "leg _l" ] } ]
   },
   {
     "id": "fancy_boxer_shorts",
@@ -656,7 +656,7 @@
     "warmth": 5,
     "material_thickness": 1,
     "flags": [ "VARSIZE", "SKINTIGHT", "SUPER_FANCY" ],
-    "armor": [ { "encumbrance": 0, "coverage": 25, "covers": [ "legs" ] } ]
+    "armor": [ { "encumbrance": 0, "coverage": 25, "covers": [ "leg_r", "leg _l" ] } ]
   },
   {
     "id": "fancy_boxer_briefs",
@@ -674,7 +674,7 @@
     "warmth": 5,
     "material_thickness": 1,
     "flags": [ "VARSIZE", "SKINTIGHT", "SUPER_FANCY" ],
-    "armor": [ { "encumbrance": 0, "coverage": 20, "covers": [ "legs" ] } ]
+    "armor": [ { "encumbrance": 0, "coverage": 20, "covers": [ "leg_r", "leg _l" ] } ]
   },
   {
     "id": "bikini_bottom_leather",
@@ -692,7 +692,7 @@
     "warmth": 5,
     "material_thickness": 1,
     "flags": [ "VARSIZE", "SKINTIGHT", "WATER_FRIENDLY", "FANCY" ],
-    "armor": [ { "encumbrance": 0, "coverage": 15, "covers": [ "legs" ] } ]
+    "armor": [ { "encumbrance": 0, "coverage": 15, "covers": [ "leg_r", "leg _l" ] } ]
   },
   {
     "id": "bikini_bottom_fur",
@@ -710,7 +710,7 @@
     "warmth": 5,
     "material_thickness": 1,
     "flags": [ "VARSIZE", "SKINTIGHT", "WATER_FRIENDLY", "FANCY" ],
-    "armor": [ { "encumbrance": 0, "coverage": 15, "covers": [ "legs" ] } ]
+    "armor": [ { "encumbrance": 0, "coverage": 15, "covers": [ "leg_r", "leg _l" ] } ]
   },
   {
     "id": "thong",


### PR DESCRIPTION
* Updated alloy sheet harvest for bio-weapon monsters to be a bit more standardized, based on mass ratio used by kevlar zombies.
* Now that harvested bionics in BN no longer spawn filthy and faulty, applied the same update to harvests in the BN version.
* Fixed incorrect bodypart IDs in the DDA version for designer clothes. Whoops. Closes https://github.com/Noctifer-de-Mortem/nocts_cata_mod/issues/313