### PR TITLE
Martial art addition, related tweaks

### DIFF
--- a/nocts_cata_mod_BN/Char_creation/c_scenarios.json
+++ b/nocts_cata_mod_BN/Char_creation/c_scenarios.json
@@ -9,23 +9,8 @@
     "start_name": "Bio-Weapon Lab",
     "allowed_locs": [ "Bio_Weapon_Lab_l" ],
     "professions": [ "bio_weapon_a", "bio_weapon_b", "bio_weapon_g", "bio_weapon_d", "failed_weapon" ],
-    "forbidden_traits": [
-      "GOURMAND",
-      "MARTIAL_ARTS",
-      "MARTIAL_ARTS5",
-      "PARKOUR",
-      "MARTIAL_ARTS2",
-      "MARTIAL_ARTS3",
-      "SPIRITUAL",
-      "STYLISH",
-      "MARTIAL_ARTS4",
-      "HOARDER",
-      "NOMAD",
-      "PACIFIST",
-      "TABLEMANNERS",
-      "SQUEAMISH",
-      "WAYFARER"
-    ]
+    "traits": [ "MARTIAL_ARTS_MUT_COM", "MARTIAL_ARTS_BIOJUTSU" ],
+    "forbidden_traits": [ "GOURMAND", "PARKOUR", "SPIRITUAL", "STYLISH", "HOARDER", "NOMAD", "PACIFIST", "SQUEAMISH", "WAYFARER" ]
   },
   {
     "type": "scenario",
@@ -37,16 +22,12 @@
     "start_name": "Fungal Territory",
     "allowed_locs": [ "sloc_forest", "sloc_field" ],
     "professions": [ "mycus_weapon" ],
+    "traits": [ "MARTIAL_ARTS_MUT_COM", "MARTIAL_ARTS_BIOJUTSU" ],
     "forbidden_traits": [
       "GOURMAND",
-      "MARTIAL_ARTS",
-      "MARTIAL_ARTS5",
       "PARKOUR",
-      "MARTIAL_ARTS2",
-      "MARTIAL_ARTS3",
       "SPIRITUAL",
       "STYLISH",
-      "MARTIAL_ARTS4",
       "HOARDER",
       "NOMAD",
       "PACIFIST",
@@ -63,7 +44,8 @@
     "points": 2,
     "start_name": "Boarded Up House",
     "allowed_locs": [ "sloc_house_boarded" ],
-    "professions": [ "survivalist", "jr_survivalist", "bionic_prepper", "prepper" ]
+    "professions": [ "survivalist", "jr_survivalist", "bionic_prepper", "prepper" ],
+    "traits": [ "MARTIAL_ARTS_SURV_COM" ]
   },
   {
     "type": "scenario",
@@ -84,6 +66,9 @@
       "FELINE_EARS",
       "GROWL",
       "LIGHT_BONES",
+      "MARTIAL_ARTS_BIOJUTSU",
+      "MARTIAL_ARTS_MUT_COM",
+      "MARTIAL_ARTS_SURV_COM",
       "NAILS",
       "PADDED_FEET",
       "PLANTSKIN",
@@ -115,31 +100,26 @@
       "Bio_Weapon_Lab",
       "haz_sar_1_2"
     ],
-    "professions": [ "bio_infantry", "bio_scout", "bio_knight", "bio_tool" ]
+    "professions": [ "bio_infantry", "bio_scout", "bio_knight", "bio_tool" ],
+    "traits": [ "MARTIAL_ARTS_BIOJUTSU" ]
   },
   {
     "copy-from": "alone",
     "type": "scenario",
     "id": "alone",
-    "extend": { "traits": [ "MARTIAL_ARTS_SURV_COM", "MARTIAL_ARTS_BIOJUTSU" ] }
+    "extend": { "traits": [ "MARTIAL_ARTS_SURV_COM" ] }
   },
   {
     "copy-from": "summer_advanced_start",
     "type": "scenario",
     "id": "summer_advanced_start",
-    "extend": {
-      "traits": [ "MARTIAL_ARTS_SURV_COM", "MARTIAL_ARTS_BIOJUTSU" ],
-      "professions": [ "bio_infantry", "bio_scout", "bio_knight", "bio_tool" ]
-    }
+    "extend": { "traits": [ "MARTIAL_ARTS_SURV_COM" ], "professions": [ "bio_infantry", "bio_scout", "bio_knight", "bio_tool" ] }
   },
   {
     "copy-from": "ambushed",
     "type": "scenario",
     "id": "ambushed",
-    "extend": {
-      "traits": [ "MARTIAL_ARTS_SURV_COM", "MARTIAL_ARTS_BIOJUTSU" ],
-      "professions": [ "bio_infantry", "bio_scout", "bio_knight", "bio_tool" ]
-    }
+    "extend": { "traits": [ "MARTIAL_ARTS_SURV_COM" ], "professions": [ "bio_infantry", "bio_scout", "bio_knight", "bio_tool" ] }
   },
   {
     "copy-from": "cyberpunk",
@@ -157,7 +137,7 @@
     "copy-from": "mutant",
     "type": "scenario",
     "id": "mutant",
-    "extend": { "professions": [ "failed_weapon" ] }
+    "extend": { "traits": [ "MARTIAL_ARTS_MUT_COM" ], "professions": [ "failed_weapon" ] }
   },
   {
     "copy-from": "lab_chal",

--- a/nocts_cata_mod_BN/Monsters/c_monster_drops.json
+++ b/nocts_cata_mod_BN/Monsters/c_monster_drops.json
@@ -9,7 +9,11 @@
       { "group": "weapon_suit", "damage": [ 1, 4 ] },
       { "group": "weapon_badge", "damage": [ 0, 0 ] },
       { "group": "weapom_feet", "damage": [ 1, 4 ] },
-      { "group": "bio_weapon_power", "damage": [ 0, 1 ], "prob": 25 }
+      { "group": "bio_weapon_power", "damage": [ 0, 1 ], "prob": 25 },
+      {
+        "distribution": [ { "item": "manual_biojutsu", "prob": 50 }, { "item": "manual_mut_com", "prob": 50 } ],
+        "prob": 5
+      }
     ]
   },
   {
@@ -23,6 +27,10 @@
       { "group": "weapon_badge", "damage": [ 0, 0 ] },
       { "group": "weapom_feet", "damage": [ 1, 4 ] },
       { "group": "bio_weapon_power", "damage": [ 0, 1 ], "prob": 25 },
+      {
+        "distribution": [ { "item": "manual_biojutsu", "prob": 50 }, { "item": "manual_mut_com", "prob": 50 } ],
+        "prob": 5
+      },
       {
         "distribution": [
           { "item": "marloss_berry", "prob": 50 },
@@ -42,7 +50,11 @@
       { "group": "weapon_hat", "damage": [ 1, 4 ] },
       { "group": "weapon_suit", "damage": [ 1, 4 ] },
       { "group": "weapon_badge_apophis", "damage": [ 0, 0 ] },
-      { "group": "weapom_feet", "damage": [ 1, 4 ] }
+      { "group": "weapom_feet", "damage": [ 1, 4 ] },
+      {
+        "distribution": [ { "item": "manual_biojutsu", "prob": 50 }, { "item": "manual_mut_com", "prob": 50 } ],
+        "prob": 100
+      }
     ]
   },
   {

--- a/nocts_cata_mod_BN/Mutations/c_bio_mutation.json
+++ b/nocts_cata_mod_BN/Mutations/c_bio_mutation.json
@@ -90,7 +90,7 @@
     "id": "MARTIAL_ARTS_SURV_COM",
     "name": { "str": "Survivor Combatives" },
     "points": 3,
-    "description": "You have become good at using improvised and hand made weaponry, and to a lesser extent your fists.  You start with the Survivor Combatives style.",
+    "description": "You learned how to handle yourself in the cataclysm.  Whether armed or unarmed, you know how to use your wits to stay alive.  Survival is of the highest priority.",
     "initial_ma_styles": [ "style_surv_com" ],
     "valid": false
   },
@@ -101,6 +101,15 @@
     "points": 3,
     "description": "You start with the Bionic Combatives style.  A modern combat style for the post-modern human.  Nicknamed \"Biojutsu\", Bionic Combatives combines integrated weaponry, armor and augments into an consolidated fighting discipline.",
     "initial_ma_styles": [ "style_biojutsu" ],
+    "valid": false
+  },
+  {
+    "type": "mutation",
+    "id": "MARTIAL_ARTS_MUT_COM",
+    "name": { "str": "Post-Human Combatives" },
+    "points": 3,
+    "description": "You start with the Post-Human Combatives style.  You've learned a number of tricks to take advantage of the potential that abandoning your humanity can offer.  Focused on heavy, powerful weapons or mutant limbs, a supernaturally strong post-human can use their abilities to great effect.",
+    "initial_ma_styles": [ "style_mut_com" ],
     "valid": false
   },
   {

--- a/nocts_cata_mod_BN/Surv_help/c_item_groups.json
+++ b/nocts_cata_mod_BN/Surv_help/c_item_groups.json
@@ -156,8 +156,7 @@
       [ "surv_sniper", 2 ],
       [ "elc_bld", 2 ],
       [ "recipe_surv", 2 ],
-      [ "manual_surv_com", 1 ],
-      [ "manual_biojutsu", 1 ]
+      { "group": "survivor_combative_books", "prob": 2 }
     ]
   },
   {
@@ -165,6 +164,11 @@
     "type": "item_group",
     "subtype": "collection",
     "groups": [ [ "encylopedias_rare", 5 ] ]
+  },
+  {
+    "id": "survivor_combative_books",
+    "type": "item_group",
+    "items": [ [ "manual_surv_com", 75 ], [ "manual_biojutsu", 20 ], [ "manual_mut_com", 5 ] ]
   },
   {
     "id": "encylopedias_common",
@@ -237,8 +241,7 @@
     "type": "item_group",
     "items": [
       [ "recipe_surv", 1 ],
-      [ "manual_surv_com", 1 ],
-      [ "manual_biojutsu", 1 ],
+      { "group": "survivor_combative_books", "prob": 1 },
       { "group": "encylopedias_common", "prob": 1 }
     ]
   },
