### PR TITLE
Port over DDA updates from modpack, rarity update for fancy clothes

### DIFF
--- a/nocts_cata_mod_BN/Surv_help/c_item_groups.json
+++ b/nocts_cata_mod_BN/Surv_help/c_item_groups.json
@@ -376,11 +376,11 @@
     "type": "item_group",
     "items": [
       [ "biomap", 1 ],
-      [ "dress_skirt", 75 ],
+      [ "dress_skirt", 25 ],
       [ "microskirt", 10 ],
-      [ "fancy_bra", 30 ],
-      [ "fancy_panties", 30 ],
-      [ "thong", 30 ]
+      [ "fancy_bra", 10 ],
+      [ "fancy_panties", 10 ],
+      [ "thong", 5 ]
     ]
   },
   {
@@ -438,42 +438,42 @@
   {
     "id": "female_underwear_top",
     "type": "item_group",
-    "items": [ [ "fancy_bra", 90 ] ]
+    "items": [ [ "fancy_bra", 10 ] ]
   },
   {
     "id": "female_underwear_bottom",
     "type": "item_group",
-    "items": [ [ "fancy_panties", 70 ], [ "thong", 70 ], [ "bikini_bottom_fur", 5 ], [ "bikini_bottom_leather", 7 ] ]
+    "items": [ [ "fancy_panties", 20 ], [ "thong", 10 ], [ "bikini_bottom_fur", 3 ], [ "bikini_bottom_leather", 3 ] ]
   },
   {
     "type": "item_group",
     "id": "male_underwear_bottom",
-    "items": [ [ "fancy_boxer_shorts", 70 ], [ "fancy_briefs", 30 ], [ "fancy_boxer_briefs", 50 ] ]
+    "items": [ [ "fancy_boxer_shorts", 10 ], [ "fancy_briefs", 10 ], [ "fancy_boxer_briefs", 10 ] ]
   },
   {
     "id": "allclothes",
     "type": "item_group",
     "items": [
-      [ "dress_skirt", 75 ],
+      [ "dress_skirt", 25 ],
       [ "microskirt", 10 ],
-      [ "fancy_bra", 30 ],
-      [ "fancy_panties", 30 ],
-      [ "thong", 30 ],
-      { "item": "fancy_briefs", "prob": 15 },
-      { "item": "fancy_boxer_briefs", "prob": 20 },
-      { "item": "fancy_panties", "prob": 30 },
-      { "item": "fancy_house_coat", "prob": 25 }
+      [ "fancy_bra", 10 ],
+      [ "fancy_panties", 10 ],
+      [ "thong", 10 ],
+      { "item": "fancy_briefs", "prob": 5 },
+      { "item": "fancy_boxer_briefs", "prob": 10 },
+      { "item": "fancy_panties", "prob": 10 },
+      { "item": "fancy_house_coat", "prob": 10 }
     ]
   },
   {
     "type": "item_group",
     "id": "swimmer_torso",
-    "items": [ [ "bikini_top_fur", 50 ], [ "bikini_top_leather", 50 ] ]
+    "items": [ [ "bikini_top_fur", 10 ], [ "bikini_top_leather", 10 ] ]
   },
   {
     "type": "item_group",
     "id": "swimmer_pants",
-    "items": [ [ "bikini_bottom_fur", 35 ], [ "bikini_bottom_leather", 35 ] ]
+    "items": [ [ "bikini_bottom_fur", 10 ], [ "bikini_bottom_leather", 10 ] ]
   },
   {
     "id": "underwear_womens",
@@ -481,12 +481,12 @@
     "//": "womens underwear.",
     "subtype": "distribution",
     "items": [
-      { "item": "bikini_bottom", "prob": 20 },
+      { "item": "bikini_bottom", "prob": 15 },
       { "item": "bikini_bottom_fur", "prob": 5 },
-      { "item": "bikini_bottom_leather", "prob": 10 },
-      { "item": "fancy_bra", "prob": 60 },
-      { "item": "fancy_panties", "prob": 70 },
-      { "item": "thong", "prob": 70 }
+      { "item": "bikini_bottom_leather", "prob": 5 },
+      { "item": "fancy_bra", "prob": 30 },
+      { "item": "fancy_panties", "prob": 30 },
+      { "item": "thong", "prob": 20 }
     ]
   },
   {
@@ -495,20 +495,20 @@
     "//": "mens underwear.",
     "subtype": "distribution",
     "items": [
-      { "item": "fancy_boxer_briefs", "prob": 30 },
-      { "item": "fancy_boxer_shorts", "prob": 50 },
-      { "item": "fancy_briefs", "prob": 50 }
+      { "item": "fancy_boxer_briefs", "prob": 10 },
+      { "item": "fancy_boxer_shorts", "prob": 10 },
+      { "item": "fancy_briefs", "prob": 10 }
     ]
   },
   {
     "id": "pawn",
     "type": "item_group",
-    "items": [ [ "dress_skirt", 75 ], [ "microskirt", 10 ] ]
+    "items": [ [ "dress_skirt", 25 ], [ "microskirt", 10 ] ]
   },
   {
     "id": "pants",
     "type": "item_group",
-    "items": [ [ "dress_skirt", 75 ], [ "microskirt", 10 ] ]
+    "items": [ [ "dress_skirt", 25 ], [ "microskirt", 10 ] ]
   },
   {
     "id": "dead_slave_fighters",

--- a/nocts_cata_mod_DDA/Npc/NC_BIO_WEAPONS.json
+++ b/nocts_cata_mod_DDA/Npc/NC_BIO_WEAPONS.json
@@ -43,7 +43,7 @@
     "type": "item_group",
     "subtype": "collection",
     "entries": [
-      { "item": "adv_UPS_off", "charges": [ 1250, 2500 ] },
+      { "item": "UPS_off", "charges": [ 1250, 2500 ] },
       { "item": "mre_veggy_box" },
       { "item": "biomap" },
       { "item": "militarymap" },

--- a/nocts_cata_mod_DDA/Recipe/c_recipes.json
+++ b/nocts_cata_mod_DDA/Recipe/c_recipes.json
@@ -585,7 +585,7 @@
       [ [ "leather", 10 ], [ "tanned_hide", 2 ] ],
       [ [ "fur", 15 ], [ "tanned_pelt", 3 ] ],
       [ [ "duct_tape", 150 ] ],
-      [ [ "kevlar_plate", 12 ] ],
+      [ [ "sheet_kevlar_layered", 12 ] ],
       [ [ "cable", 50 ] ],
       [ [ "wristwatch", 1 ] ]
     ]
@@ -613,7 +613,7 @@
       [ [ "hazmat_suit", 1 ], [ "cleansuit", 1 ] ],
       [ [ "fur", 15 ], [ "tanned_pelt", 3 ] ],
       [ [ "duct_tape", 150 ] ],
-      [ [ "kevlar_plate", 12 ] ],
+      [ [ "sheet_kevlar_layered", 12 ] ],
       [ [ "cable", 50 ] ],
       [ [ "wristwatch", 1 ] ]
     ]
@@ -1892,7 +1892,7 @@
       [ [ "leather", 10 ], [ "tanned_hide", 2 ] ],
       [ [ "coat_rain", 1 ], [ "jacket_windbreaker", 1 ], [ "jacket_evac", 1 ], [ "coat_gut", 1 ] ],
       [ [ "duct_tape", 300 ] ],
-      [ [ "kevlar", 1 ], [ "swat_armor", 1 ], [ "kevlar_plate", 24 ] ]
+      [ [ "kevlar", 1 ], [ "swat_armor", 1 ], [ "sheet_kevlar_layered", 24 ] ]
     ]
   },
   {
@@ -1932,7 +1932,7 @@
       [ [ "leather", 5 ], [ "tanned_hide", 1 ] ],
       [ [ "coat_rain", 1 ], [ "jacket_windbreaker", 1 ], [ "jacket_evac", 1 ], [ "coat_gut", 1 ] ],
       [ [ "duct_tape", 125 ] ],
-      [ [ "kevlar_plate", 10 ] ]
+      [ [ "sheet_kevlar_layered", 10 ] ]
     ]
   },
   {
@@ -1954,7 +1954,7 @@
       [ [ "rag", 2 ] ],
       [ [ "leather", 2 ] ],
       [ [ "duct_tape", 75 ] ],
-      [ [ "kevlar_plate", 6 ] ]
+      [ [ "sheet_kevlar_layered", 6 ] ]
     ]
   },
   {
@@ -1976,7 +1976,7 @@
       [ [ "rag", 3 ] ],
       [ [ "leather", 3 ] ],
       [ [ "duct_tape", 100 ] ],
-      [ [ "kevlar_plate", 8 ] ]
+      [ [ "sheet_kevlar_layered", 8 ] ]
     ]
   },
   {
@@ -1997,7 +1997,7 @@
     "components": [
       [ [ "helmet_plate", 1 ] ],
       [ [ "leather", 5 ], [ "tanned_hide", 1 ] ],
-      [ [ "tac_helmet", 1 ], [ "tac_fullhelmet", 1 ], [ "helmet_army", 1 ], [ "kevlar_plate", 6 ] ],
+      [ [ "tac_helmet", 1 ], [ "tac_fullhelmet", 1 ], [ "helmet_army", 1 ], [ "sheet_kevlar_layered", 6 ] ],
       [ [ "rag", 2 ], [ "bandana", 1 ] ],
       [ [ "glasses_safety", 2 ], [ "glasses_bal", 1 ] ],
       [ [ "duct_tape", 75 ] ]
@@ -2021,7 +2021,7 @@
       [ [ "gloves_plate", 1 ] ],
       [ [ "leather", 2 ] ],
       [ [ "duct_tape", 50 ] ],
-      [ [ "gloves_tactical", 1 ], [ "kevlar_plate", 4 ] ]
+      [ [ "gloves_tactical", 1 ], [ "sheet_kevlar_layered", 4 ] ]
     ]
   },
   {
@@ -2038,7 +2038,7 @@
     "book_learn": [ [ "textbook_armwest", 6 ], [ "recipe_surv", 5 ] ],
     "using": [ [ "sewing_standard", 60 ] ],
     "tools": [ [ [ "welder", 42 ], [ "welder_crude", 63 ], [ "soldering_iron", 63 ], [ "toolset", 63 ] ] ],
-    "components": [ [ [ "boots_plate", 1 ] ], [ [ "leather", 4 ] ], [ [ "kevlar_plate", 4 ] ], [ [ "duct_tape", 100 ] ] ]
+    "components": [ [ [ "boots_plate", 1 ] ], [ [ "leather", 4 ] ], [ [ "sheet_kevlar_layered", 4 ] ], [ [ "duct_tape", 100 ] ] ]
   },
   {
     "type": "recipe",
@@ -2219,7 +2219,7 @@
     "skill_used": "fabrication",
     "difficulty": 5,
     "qualities": [ { "id": "CUT", "level": 1 }, { "id": "SEW", "level": 1 } ],
-    "components": [ [ [ "rag", 18 ] ], [ [ "kevlar_plate", 9 ] ], [ [ "alloy_plate", 2 ] ], [ [ "alloy_sheet", 3 ] ] ]
+    "components": [ [ [ "rag", 18 ] ], [ [ "sheet_kevlar_layered", 9 ] ], [ [ "alloy_plate", 2 ] ], [ [ "alloy_sheet", 3 ] ] ]
   },
   {
     "result": "mil_armor",
@@ -2231,7 +2231,7 @@
     "qualities": [ { "id": "CUT", "level": 1 }, { "id": "SEW", "level": 1 } ],
     "components": [
       [ [ "leather", 18 ] ],
-      [ [ "kevlar_plate", 12 ] ],
+      [ [ "sheet_kevlar_layered", 12 ] ],
       [ [ "alloy_plate", 3 ] ],
       [ [ "alloy_sheet", 1 ] ],
       [ [ "hard_steel_armor", 1 ] ]
@@ -2245,7 +2245,7 @@
     "skill_used": "fabrication",
     "difficulty": 7,
     "qualities": [ { "id": "CUT", "level": 1 }, { "id": "SEW", "level": 1 } ],
-    "components": [ [ [ "kevlar_plate", 45 ] ], [ [ "alloy_plate", 6 ] ], [ [ "hard_steel_armor", 3 ] ] ]
+    "components": [ [ [ "sheet_kevlar_layered", 45 ] ], [ [ "alloy_plate", 6 ] ], [ [ "hard_steel_armor", 3 ] ] ]
   },
   {
     "result": "lmil_helm",
@@ -2255,7 +2255,7 @@
     "skill_used": "fabrication",
     "difficulty": 5,
     "qualities": [ { "id": "CUT", "level": 1 }, { "id": "SEW", "level": 1 } ],
-    "components": [ [ [ "rag", 2 ] ], [ [ "kevlar_plate", 1 ] ], [ [ "alloy_sheet", 3 ] ] ]
+    "components": [ [ [ "rag", 2 ] ], [ [ "sheet_kevlar_layered", 1 ] ], [ [ "alloy_sheet", 3 ] ] ]
   },
   {
     "result": "mil_helm",
@@ -2267,7 +2267,7 @@
     "qualities": [ { "id": "CUT", "level": 1 }, { "id": "SEW", "level": 1 } ],
     "components": [
       [ [ "leather", 2 ] ],
-      [ [ "kevlar_plate", 3 ] ],
+      [ [ "sheet_kevlar_layered", 3 ] ],
       [ [ "alloy_plate", 1 ] ],
       [ [ "alloy_sheet", 2 ] ],
       [ [ "hard_steel_armor", 1 ] ]
@@ -2281,7 +2281,7 @@
     "skill_used": "fabrication",
     "difficulty": 7,
     "qualities": [ { "id": "CUT", "level": 1 }, { "id": "SEW", "level": 1 } ],
-    "components": [ [ [ "kevlar_plate", 5 ] ], [ [ "alloy_plate", 2 ] ], [ [ "hard_steel_armor", 1 ] ] ]
+    "components": [ [ [ "sheet_kevlar_layered", 5 ] ], [ [ "alloy_plate", 2 ] ], [ [ "hard_steel_armor", 1 ] ] ]
   },
   {
     "result": "flamethrower_surv",

--- a/nocts_cata_mod_DDA/Surv_help/c_item_groups.json
+++ b/nocts_cata_mod_DDA/Surv_help/c_item_groups.json
@@ -374,11 +374,11 @@
     "type": "item_group",
     "items": [
       [ "biomap", 1 ],
-      [ "dress_skirt", 75 ],
+      [ "dress_skirt", 25 ],
       [ "microskirt", 10 ],
-      [ "fancy_bra", 30 ],
-      [ "fancy_panties", 30 ],
-      [ "thong", 30 ]
+      [ "fancy_bra", 10 ],
+      [ "fancy_panties", 10 ],
+      [ "thong", 5 ]
     ]
   },
   {
@@ -436,42 +436,42 @@
   {
     "id": "female_underwear_top",
     "type": "item_group",
-    "items": [ [ "fancy_bra", 90 ] ]
+    "items": [ [ "fancy_bra", 10 ] ]
   },
   {
     "id": "female_underwear_bottom",
     "type": "item_group",
-    "items": [ [ "fancy_panties", 70 ], [ "thong", 70 ], [ "bikini_bottom_fur", 5 ], [ "bikini_bottom_leather", 7 ] ]
+    "items": [ [ "fancy_panties", 20 ], [ "thong", 10 ], [ "bikini_bottom_fur", 3 ], [ "bikini_bottom_leather", 3 ] ]
   },
   {
     "type": "item_group",
     "id": "male_underwear_bottom",
-    "items": [ [ "fancy_boxer_shorts", 70 ], [ "fancy_briefs", 30 ], [ "fancy_boxer_briefs", 50 ] ]
+    "items": [ [ "fancy_boxer_shorts", 10 ], [ "fancy_briefs", 10 ], [ "fancy_boxer_briefs", 10 ] ]
   },
   {
     "id": "allclothes",
     "type": "item_group",
     "items": [
-      [ "dress_skirt", 75 ],
+      [ "dress_skirt", 25 ],
       [ "microskirt", 10 ],
-      [ "fancy_bra", 30 ],
-      [ "fancy_panties", 30 ],
-      [ "thong", 30 ],
-      { "item": "fancy_briefs", "prob": 15 },
-      { "item": "fancy_boxer_briefs", "prob": 20 },
-      { "item": "fancy_panties", "prob": 30 },
-      { "item": "fancy_house_coat", "prob": 25 }
+      [ "fancy_bra", 10 ],
+      [ "fancy_panties", 10 ],
+      [ "thong", 10 ],
+      { "item": "fancy_briefs", "prob": 5 },
+      { "item": "fancy_boxer_briefs", "prob": 10 },
+      { "item": "fancy_panties", "prob": 10 },
+      { "item": "fancy_house_coat", "prob": 10 }
     ]
   },
   {
     "type": "item_group",
     "id": "swimmer_torso",
-    "items": [ [ "bikini_top_fur", 50 ], [ "bikini_top_leather", 50 ] ]
+    "items": [ [ "bikini_top_fur", 10 ], [ "bikini_top_leather", 10 ] ]
   },
   {
     "type": "item_group",
     "id": "swimmer_pants",
-    "items": [ [ "bikini_bottom_fur", 35 ], [ "bikini_bottom_leather", 35 ] ]
+    "items": [ [ "bikini_bottom_fur", 10 ], [ "bikini_bottom_leather", 10 ] ]
   },
   {
     "id": "underwear_womens",
@@ -479,12 +479,12 @@
     "//": "womens underwear.",
     "subtype": "distribution",
     "items": [
-      { "item": "bikini_bottom", "prob": 20 },
+      { "item": "bikini_bottom", "prob": 15 },
       { "item": "bikini_bottom_fur", "prob": 5 },
-      { "item": "bikini_bottom_leather", "prob": 10 },
-      { "item": "fancy_bra", "prob": 60 },
-      { "item": "fancy_panties", "prob": 70 },
-      { "item": "thong", "prob": 70 }
+      { "item": "bikini_bottom_leather", "prob": 5 },
+      { "item": "fancy_bra", "prob": 30 },
+      { "item": "fancy_panties", "prob": 30 },
+      { "item": "thong", "prob": 20 }
     ]
   },
   {
@@ -493,20 +493,20 @@
     "//": "mens underwear.",
     "subtype": "distribution",
     "items": [
-      { "item": "fancy_boxer_briefs", "prob": 30 },
-      { "item": "fancy_boxer_shorts", "prob": 50 },
-      { "item": "fancy_briefs", "prob": 50 }
+      { "item": "fancy_boxer_briefs", "prob": 10 },
+      { "item": "fancy_boxer_shorts", "prob": 10 },
+      { "item": "fancy_briefs", "prob": 10 }
     ]
   },
   {
     "id": "pawn",
     "type": "item_group",
-    "items": [ [ "dress_skirt", 75 ], [ "microskirt", 10 ] ]
+    "items": [ [ "dress_skirt", 25 ], [ "microskirt", 10 ] ]
   },
   {
     "id": "pants",
     "type": "item_group",
-    "items": [ [ "dress_skirt", 75 ], [ "microskirt", 10 ] ]
+    "items": [ [ "dress_skirt", 25 ], [ "microskirt", 10 ] ]
   },
   {
     "id": "dead_slave_fighters",

--- a/nocts_cata_mod_DDA/Terrain/Mapgen_Variants.json
+++ b/nocts_cata_mod_DDA/Terrain/Mapgen_Variants.json
@@ -122,7 +122,7 @@
         { "group": "hmil_armor_collection", "x": 10, "y": 9, "chance": 75, "repeat": 3 },
         { "group": "mil_armor_collection", "x": 10, "y": 9, "chance": 75, "repeat": 2 },
         { "group": "lmil_armor_collection", "x": 10, "y": 9, "chance": 75, "repeat": 1 },
-        { "item": "adv_UPS_off", "x": 10, "y": 10, "chance": 75, "repeat": 1 },
+        { "item": "UPS_off", "x": 10, "y": 10, "chance": 75, "repeat": 1 },
         { "item": "plut_cell", "x": 10, "y": 10, "chance": 75, "repeat": 5 },
         { "item": "medium_atomic_battery_cell", "x": 10, "y": 11, "chance": 75, "repeat": 10 },
         { "item": "plasma", "x": 10, "y": 12, "chance": 75, "repeat": 2 },

--- a/nocts_cata_mod_DDA/Terrain/sketchy_cabin.json
+++ b/nocts_cata_mod_DDA/Terrain/sketchy_cabin.json
@@ -147,7 +147,7 @@
       "furniture": { "C": "f_counter", "f": "f_counter_gate_c", "e": "f_table", "h": "f_chair", "l": "f_locker" },
       "place_loot": [
         { "group": "sketchy_cabin_guard_weapons", "x": 21, "y": 13, "chance": 90 },
-        { "item": "money_bundle", "x": 21, "y": 13, "chance": 50, "repeat": 5 }
+        { "item": "money_bundle_twenty", "x": 21, "y": 13, "chance": 50, "repeat": 5 }
       ]
     }
   },

--- a/nocts_cata_mod_DDA/legacy.json
+++ b/nocts_cata_mod_DDA/legacy.json
@@ -72,7 +72,7 @@
   {
     "id": "omnitech_plut_core",
     "type": "MIGRATION",
-    "replace": "adv_UPS_off"
+    "replace": "UPS_off"
   },
   {
     "id": "omnitech_ups_core",


### PR DESCRIPTION
* Ported over changes from Kenan's mod pack for the DDA version, involving fixing the item ID of money bundles, not using apparently obsolete UPS variant, and use of new kevlar sheet item instead of kevlar plates.
* And for both versions, made fancy clothes much more rare, as their combined weights will already make them appear at a reasonable rate overall.