### PR TITLE
Add PYROMANIAC_WEAPON to BN items

### DIFF
--- a/nocts_cata_mod_BN/Surv_help/c_bionics.json
+++ b/nocts_cata_mod_BN/Surv_help/c_bionics.json
@@ -94,7 +94,7 @@
     "modes": [ [ "DEFAULT", "auto", 5 ] ],
     "reload": 500,
     "ammo_effects": [ "FLAME", "INCENDIARY" ],
-    "flags": [ "NEVER_JAMS", "TRADER_AVOID", "NON-FOULING", "NEEDS_NO_LUBE" ]
+    "flags": [ "NEVER_JAMS", "TRADER_AVOID", "NON-FOULING", "NEEDS_NO_LUBE", "PYROMANIAC_WEAPON" ]
   },
   {
     "type": "bionic",

--- a/nocts_cata_mod_BN/Weapons/c_mods.json
+++ b/nocts_cata_mod_BN/Weapons/c_mods.json
@@ -26,7 +26,7 @@
     },
     "min_skills": [ [ "weapon", 2 ], [ "launcher", 1 ] ],
     "install_time": "30 m",
-    "flags": [ "FIRE_50", "STR_RELOAD", "PUMP_RAIL_COMPATIBLE", "NON-FOULING" ]
+    "flags": [ "FIRE_50", "STR_RELOAD", "PUMP_RAIL_COMPATIBLE", "NON-FOULING", "PYROMANIAC_WEAPON" ]
   },
   {
     "type": "GUNMOD",

--- a/nocts_cata_mod_BN/Weapons/c_ranged.json
+++ b/nocts_cata_mod_BN/Weapons/c_ranged.json
@@ -1582,7 +1582,7 @@
     "price_postapoc": "90 USD",
     "material": [ "superalloy", "steel" ],
     "ammo_effects": [ "PLASMA", "EXPLOSIVE_HUGE", "STREAM_BIG", "INCENDIARY", "WIDE", "EMP", "FLASHBANG" ],
-    "flags": [ "ALWAYS_TWOHAND", "NEVER_JAMS", "NON-FOULING", "NEEDS_NO_LUBE" ],
+    "flags": [ "ALWAYS_TWOHAND", "NEVER_JAMS", "NON-FOULING", "NEEDS_NO_LUBE", "PYROMANIAC_WEAPON" ],
     "ups_charges": 150,
     "skill": "launcher",
     "ammo": [ "plasma" ],


### PR DESCRIPTION
Adds the right flag to the flamethrower bionic weapon, the aux flamethrower, and the ionic cannon. Survivor flamethrower will also get this automatically once the relevant PR is merged since it inherits from the flamethrower template item.

Leave it for now until is https://github.com/cataclysmbnteam/Cataclysm-BN/pull/1004 merged, fiarly certain it'll only cause a skippable load error from citing a non-existent flag if merged early but still.