@@ -247,8 +250,7 @@
     "type": "item_group",
     "items": [
       [ "recipe_surv", 1 ],
-      [ "manual_surv_com", 1 ],
-      [ "manual_biojutsu", 1 ],
+      { "group": "survivor_combative_books", "prob": 1 },
       { "group": "encylopedias_common", "prob": 1 }
     ]
   },
@@ -257,8 +259,7 @@
     "type": "item_group",
     "items": [
       [ "recipe_surv", 2 ],
-      [ "manual_surv_com", 1 ],
-      [ "manual_biojutsu", 1 ],
+      { "group": "survivor_combative_books", "prob": 3 },
       { "group": "encylopedias_common", "prob": 5 }
     ]
   },
@@ -267,8 +268,7 @@
     "type": "item_group",
     "items": [
       [ "recipe_surv", 1 ],
-      [ "manual_surv_com", 1 ],
-      [ "manual_biojutsu", 1 ],
+      { "group": "survivor_combative_books", "prob": 1 },
       { "group": "encylopedias_common", "prob": 1 },
       [ "biomap", 1 ]
     ]
@@ -278,8 +278,7 @@
     "type": "item_group",
     "items": [
       [ "recipe_surv", 2 ],
-      [ "manual_surv_com", 1 ],
-      [ "manual_biojutsu", 1 ],
+      { "group": "survivor_combative_books", "prob": 1 },
       { "group": "encylopedias_common", "prob": 1 }
     ]
   },
@@ -864,5 +863,40 @@
     "id": "c_mi_go_advanced_dissection_myrmidon",
     "subtype": "distribution",
     "items": [ [ "c_mi_go_carapace_broken", 3 ], [ "c_mi_go_beam_broken", 1 ], [ "c_mi_go_claw_broken", 1 ] ]
+  },
+  {
+    "id": "sewer",
+    "type": "item_group",
+    "items": [ [ "manual_mut_com", 1 ] ]
+  },
+  {
+    "id": "sewage_plant",
+    "type": "item_group",
+    "items": [ [ "manual_mut_com", 1 ] ]
+  },
+  {
+    "id": "toxic_dump_equipment",
+    "type": "item_group",
+    "items": [ [ "manual_mut_com", 1 ] ]
+  },
+  {
+    "id": "trash",
+    "type": "item_group",
+    "items": [ [ "manual_mut_com", 1 ] ]
+  },
+  {
+    "id": "book_martial",
+    "type": "item_group",
+    "items": [ { "group": "survivor_combative_books", "prob": 5 } ]
+  },
+  {
+    "id": "book_military",
+    "type": "item_group",
+    "items": [ { "group": "survivor_combative_books", "prob": 10 } ]
+  },
+  {
+    "id": "rare_martial_arts_books",
+    "type": "item_group",
+    "items": [ { "group": "survivor_combative_books", "prob": 1 } ]
   }
 ]

