### PR TITLE
Fix heavy military helmets in BN version

### DIFF
--- a/nocts_cata_mod_BN/Surv_help/c_armor.json
+++ b/nocts_cata_mod_BN/Surv_help/c_armor.json
@@ -503,7 +503,7 @@
     "coverage": 100,
     "encumbrance": 36,
     "warmth": 30,
-    "material_thickness": 6,
+    "material_thickness": 1,
     "environmental_protection": 4,
     "environmental_protection_with_filter": 16,
     "max_charges": 100,


### PR DESCRIPTION
Easy fix, just a small holdover from before the material updates were added to let them be repairable while having the exact specified armor values.