### PR TITLE
Changing mod category from misc additions to content

### DIFF
--- a/nocts_cata_mod_BN/modinfo.json
+++ b/nocts_cata_mod_BN/modinfo.json
@@ -4,7 +4,7 @@
     "id": "Cata++",
     "name": "Cataclysm++",
     "authors": [ "Noctifer" ],
-    "description": "The unofficial expansion mod for Cataclysm: Dark Days Ahead.",
+    "description": "The unofficial expansion mod for Cataclysm: Bright Nights.\n\nThe gigantic jabberwock of a mod that adds a lot of content to the game: new items, buildings, scenarios, monsters, etc. It also reworks and adds alternatives to many things from recipes to scenarios. It also adds a pseudo-story and lore on the works.\n\nThe Bio-Weapon, Super Soldier, Commandeers, Slave Fighters and the Old World Prepper NPC factions join the world.\n\nSeek the Bio-weapons, find loot, take down new monsters and invest in skills for new craftable items.",
     "category": "content",
     "dependencies": [ "dda" ]
   }

--- a/nocts_cata_mod_BN/modinfo.json
+++ b/nocts_cata_mod_BN/modinfo.json
@@ -5,7 +5,7 @@
     "name": "Cataclysm++",
     "authors": [ "Noctifer" ],
     "description": "The unofficial expansion mod for Cataclysm: Dark Days Ahead.",
-    "category": "misc_additions",
+    "category": "content",
     "dependencies": [ "dda" ]
   }
 ]

--- a/nocts_cata_mod_DDA/modinfo.json
+++ b/nocts_cata_mod_DDA/modinfo.json
@@ -5,7 +5,7 @@
     "name": "Cataclysm++",
     "authors": [ "Noctifer" ],
     "description": "The unofficial expansion mod for Cataclysm: Dark Days Ahead.",
-    "category": "misc_additions",
+    "category": "content",
     "dependencies": [ "dda" ]
   }
 ]

--- a/nocts_cata_mod_DDA/modinfo.json
+++ b/nocts_cata_mod_DDA/modinfo.json
@@ -4,7 +4,7 @@
     "id": "Cata++",
     "name": "Cataclysm++",
     "authors": [ "Noctifer" ],
-    "description": "The unofficial expansion mod for Cataclysm: Dark Days Ahead.",
+    "description": "The unofficial expansion mod for Cataclysm: Dark Days Ahead.\n\nThe gigantic jabberwock of a mod that adds a lot of content to the game: new items, buildings, scenarios, monsters, etc. It also reworks and adds alternatives to many things from recipes to scenarios. It also adds a pseudo-story and lore on the works.\n\nThe Bio-Weapon, Super Soldier, Commandeers, Slave Fighters and the Old World Prepper NPC factions join the world.\n\nSeek the Bio-weapons, find loot, take down new monsters and invest in skills for new craftable items.",
     "category": "content",
     "dependencies": [ "dda" ]
   }


### PR DESCRIPTION
According to 
https://github.com/cataclysmbnteam/Cataclysm-BN/blob/upload/doc/MODDING.md 
and 
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/MODDING.md

`content` category is expected to be used with such large mods as Cataclysm++, so I'm proposing this via PR.

This is a little change that will sure not break anything but will help inexperienced players to see at glance that this is a big thing.
Additionally, changed modinfo description to better describe what exactly to expect from the mod via in-game UI.

![изображение](https://user-images.githubusercontent.com/60776130/143733670-8fba1ccb-c1a4-442a-bf64-3ab561847cf0.png)