--- a/nocts_cata_mod_BN/Surv_help/c_item_groups_modcompat.json
+++ b/nocts_cata_mod_BN/Surv_help/c_item_groups_modcompat.json
@@ -12,7 +12,7 @@
   {
     "id": "sanguine_cult_books",
     "type": "item_group",
-    "items": [ { "group": "encylopedias_rare", "prob": 5 } ]
+    "items": [ { "group": "encylopedias_rare", "prob": 3 }, [ "manual_mut_com", 2 ] ]
   },
   {
     "id": "unaligned_arcanist_books",

--- a/nocts_cata_mod_BN/Surv_help/c_martialarts.json
+++ b/nocts_cata_mod_BN/Surv_help/c_martialarts.json
@@ -64,6 +64,126 @@
     ]
   },
   {
+    "type": "martial_art",
+    "id": "style_mut_com",
+    "name": { "str": "Post-Human Combatives" },
+    "description": "You've learned a number of tricks to take advantage of the potential that abandoning your humanity can offer.  Focused on heavy, powerful weapons or mutant limbs, a supernaturally strong post-human can use their abilities to great effect.",
+    "initiate": [ "Your loosen your footwork and let your instincts take over.", "%s enters a loose, animalistic stance." ],
+    "learn_difficulty": 9,
+    "primary_skill": "melee",
+    "static_buffs": [
+      {
+        "id": "buff_mut_com_static",
+        "name": "Large And In Charge",
+        "description": "Your stance makes better use of your might to compensate for poor footwork.\nAccuracy increased by 15% of strength, -10 move cost.",
+        "skill_requirements": [ { "name": "melee", "level": 6 } ],
+        "unarmed_allowed": true,
+        "melee_allowed": true,
+        "flat_bonuses": [ { "stat": "hit", "scaling-stat": "str", "scale": 0.15 }, { "stat": "movecost", "scale": -10.0 } ]
+      }
+    ],
+    "onpause_buffs": [
+      {
+        "id": "buff_mut_com_onpause",
+        "name": "Stored Potential",
+        "description": "Conserving your energy and focusing your mind will permit explosive bursts of action.\n\n-10 move cost.\nLasts 2 turns, stacks 3 times.",
+        "skill_requirements": [ { "name": "melee", "level": 5 } ],
+        "unarmed_allowed": true,
+        "melee_allowed": true,
+        "buff_duration": 3,
+        "max_stacks": 3,
+        "flat_bonuses": [ { "stat": "movecost", "scale": -10.0 } ]
+      }
+    ],
+    "onmove_buffs": [
+      {
+        "id": "buff_mut_com_onmove",
+        "name": "Bull Rush",
+        "description": "When you get enough momentum going, they're going to feel it.\n\nMovement speed increased by 45% of strength, bash damage increased by 15% of strength.  Enables \"Battering Ram\" technique.\nLasts 2 turns, stacks 3 times.",
+        "skill_requirements": [ { "name": "melee", "level": 4 } ],
+        "unarmed_allowed": true,
+        "melee_allowed": true,
+        "buff_duration": 2,
+        "max_stacks": 3,
+        "flat_bonuses": [
+          { "stat": "speed", "scaling-stat": "str", "scale": 0.45 },
+          { "stat": "damage", "type": "bash", "scaling-stat": "str", "scale": 0.15 }
+        ]
+      }
+    ],
+    "onhit_buffs": [
+      {
+        "id": "buff_mut_com_onhit",
+        "name": "Brutal Efficiency",
+        "description": "One powerful blow makes the follow-up that much easier.\n\n+2 Accuracy, bash armor penetration increased by 30% of strength.\nLasts 2 turns, stacks 2 times.",
+        "skill_requirements": [ { "name": "melee", "level": 7 } ],
+        "unarmed_allowed": true,
+        "melee_allowed": true,
+        "buff_duration": 2,
+        "max_stacks": 2,
+        "flat_bonuses": [
+          { "stat": "hit", "scale": 2 },
+          { "stat": "arpen", "type": "bash", "scaling-stat": "str", "scale": 0.3 }
+        ]
+      }
+    ],
+    "techniques": [ "tec_mut_com_battering_ram", "tec_mut_com_overrun", "tec_mut_com_stampeding_strike" ],
+    "weapons": [
+      "2h_flail_steel",
+      "2h_flail_wood",
+      "chainsaw_off",
+      "chainsaw_on",
+      "cs_lajatang_off",
+      "cs_lajatang_on",
+      "combatsaw_off",
+      "combatsaw_on",
+      "e_combatsaw_off",
+      "e_combatsaw_on",
+      "elec_chainsaw_off",
+      "elec_chainsaw_on",
+      "ecs_lajatang_off",
+      "ecs_lajatang_on",
+      "glaive",
+      "halberd",
+      "halberd_fake",
+      "hammer_sledge",
+      "hammer_sledge_engineer",
+      "hammer_sledge_heavy",
+      "hammer_sledge_short",
+      "homewrecker",
+      "ji",
+      "lajatang",
+      "lobotomizer",
+      "longsword",
+      "longsword_fake",
+      "longsword_inferior",
+      "lucern_hammer",
+      "lucern_hammerfake",
+      "makeshift_halberd",
+      "makeshift_scythe_war",
+      "masonrysaw_off",
+      "masonrysaw_on",
+      "naginata",
+      "naginata_fake",
+      "naginata_inferior",
+      "nodachi",
+      "nodachi_fake",
+      "nodachi_inferior",
+      "pickaxe",
+      "pike",
+      "pike_copper",
+      "pike_fake",
+      "pike_inferior",
+      "pike_wood",
+      "scythe",
+      "scythe_war",
+      "spear_survivor",
+      "zweihander",
+      "zweihander_fake",
+      "zweihander_inferior"
+    ]
+  },
+  {
     "id": "style_biojutsu",
     "copy-from": "style_biojutsu",
     "type": "martial_art",

--- a/nocts_cata_mod_BN/Surv_help/c_martialarts.json
+++ b/nocts_cata_mod_BN/Surv_help/c_martialarts.json
@@ -102,7 +102,7 @@
         "skill_requirements": [ { "name": "melee", "level": 4 } ],
         "unarmed_allowed": true,
         "melee_allowed": true,
-        "buff_duration": 2,
+        "buff_duration": 3,
         "max_stacks": 3,
         "flat_bonuses": [
           { "stat": "speed", "scaling-stat": "str", "scale": 0.45 },
@@ -120,13 +120,10 @@
         "melee_allowed": true,
         "buff_duration": 2,
         "max_stacks": 2,
-        "flat_bonuses": [
-          { "stat": "hit", "scale": 2 },
-          { "stat": "arpen", "type": "bash", "scaling-stat": "str", "scale": 0.3 }
-        ]
+        "flat_bonuses": [ { "stat": "hit", "scale": 2 }, { "stat": "arpen", "type": "bash", "scaling-stat": "str", "scale": 0.3 } ]
       }
     ],
