### PR TITLE
Fix DDA version yet again

### DIFF
--- a/nocts_cata_mod_DDA/Surv_help/c_armor.json
+++ b/nocts_cata_mod_DDA/Surv_help/c_armor.json
@@ -827,10 +827,12 @@
       "type": "transform"
     },
     "environmental_protection": 15,
+    "material_thickness": 4,
     "extend": { "flags": [ "WATERPROOF", "RAINPROOF", "CLIMATE_CONTROL", "GAS_PROOF", "REBREATHER" ] },
+    "material": [ "alien_resin", "flesh", "steel" ],
     "armor": [
       {
-        "encumbrance": 10,
+        "encumbrance": 30,
         "coverage": 100,
         "covers": [ "head", "mouth", "eyes", "torso", "arm_l", "arm_r", "hand_l", "hand_r", "leg_l", "leg_r", "foot_l", "foot_r" ]
       }

--- a/nocts_cata_mod_DDA/Weapons/c_magazines.json
+++ b/nocts_cata_mod_DDA/Weapons/c_magazines.json
@@ -152,14 +152,13 @@
     "description": "An ammo belt for the survivor's .223 LMG, using canvas and steel wire to form non-disintegrating links.  Not as effective as factory-made ammunition belts, and more awkward to reload too.",
     "weight": "200 g",
     "volume": "250 ml",
-    "material": [ "steel" ],
     "symbol": "#",
     "color": "light_gray",
     "ammo_type": [ "223" ],
     "pocket_data": [ { "pocket_type": "MAGAZINE", "ammo_restriction": { "223": 80 } } ],
     "capacity": 80,
     "reload_time": 200,
-    "armor_data": { "armor": [ { "encumbrance": 10, "coverage": 5, "covers": [ "torso" ] } ] },
+    "armor_data": { "material": [ "steel" ], "armor": [ { "encumbrance": 10, "coverage": 5, "covers": [ "torso" ] } ] },
     "flags": [ "BELTED", "OVERSIZE" ]
   },
   {
@@ -169,14 +168,13 @@
     "description": "An ammo belt for the survivor's 7.62x39 LMG, using canvas and steel wire to form non-disintegrating links.  Not as effective as factory-made ammunition belts, and more awkward to reload too.",
     "weight": "200 g",
     "volume": "250 ml",
-    "material": [ "steel" ],
     "symbol": "#",
     "color": "light_gray",
     "ammo_type": [ "762" ],
     "pocket_data": [ { "pocket_type": "MAGAZINE", "ammo_restriction": { "762": 80 } } ],
     "capacity": 80,
     "reload_time": 200,
-    "armor_data": { "armor": [ { "encumbrance": 10, "coverage": 5, "covers": [ "torso" ] } ] },
+    "armor_data": { "material": [ "steel" ], "armor": [ { "encumbrance": 10, "coverage": 5, "covers": [ "torso" ] } ] },
     "flags": [ "BELTED", "OVERSIZE" ]
   },
   {
@@ -186,14 +184,13 @@
     "description": "An ammo belt for the survivor's .308 GPMG, using canvas and steel wire to form non-disintegrating links.  Not as effective as factory-made ammunition belts, and more awkward to reload too.",
     "weight": "200 g",
     "volume": "250 ml",
-    "material": [ "steel" ],
     "symbol": "#",
     "color": "light_gray",
     "ammo_type": [ "308" ],
     "pocket_data": [ { "pocket_type": "MAGAZINE", "ammo_restriction": { "308": 80 } } ],
     "capacity": 80,
     "reload_time": 200,
-    "armor_data": { "armor": [ { "encumbrance": 10, "coverage": 5, "covers": [ "torso" ] } ] },
+    "armor_data": { "material": [ "steel" ], "armor": [ { "encumbrance": 10, "coverage": 5, "covers": [ "torso" ] } ] },
     "flags": [ "BELTED", "OVERSIZE" ]
   },
   {
@@ -204,14 +201,13 @@
     "weight": "200 g",
     "volume": "250 ml",
     "looks_like": "surv_belt_308",
-    "material": [ "steel" ],
     "symbol": "#",
     "color": "light_gray",
     "ammo_type": [ "762R" ],
     "pocket_data": [ { "pocket_type": "MAGAZINE", "ammo_restriction": { "762R": 80 } } ],
     "capacity": 80,
     "reload_time": 200,
-    "armor_data": { "armor": [ { "encumbrance": 10, "coverage": 5, "covers": [ "torso" ] } ] },
+    "armor_data": { "material": [ "steel" ], "armor": [ { "encumbrance": 10, "coverage": 5, "covers": [ "torso" ] } ] },
     "flags": [ "BELTED", "OVERSIZE" ]
   },
   {


### PR DESCRIPTION
This should now be the last batch of fixes for mods required by https://github.com/CleverRaven/Cataclysm-DDA/pull/52029 messing with copy-from and material definitions for armor.