-    "techniques": [ "tec_mut_com_battering_ram", "tec_mut_com_overrun", "tec_mut_com_stampeding_strike" ],
+    "techniques": [ "tec_mut_com_battering_ram", "tec_mut_com_overrun", "tec_mut_com_stampeding_strike", "tec_mut_com_feint" ],
     "weapons": [
       "2h_flail_steel",
       "2h_flail_wood",
@@ -258,15 +255,7 @@
     "type": "martial_art",
     "name": "Ninjutsu",
     "extend": {
-      "weapons": [
-        "elc_bld",
-        "elc_blds",
-        "molded_knife",
-        "unbio_bladed_weapon",
-        "unbio_sword_weapon",
-        "flesh_knife",
-        "flesh_blade"
-      ]
+      "weapons": [ "elc_bld", "elc_blds", "molded_knife", "unbio_bladed_weapon", "unbio_sword_weapon", "flesh_knife", "flesh_blade" ]
     }
   },
   {

--- a/nocts_cata_mod_BN/Surv_help/c_martialarts.json
+++ b/nocts_cata_mod_BN/Surv_help/c_martialarts.json
@@ -68,7 +68,7 @@
     "name": { "str": "Post-Human Combatives" },
     "description": "You've learned a number of tricks to take advantage of the potential that abandoning your humanity can offer.  Focused on heavy, powerful weapons or mutant limbs, a supernaturally strong post-human can use their abilities to great effect.",
     "initiate": [ "Your loosen your footwork and let your instincts take over.", "%s enters a loose, animalistic stance." ],
-    "learn_difficulty": 9,
+    "learn_difficulty": 7,
     "primary_skill": "melee",
     "static_buffs": [
       {

--- a/nocts_cata_mod_BN/Surv_help/c_martialartsbook.json
+++ b/nocts_cata_mod_BN/Surv_help/c_martialartsbook.json
@@ -32,5 +32,22 @@
       "chapters": 3,
       "martial_art": "style_biojutsu"
     }
+  },
+  {
+    "id": "manual_mut_com",
+    "copy-from": "book_martial",
+    "type": "GENERIC",
+    "name": { "str": "Post-Human Combatives Manual" },
+    "description": "A very lengthy and boring journal detailing the ramblings of some increasingly mutated and augmented survivor, and the unorthodox combat techniques they developed to suit their inhuman abilities.",
+    "book_data": {
+      "max_level": 10,
+      "intelligence": 8,
+      "time": "50 m",
+      "fun": -2,
+      "skill": "melee",
+      "required_level": 7,
+      "chapters": 4,
+      "martial_art": "style_mut_com"
+    }
   }
 ]

--- a/nocts_cata_mod_BN/Surv_help/c_martialartsbook.json
+++ b/nocts_cata_mod_BN/Surv_help/c_martialartsbook.json
@@ -40,12 +40,12 @@
     "name": { "str": "Post-Human Combatives Manual" },
     "description": "A very lengthy and boring journal detailing the ramblings of some increasingly mutated and augmented survivor, and the unorthodox combat techniques they developed to suit their inhuman abilities.",
     "book_data": {
-      "max_level": 10,
+      "max_level": 7,
       "intelligence": 8,
       "time": "50 m",
       "fun": -2,
       "skill": "melee",
-      "required_level": 7,
+      "required_level": 4,
       "chapters": 4,
       "martial_art": "style_mut_com"
     }

--- a/nocts_cata_mod_BN/Surv_help/c_techniques.json
+++ b/nocts_cata_mod_BN/Surv_help/c_techniques.json
@@ -67,5 +67,44 @@
     "unarmed_allowed": true,
     "melee_allowed": true,
     "disarms": true
+  },
+  {
+    "type": "technique",
+    "id": "tec_mut_com_battering_ram",
+    "name": "Battering Ram",
+    "messages": [ "You send %s flying with a mighty blow", "<npcname>'s sends %s flying with a mighty blow" ],
+    "skill_requirements": [ { "name": "melee", "level": 6 } ],
+    "unarmed_allowed": true,
+    "melee_allowed": true,
+    "req_buffs": [ "buff_mut_com_onmove" ],
+    "crit_tec": true,
+    "stun_dur": 2,
+    "knockback_dist": 4,
+    "powerful_knockback": true
+  },
+  {
+    "type": "technique",
+    "id": "tec_mut_com_overrun",
+    "name": "Overrun",
+    "messages": [ "You swiftly slam into and bowl over %s", "<npcname> swiftly slams into and bowls over %s" ],
+    "skill_requirements": [ { "name": "melee", "level": 5 } ],
+    "unarmed_allowed": true,
+    "melee_allowed": true,
+    "crit_tec": true,
+    "down_dur": 2,
+    "mult_bonuses": [ { "stat": "movecost", "scale": 0.9 } ]
+  },
+  {
+    "type": "technique",
+    "id": "tec_mut_com_stampeding_strike",
+    "name": "Stampeding Strike",
+    "messages": [ "You bear down on %s with terrible force", "<npcname> bears down on %s with terrible force" ],
+    "skill_requirements": [ { "name": "melee", "level": 7 } ],
+    "unarmed_allowed": true,
+    "crit_tec": true,
+    "downed_target": true,
+    "stun_dur": 1,
+    "flat_bonuses": [ { "stat": "arpen", "type": "bash", "scaling-stat": "str", "scale": 0.9 } ],
+    "mult_bonuses": [ { "stat": "damage", "type": "bash", "scale": 1.3 } ]
   }
 ]

--- a/nocts_cata_mod_BN/Surv_help/c_techniques.json
+++ b/nocts_cata_mod_BN/Surv_help/c_techniques.json
@@ -106,5 +106,16 @@
     "stun_dur": 1,
     "flat_bonuses": [ { "stat": "arpen", "type": "bash", "scaling-stat": "str", "scale": 0.9 } ],
     "mult_bonuses": [ { "stat": "damage", "type": "bash", "scale": 1.3 } ]
+  },
+  {
+    "type": "technique",
+    "id": "tec_mut_com_feint",
+    "name": "Feint",
+    "messages": [ "You fake a strike at %s", "<npcname> fakes a strike at %s" ],
+    "skill_requirements": [ { "name": "melee", "level": 5 } ],
+    "unarmed_allowed": true,
+    "melee_allowed": true,
+    "defensive": true,
+    "miss_recovery": true
   }
 ]

--- a/nocts_cata_mod_DDA/Char_creation/c_scenarios.json
+++ b/nocts_cata_mod_DDA/Char_creation/c_scenarios.json
@@ -10,15 +10,11 @@
     "start_name": "Bio-Weapon Lab",
     "allowed_locs": [ "Bio_Weapon_Lab_l" ],
     "professions": [ "bio_weapon_a", "bio_weapon_b", "bio_weapon_g", "bio_weapon_d", "failed_weapon" ],
+    "traits": [ "MARTIAL_ARTS_MUT_COM", "MARTIAL_ARTS_BIOJUTSU" ],
     "forbidden_traits": [
       "GOURMAND",
-      "MARTIAL_ARTS",
-      "MARTIAL_ARTS5",
-      "MARTIAL_ARTS2",
-      "MARTIAL_ARTS3",
       "SPIRITUAL",
       "STYLISH",
-      "MARTIAL_ARTS4",
       "HOARDER",
       "NOMAD",
       "PACIFIST",
@@ -40,15 +36,11 @@
     "start_name": "Fungal Territory",
     "allowed_locs": [ "sloc_forest", "sloc_field" ],
     "professions": [ "mycus_weapon" ],
+    "traits": [ "MARTIAL_ARTS_MUT_COM", "MARTIAL_ARTS_BIOJUTSU" ],
     "forbidden_traits": [
       "GOURMAND",
-      "MARTIAL_ARTS",
-      "MARTIAL_ARTS5",
-      "MARTIAL_ARTS2",
-      "MARTIAL_ARTS3",
       "SPIRITUAL",
       "STYLISH",
-      "MARTIAL_ARTS4",
       "HOARDER",
       "NOMAD",
       "PACIFIST",
@@ -67,7 +59,8 @@
     "points": 2,
     "start_name": "Boarded Up House",
     "allowed_locs": [ "sloc_house_boarded" ],
-    "professions": [ "survivalist", "jr_survivalist", "prepper" ]
+    "professions": [ "survivalist", "jr_survivalist", "prepper" ],
+    "traits": [ "MARTIAL_ARTS_SURV_COM" ]
   },
   {
     "type": "scenario",
@@ -88,6 +81,9 @@
       "FELINE_EARS",
       "GROWL",
       "LIGHT_BONES",
+      "MARTIAL_ARTS_BIOJUTSU",
+      "MARTIAL_ARTS_MUT_COM",
+      "MARTIAL_ARTS_SURV_COM",
       "NAILS",
       "PADDED_FEET",
       "PLANTSKIN",
@@ -119,31 +115,26 @@
       "Bio_Weapon_Lab",
       "haz_sar_1_2"
     ],
-    "professions": [ "bio_infantry", "bio_scout", "bio_knight", "bio_tool" ]
+    "professions": [ "bio_infantry", "bio_scout", "bio_knight", "bio_tool" ],
+    "traits": [ "MARTIAL_ARTS_BIOJUTSU" ]
   },
   {
     "copy-from": "alone",
     "type": "scenario",
     "id": "alone",
-    "extend": { "traits": [ "MARTIAL_ARTS_SURV_COM", "MARTIAL_ARTS_BIOJUTSU" ] }
+    "extend": { "traits": [ "MARTIAL_ARTS_SURV_COM" ] }
   },
   {
     "copy-from": "summer_advanced_start",
     "type": "scenario",
     "id": "summer_advanced_start",
-    "extend": {
-      "traits": [ "MARTIAL_ARTS_SURV_COM", "MARTIAL_ARTS_BIOJUTSU" ],
-      "professions": [ "bio_infantry", "bio_scout", "bio_knight", "bio_tool" ]
-    }
+    "extend": { "traits": [ "MARTIAL_ARTS_SURV_COM" ], "professions": [ "bio_infantry", "bio_scout", "bio_knight", "bio_tool" ] }
   },
   {
     "copy-from": "ambushed",
     "type": "scenario",
     "id": "ambushed",
-    "extend": {
-      "traits": [ "MARTIAL_ARTS_SURV_COM", "MARTIAL_ARTS_BIOJUTSU" ],
-      "professions": [ "bio_infantry", "bio_scout", "bio_knight", "bio_tool" ]
-    }
+    "extend": { "traits": [ "MARTIAL_ARTS_SURV_COM" ], "professions": [ "bio_infantry", "bio_scout", "bio_knight", "bio_tool" ] }
   },
   {
     "copy-from": "cyberpunk",
@@ -161,7 +152,7 @@
     "copy-from": "mutant",
     "type": "scenario",
     "id": "mutant",
-    "extend": { "professions": [ "failed_weapon" ] }
+    "extend": { "traits": [ "MARTIAL_ARTS_MUT_COM" ], "professions": [ "failed_weapon" ] }
   },
   {
     "copy-from": "lab_chal",

--- a/nocts_cata_mod_DDA/Monsters/c_monster_drops.json
+++ b/nocts_cata_mod_DDA/Monsters/c_monster_drops.json
@@ -9,7 +9,11 @@
       { "group": "weapon_suit", "damage": [ 1, 4 ] },
       { "group": "weapon_badge", "damage": [ 0, 0 ] },
       { "group": "weapom_feet", "damage": [ 1, 4 ] },
-      { "group": "bio_weapon_power", "damage": [ 0, 1 ], "prob": 25 }
+      { "group": "bio_weapon_power", "damage": [ 0, 1 ], "prob": 25 },
+      {
+        "distribution": [ { "item": "manual_biojutsu", "prob": 50 }, { "item": "manual_mut_com", "prob": 50 } ],
+        "prob": 5
+      }
     ]
   },
   {
@@ -23,6 +27,10 @@
       { "group": "weapon_badge", "damage": [ 0, 0 ] },
       { "group": "weapom_feet", "damage": [ 1, 4 ] },
       { "group": "bio_weapon_power", "damage": [ 0, 1 ], "prob": 25 },
+      {
+        "distribution": [ { "item": "manual_biojutsu", "prob": 50 }, { "item": "manual_mut_com", "prob": 50 } ],
+        "prob": 5
+      },
       {
         "distribution": [
           { "item": "marloss_berry", "prob": 50 },
@@ -42,7 +50,11 @@
       { "group": "weapon_hat", "damage": [ 1, 4 ] },
       { "group": "weapon_suit", "damage": [ 1, 4 ] },
       { "group": "weapon_badge_apophis", "damage": [ 0, 0 ] },
-      { "group": "weapom_feet", "damage": [ 1, 4 ] }
+      { "group": "weapom_feet", "damage": [ 1, 4 ] },
+      {
+        "distribution": [ { "item": "manual_biojutsu", "prob": 50 }, { "item": "manual_mut_com", "prob": 50 } ],
+        "prob": 100
+      }
     ]
   },
   {

--- a/nocts_cata_mod_DDA/Mutations/c_bio_mutation.json
+++ b/nocts_cata_mod_DDA/Mutations/c_bio_mutation.json
@@ -92,7 +92,7 @@
     "id": "MARTIAL_ARTS_SURV_COM",
     "name": { "str": "Survivor Combatives" },
     "points": 3,
-    "description": "You have become good at using improvised and hand made weaponry, and to a lesser extent your fists.  You start with the Survivor Combatives style.",
+    "description": "You learned how to handle yourself in the cataclysm.  Whether armed or unarmed, you know how to use your wits to stay alive.  Survival is of the highest priority.",
     "initial_ma_styles": [ "style_surv_com" ],
     "valid": false
   },
@@ -103,6 +103,15 @@
     "points": 3,
     "description": "You start with the Bionic Combatives style.  A modern combat style for the post-modern human.  Nicknamed \"Biojutsu\", Bionic Combatives combines integrated weaponry, armor and augments into an consolidated fighting discipline.",
     "initial_ma_styles": [ "style_biojutsu" ],
+    "valid": false
+  },
+  {
+    "type": "mutation",
+    "id": "MARTIAL_ARTS_MUT_COM",
+    "name": { "str": "Post-Human Combatives" },
+    "points": 3,
+    "description": "You start with the Post-Human Combatives style.  You've learned a number of tricks to take advantage of the potential that abandoning your humanity can offer.  Focused on heavy, powerful weapons or mutant limbs, a supernaturally strong post-human can use their abilities to great effect.",
+    "initial_ma_styles": [ "style_mut_com" ],
     "valid": false
   },
   {

--- a/nocts_cata_mod_DDA/Surv_help/c_item_groups.json
+++ b/nocts_cata_mod_DDA/Surv_help/c_item_groups.json
@@ -156,8 +156,7 @@
       [ "surv_sniper", 2 ],
       [ "elc_bld", 2 ],
       [ "recipe_surv", 2 ],
-      [ "manual_surv_com", 1 ],
-      [ "manual_biojutsu", 1 ]
+      { "group": "survivor_combative_books", "prob": 2 }
     ]
   },
   {
@@ -165,6 +164,11 @@
     "type": "item_group",
     "subtype": "collection",
     "groups": [ [ "encylopedias_rare", 5 ] ]
+  },
+  {
+    "id": "survivor_combative_books",
+    "type": "item_group",
+    "items": [ [ "manual_surv_com", 75 ], [ "manual_biojutsu", 20 ], [ "manual_mut_com", 5 ] ]
   },
   {
     "id": "encylopedias_common",
@@ -235,8 +239,7 @@
     "type": "item_group",
     "items": [
       [ "recipe_surv", 1 ],
-      [ "manual_surv_com", 1 ],
-      [ "manual_biojutsu", 1 ],
+      { "group": "survivor_combative_books", "prob": 1 },
       { "group": "encylopedias_common", "prob": 1 }
     ]
   },
@@ -245,8 +248,7 @@
     "type": "item_group",
     "items": [
       [ "recipe_surv", 1 ],
-      [ "manual_surv_com", 1 ],
-      [ "manual_biojutsu", 1 ],
+      { "group": "survivor_combative_books", "prob": 1 },
       { "group": "encylopedias_common", "prob": 1 }
     ]
   },
@@ -255,8 +257,7 @@
     "type": "item_group",
     "items": [
       [ "recipe_surv", 2 ],
-      [ "manual_surv_com", 1 ],
-      [ "manual_biojutsu", 1 ],
+      { "group": "survivor_combative_books", "prob": 3 },
       { "group": "encylopedias_common", "prob": 5 }
     ]
   },
@@ -265,8 +266,7 @@
     "type": "item_group",
     "items": [
       [ "recipe_surv", 1 ],
-      [ "manual_surv_com", 1 ],
-      [ "manual_biojutsu", 1 ],
+      { "group": "survivor_combative_books", "prob": 1 },
       { "group": "encylopedias_common", "prob": 1 },
       [ "biomap", 1 ]
     ]
@@ -276,8 +276,7 @@
     "type": "item_group",
     "items": [
       [ "recipe_surv", 2 ],
-      [ "manual_surv_com", 1 ],
-      [ "manual_biojutsu", 1 ],
+      { "group": "survivor_combative_books", "prob": 1 },
       { "group": "encylopedias_common", "prob": 1 }
     ]
   },
@@ -874,5 +873,40 @@
     "id": "c_mi_go_advanced_dissection_myrmidon",
     "subtype": "distribution",
     "items": [ [ "c_mi_go_carapace_broken", 3 ], [ "c_mi_go_beam_broken", 1 ], [ "c_mi_go_claw_broken", 1 ] ]
+  },
+  {
+    "id": "sewer",
+    "type": "item_group",
+    "items": [ [ "manual_mut_com", 1 ] ]
+  },
+  {
+    "id": "sewage_plant",
+    "type": "item_group",
+    "items": [ [ "manual_mut_com", 1 ] ]
+  },
+  {
+    "id": "toxic_dump_equipment",
+    "type": "item_group",
+    "items": [ [ "manual_mut_com", 1 ] ]
+  },
+  {
+    "id": "trash",
+    "type": "item_group",
+    "items": [ [ "manual_mut_com", 1 ] ]
+  },
+  {
+    "id": "book_martial",
+    "type": "item_group",
+    "items": [ { "group": "survivor_combative_books", "prob": 5 } ]
+  },
+  {
+    "id": "book_military",
+    "type": "item_group",
+    "items": [ { "group": "survivor_combative_books", "prob": 10 } ]
+  },
+  {
+    "id": "rare_martial_arts_books",
+    "type": "item_group",
+    "items": [ { "group": "survivor_combative_books", "prob": 1 } ]
   }
 ]

--- a/nocts_cata_mod_DDA/Surv_help/c_item_groups_modcompat.json
+++ b/nocts_cata_mod_DDA/Surv_help/c_item_groups_modcompat.json
@@ -12,7 +12,7 @@
   {
     "id": "sanguine_cult_books",
     "type": "item_group",
-    "items": [ { "group": "encylopedias_rare", "prob": 5 } ]
+    "items": [ { "group": "encylopedias_rare", "prob": 3 }, [ "manual_mut_com", 2 ] ]
   },
   {
     "id": "unaligned_arcanist_books",

--- a/nocts_cata_mod_DDA/Surv_help/c_martialarts.json
+++ b/nocts_cata_mod_DDA/Surv_help/c_martialarts.json
@@ -64,6 +64,126 @@
     ]
   },
   {
+    "type": "martial_art",
+    "id": "style_mut_com",
+    "name": { "str": "Post-Human Combatives" },
+    "description": "You've learned a number of tricks to take advantage of the potential that abandoning your humanity can offer.  Focused on heavy, powerful weapons or mutant limbs, a supernaturally strong post-human can use their abilities to great effect.",
+    "initiate": [ "Your loosen your footwork and let your instincts take over.", "%s enters a loose, animalistic stance." ],
+    "learn_difficulty": 9,
+    "primary_skill": "melee",
+    "static_buffs": [
+      {
+        "id": "buff_mut_com_static",
+        "name": "Large And In Charge",
+        "description": "Your stance makes better use of your might to compensate for poor footwork.\nAccuracy increased by 15% of strength, -10 move cost.",
+        "skill_requirements": [ { "name": "melee", "level": 6 } ],
+        "unarmed_allowed": true,
+        "melee_allowed": true,
+        "flat_bonuses": [ { "stat": "hit", "scaling-stat": "str", "scale": 0.15 }, { "stat": "movecost", "scale": -10.0 } ]
+      }
+    ],
+    "onpause_buffs": [
+      {
+        "id": "buff_mut_com_onpause",
+        "name": "Stored Potential",
+        "description": "Conserving your energy and focusing your mind will permit explosive bursts of action.\n\n-10 move cost.\nLasts 2 turns, stacks 3 times.",
+        "skill_requirements": [ { "name": "melee", "level": 5 } ],
+        "unarmed_allowed": true,
+        "melee_allowed": true,
+        "buff_duration": 3,
+        "max_stacks": 3,
+        "flat_bonuses": [ { "stat": "movecost", "scale": -10.0 } ]
+      }
+    ],
+    "onmove_buffs": [
+      {
+        "id": "buff_mut_com_onmove",
+        "name": "Bull Rush",
+        "description": "When you get enough momentum going, they're going to feel it.\n\nMovement speed increased by 45% of strength, bash damage increased by 15% of strength.  Enables \"Battering Ram\" technique.\nLasts 2 turns, stacks 3 times.",
+        "skill_requirements": [ { "name": "melee", "level": 4 } ],
+        "unarmed_allowed": true,
+        "melee_allowed": true,
+        "buff_duration": 2,
+        "max_stacks": 3,
+        "flat_bonuses": [
+          { "stat": "speed", "scaling-stat": "str", "scale": 0.45 },
+          { "stat": "damage", "type": "bash", "scaling-stat": "str", "scale": 0.15 }
+        ]
+      }
+    ],
+    "onhit_buffs": [
+      {
+        "id": "buff_mut_com_onhit",
+        "name": "Brutal Efficiency",
+        "description": "One powerful blow makes the follow-up that much easier.\n\n+2 Accuracy, bash armor penetration increased by 30% of strength.\nLasts 2 turns, stacks 2 times.",
+        "skill_requirements": [ { "name": "melee", "level": 7 } ],
+        "unarmed_allowed": true,
+        "melee_allowed": true,
+        "buff_duration": 2,
+        "max_stacks": 2,
+        "flat_bonuses": [
+          { "stat": "hit", "scale": 2 },
+          { "stat": "arpen", "type": "bash", "scaling-stat": "str", "scale": 0.3 }
+        ]
+      }
+    ],
+    "techniques": [ "tec_mut_com_battering_ram", "tec_mut_com_overrun", "tec_mut_com_stampeding_strike" ],
+    "weapons": [
+      "2h_flail_steel",
+      "2h_flail_wood",
+      "chainsaw_off",
+      "chainsaw_on",
+      "cs_lajatang_off",
+      "cs_lajatang_on",
+      "combatsaw_off",
+      "combatsaw_on",
+      "e_combatsaw_off",
+      "e_combatsaw_on",
+      "elec_chainsaw_off",
+      "elec_chainsaw_on",
+      "ecs_lajatang_off",
+      "ecs_lajatang_on",
+      "glaive",
+      "halberd",
+      "halberd_fake",
+      "hammer_sledge",
+      "hammer_sledge_engineer",
+      "hammer_sledge_heavy",
+      "hammer_sledge_short",
+      "homewrecker",
+      "ji",
+      "lajatang",
+      "lobotomizer",
+      "longsword",
+      "longsword_fake",
+      "longsword_inferior",
+      "lucern_hammer",
+      "lucern_hammerfake",
+      "makeshift_halberd",
+      "makeshift_scythe_war",
+      "masonrysaw_off",
+      "masonrysaw_on",
+      "naginata",
+      "naginata_fake",
+      "naginata_inferior",
+      "nodachi",
+      "nodachi_fake",
+      "nodachi_inferior",
+      "pickaxe",
+      "pike",
+      "pike_copper",
+      "pike_fake",
+      "pike_inferior",
+      "pike_wood",
+      "scythe",
+      "scythe_war",
+      "spear_survivor",
+      "zweihander",
+      "zweihander_fake",
+      "zweihander_inferior"
+    ]
+  },
+  {
     "id": "style_biojutsu",
     "copy-from": "style_biojutsu",
     "type": "martial_art",

--- a/nocts_cata_mod_DDA/Surv_help/c_martialarts.json
+++ b/nocts_cata_mod_DDA/Surv_help/c_martialarts.json
@@ -102,7 +102,7 @@
         "skill_requirements": [ { "name": "melee", "level": 4 } ],
         "unarmed_allowed": true,
         "melee_allowed": true,
-        "buff_duration": 2,
+        "buff_duration": 3,
         "max_stacks": 3,
         "flat_bonuses": [
           { "stat": "speed", "scaling-stat": "str", "scale": 0.45 },
@@ -120,13 +120,10 @@
         "melee_allowed": true,
         "buff_duration": 2,
         "max_stacks": 2,
-        "flat_bonuses": [
-          { "stat": "hit", "scale": 2 },
-          { "stat": "arpen", "type": "bash", "scaling-stat": "str", "scale": 0.3 }
-        ]
+        "flat_bonuses": [ { "stat": "hit", "scale": 2 }, { "stat": "arpen", "type": "bash", "scaling-stat": "str", "scale": 0.3 } ]
       }
     ],
-    "techniques": [ "tec_mut_com_battering_ram", "tec_mut_com_overrun", "tec_mut_com_stampeding_strike" ],
+    "techniques": [ "tec_mut_com_battering_ram", "tec_mut_com_overrun", "tec_mut_com_stampeding_strike", "tec_mut_com_feint" ],
     "weapons": [
       "2h_flail_steel",
       "2h_flail_wood",
@@ -258,15 +255,7 @@
     "type": "martial_art",
     "name": "Ninjutsu",
     "extend": {
-      "weapons": [
-        "elc_bld",
-        "elc_blds",
-        "molded_knife",
-        "unbio_bladed_weapon",
-        "unbio_sword_weapon",
-        "flesh_knife",
-        "flesh_blade"
-      ]
+      "weapons": [ "elc_bld", "elc_blds", "molded_knife", "unbio_bladed_weapon", "unbio_sword_weapon", "flesh_knife", "flesh_blade" ]
     }
   },
   {

--- a/nocts_cata_mod_DDA/Surv_help/c_martialarts.json
+++ b/nocts_cata_mod_DDA/Surv_help/c_martialarts.json
@@ -68,7 +68,7 @@
     "name": { "str": "Post-Human Combatives" },
     "description": "You've learned a number of tricks to take advantage of the potential that abandoning your humanity can offer.  Focused on heavy, powerful weapons or mutant limbs, a supernaturally strong post-human can use their abilities to great effect.",
     "initiate": [ "Your loosen your footwork and let your instincts take over.", "%s enters a loose, animalistic stance." ],
-    "learn_difficulty": 9,
+    "learn_difficulty": 7,
     "primary_skill": "melee",
     "static_buffs": [
       {

--- a/nocts_cata_mod_DDA/Surv_help/c_martialartsbook.json
+++ b/nocts_cata_mod_DDA/Surv_help/c_martialartsbook.json
@@ -32,5 +32,22 @@
       "chapters": 3,
       "martial_art": "style_biojutsu"
     }
+  },
+  {
+    "id": "manual_mut_com",
+    "copy-from": "book_martial",
+    "type": "GENERIC",
+    "name": { "str": "Post-Human Combatives Manual" },
+    "description": "A very lengthy and boring journal detailing the ramblings of some increasingly mutated and augmented survivor, and the unorthodox combat techniques they developed to suit their inhuman abilities.",
+    "book_data": {
+      "max_level": 10,
+      "intelligence": 8,
+      "time": "50 m",
+      "fun": -2,
+      "skill": "melee",
+      "required_level": 7,
+      "chapters": 4,
+      "martial_art": "style_mut_com"
+    }
   }
 ]

--- a/nocts_cata_mod_DDA/Surv_help/c_martialartsbook.json
+++ b/nocts_cata_mod_DDA/Surv_help/c_martialartsbook.json
@@ -40,12 +40,12 @@
     "name": { "str": "Post-Human Combatives Manual" },
     "description": "A very lengthy and boring journal detailing the ramblings of some increasingly mutated and augmented survivor, and the unorthodox combat techniques they developed to suit their inhuman abilities.",
     "book_data": {
-      "max_level": 10,
+      "max_level": 7,
       "intelligence": 8,
       "time": "50 m",
       "fun": -2,
       "skill": "melee",
-      "required_level": 7,
+      "required_level": 4,
       "chapters": 4,
       "martial_art": "style_mut_com"
     }

--- a/nocts_cata_mod_DDA/Surv_help/c_techniques.json
+++ b/nocts_cata_mod_DDA/Surv_help/c_techniques.json
@@ -67,5 +67,44 @@
     "unarmed_allowed": true,
     "melee_allowed": true,
     "disarms": true
+  },
+  {
+    "type": "technique",
+    "id": "tec_mut_com_battering_ram",
+    "name": "Battering Ram",
+    "messages": [ "You send %s flying with a mighty blow", "<npcname>'s sends %s flying with a mighty blow" ],
+    "skill_requirements": [ { "name": "melee", "level": 6 } ],
+    "unarmed_allowed": true,
+    "melee_allowed": true,
+    "req_buffs": [ "buff_mut_com_onmove" ],
+    "crit_tec": true,
+    "stun_dur": 2,
+    "knockback_dist": 4,
+    "powerful_knockback": true
+  },
+  {
+    "type": "technique",
+    "id": "tec_mut_com_overrun",
+    "name": "Overrun",
+    "messages": [ "You swiftly slam into and bowl over %s", "<npcname> swiftly slams into and bowls over %s" ],
+    "skill_requirements": [ { "name": "melee", "level": 5 } ],
+    "unarmed_allowed": true,
+    "melee_allowed": true,
+    "crit_tec": true,
+    "down_dur": 2,
+    "mult_bonuses": [ { "stat": "movecost", "scale": 0.9 } ]
+  },
+  {
+    "type": "technique",
+    "id": "tec_mut_com_stampeding_strike",
+    "name": "Stampeding Strike",
+    "messages": [ "You bear down on %s with terrible force", "<npcname> bears down on %s with terrible force" ],
+    "skill_requirements": [ { "name": "melee", "level": 7 } ],
+    "unarmed_allowed": true,
+    "crit_tec": true,
+    "downed_target": true,
+    "stun_dur": 1,
+    "flat_bonuses": [ { "stat": "arpen", "type": "bash", "scaling-stat": "str", "scale": 0.9 } ],
+    "mult_bonuses": [ { "stat": "damage", "type": "bash", "scale": 1.3 } ]
   }
 ]

--- a/nocts_cata_mod_DDA/Surv_help/c_techniques.json
+++ b/nocts_cata_mod_DDA/Surv_help/c_techniques.json
@@ -106,5 +106,16 @@
     "stun_dur": 1,
     "flat_bonuses": [ { "stat": "arpen", "type": "bash", "scaling-stat": "str", "scale": 0.9 } ],
     "mult_bonuses": [ { "stat": "damage", "type": "bash", "scale": 1.3 } ]
+  },
+  {
+    "type": "technique",
+    "id": "tec_mut_com_feint",
+    "name": "Feint",
+    "messages": [ "You fake a strike at %s", "<npcname> fakes a strike at %s" ],
+    "skill_requirements": [ { "name": "melee", "level": 5 } ],
+    "unarmed_allowed": true,
+    "melee_allowed": true,
+    "defensive": true,
+    "miss_recovery": true
   }
 ]


### PR DESCRIPTION
Still unsure what'd be a good name for this style that fits the "X Combatives" theme Bionic Combatives and Survivor Combatives both have, but eh.

`You've learned a number of tricks to take advantage of the potential that abandoning your humanity can offer.  Focused on heavy, powerful weapons or mutant limbs, a supernaturally strong post-human can use their abilities to great effect.`

Name | Level Available | Other Requirements | Type | Effect
------------ | ------------- | ------------- | ------------- | -------------
Large And In Charge | Melee 6 | Melee/Unarmed | Static Buff | Accuracy increased by 15% of strength, -10 move cost.
Stored Potential | Melee 5 | Melee/Unarmed | OnPause Buff | -10 move cost. Lasts 3 turns, stacks 3 times.
Bull Rush | Melee 4 | Melee/Unarmed | OnMove Buff | Enables "Battering Ram" technique. Speed increased by 45% of strength, bash damage increased by 15% of strength. Lasts 2 turns, stacks 3 times.
Brutal Efficiency | Melee 7 | Melee/Unarmed | OnHit Buff | +2 Accuracy, bash Armor Pentetration increased by 30% of strength. Lasts 2 turns, stacks 2 times.
Battering Ram | Melee 6 | Melee/Unarmed | Crit Technique | Requires "Bull Rush" buff. Stuns target for 2 turns, knockback 4, powerful knockback enabled.
Overrun | Melee 5 | Melee/Unarmed | Crit Technique | Downs target for 2 turns, 90% move cost.
Stampeding Strike | Melee 7 | Melee/Unarmed | Crit Technique | Requires downed target. Stuns target for 1 turn, bash Armor Pentetration increased by 90% of strength, 130% bash damage.

**Weapons:** Chainsaws (gas and electric, including active), combat chainsaws (gas and electric, including active), flails (both variants), glaive, halberds (including fake, inferior, and makeshift), homewrecker, ji, lajatangs (including chainsaw variants), lobotomizer, longswords (including fake and inferior), lucern hammers (including fake), masonry saws (including active), naginatas (including fake, inferior, and survivor), nodachis (including fake and inferior), pickaxe, pikes (including fake, inferior, wood, and copper), scythes (including war scythes), sledgehammers (all variants), zweihanders (including fake and inferior).

Post-Human Combatives is set up to be a foil of Survivor Combatives, geared more towards mutant characters with high strength. Essentually makes the two styles, together with vanilla's Bionic Combatives, form a triad of styles suitable for post-apoaclyptic survivors of different sorts.

Both Cata++ styles heavily use stat scaling, and both get some for of speed bonus that can be used offensively or defensively. Where Survivor Combatives scales off intelligence (aimed toward any character of average INT on up) and primarly gives defensive buffs, Post-Human Combatives leans all into offensive buffs particularly aimed at offset slow attack speeds and negative to-hit.

Likewise, Survivor Combatives gets good defensive techniques including counters and grab break, while Post-Human Combatives favors crit techniques that work off throwing your weight around. It also has a minor example of a set-up combo, with a knockdown critical that can be followed up with a Bone Breaker/Dragon Strike style crit-tec.

Survivor Combatives allows any weapon, which is a big part of why it doesn't get any direct offensive buffs. Post-Human Combatives goes for a weapon list that favors various big and bulky weapons that normally go underused due to poor accuracy and terribly slow attack speeds. Almost every style weapon has 150 or more base moves-per-attack, and most of them have over 200. That said, currently the full roster of abilities is usable with unarmed weapons and bare-handed, which may be overkill if you get a beefy enough character.

---

Assorted changes:
* Implemented the above martial art and its techniques.
* Implemented the book for it, spawns tend to be associated with mutants, the sort of places the Elf-a book can be hidden in, etc.
* Grouped the rare martial art spawns in common book groups into a sub-group that allows for finer control over spawn weights.
* Made use of a few martial art book groups not previously used by Cata++.
* Set it so that the augmented abominations can be a rare source of two of the manuals.
* Standardized the descriptions for the three Combatives mutations.
* Tweaked what scenarios allow starting with the three martial art traits. Generally basic post-apoc scenarios allow Survivor Combatives, scenarios involving post-apoc/escaped mutants allow Post-Human Combatives, while scenarios focused on bionics entail Bionic Combatives.
* Set it so bio-weapons can still start with general martial arts, for consistency with being able to start off with relevant combatives programs.
* Removed Rigid Table Manners from the scenario trait blacklist in BN version since it was obsoleted.