### PR TITLE
Couple assorted fixes

### DIFF
--- a/nocts_cata_mod_BN/Surv_help/c_item_groups.json
+++ b/nocts_cata_mod_BN/Surv_help/c_item_groups.json
@@ -97,8 +97,7 @@
       [ "45aux", 1 ],
       { "group": "lmil_armor_collection", "prob": 1 },
       { "group": "mil_armor_collection", "prob": 1 },
-      { "group": "hmil_armor_collection", "prob": 1 },
-      { "group": "ammo_atomic_batteries", "prob": 25 }
+      { "group": "hmil_armor_collection", "prob": 1 }
     ]
   },
   {
@@ -128,8 +127,7 @@
       [ "megamap", 5 ],
       [ "stim", 5 ],
       [ "boots_stealth", 3 ],
-      [ "acs_74_stealth_cloak_on", 3 ],
-      { "group": "ammo_atomic_batteries", "prob": 5 }
+      [ "acs_74_stealth_cloak_on", 3 ]
     ]
   },
   {
@@ -300,8 +298,7 @@
       [ "xarm_laser_shotgun", 2 ],
       [ "br_bolt_rifle_elec", 2 ],
       [ "mk_ionic_cannon", 2 ],
-      [ "cbm_rtg_inductor", 1 ],
-      { "group": "ammo_atomic_batteries_full", "prob": 5 }
+      [ "cbm_rtg_inductor", 1 ]
     ]
   },
   {
@@ -329,8 +326,7 @@
       [ "omnitech_weapon_ups_manual", 2 ],
       [ "blood_m", 2 ],
       [ "blood_p", 2 ],
-      [ "anesthetic_kit", 2 ],
-      { "group": "ammo_atomic_batteries", "prob": 10 }
+      [ "anesthetic_kit", 2 ]
     ]
   },
   {
@@ -352,8 +348,7 @@
       [ "goggles_nv_clairvoyance", 2 ],
       [ "blood_m", 1 ],
       [ "blood_p", 1 ],
-      [ "cbm_rtg_inductor", 1 ],
-      { "group": "ammo_atomic_batteries", "prob": 10 }
+      [ "cbm_rtg_inductor", 1 ]
     ]
   },
   {
@@ -764,36 +759,6 @@
       [ "bio_targeting", 5 ],
       [ "bio_torsionratchet", 7 ],
       [ "bio_ups", 8 ]
-    ]
-  },
-  {
-    "id": "electronics",
-    "type": "item_group",
-    "items": [ { "group": "ammo_atomic_batteries", "prob": 1 } ]
-  },
-  {
-    "id": "tools_science",
-    "type": "item_group",
-    "items": [ { "group": "ammo_atomic_batteries_full", "prob": 10 } ]
-  },
-  {
-    "id": "ammo_atomic_batteries",
-    "type": "item_group",
-    "items": [
-      { "item": "light_battery_cell", "prob": 4, "charges-min": 0, "charges-max": 1000 },
-      { "item": "light_minus_atomic_battery_cell", "prob": 3, "charges-min": 0, "charges-max": 500 },
-      { "item": "medium_battery_cell", "prob": 2, "charges-min": 0, "charges-max": 5000 },
-      { "item": "heavy_battery_cell", "prob": 1, "charges-min": 0, "charges-max": 10000 }
-    ]
-  },
-  {
-    "id": "ammo_atomic_batteries_full",
-    "type": "item_group",
-    "items": [
-      { "item": "light_battery_cell", "prob": 4, "charges-min": 1000, "charges-max": 1000 },
-      { "item": "light_minus_atomic_battery_cell", "prob": 3, "charges-min": 500, "charges-max": 500 },
-      { "item": "medium_battery_cell", "prob": 2, "charges-min": 5000, "charges-max": 5000 },
-      { "item": "heavy_battery_cell", "prob": 1, "charges-min": 10000, "charges-max": 10000 }
     ]
   },
   {

--- a/nocts_cata_mod_BN/Surv_help/c_martialarts.json
+++ b/nocts_cata_mod_BN/Surv_help/c_martialarts.json
@@ -16,8 +16,7 @@
       {
         "id": "buff_surv_com_onmove",
         "name": "Elusiveness",
-        "//": "Note: Doubled percentage signs are needed for correct formatting, not a typo.",
-        "description": "Quick and fluid movements make you harder to catch.\n\n+1 Dodge attempts, Dodge skill increased by 25%% of Intelligence, immunity to knockdown.\nLasts for 1 turn.",
+        "description": "Quick and fluid movements make you harder to catch.\n\n+1 Dodge attempts, Dodge skill increased by 25% of Intelligence, immunity to knockdown.\nLasts for 1 turn.",
         "skill_requirements": [ { "name": "melee", "level": 4 } ],
         "unarmed_allowed": true,
         "melee_allowed": true,
@@ -31,7 +30,7 @@
       {
         "id": "buff_surv_com_onhit",
         "name": "Active Defense",
-        "description": "The best defense is a good offense.\n\n+1 Block attempts, damage blocked increased by 100%% of Intelligence.\nLasts 2 turns.",
+        "description": "The best defense is a good offense.\n\n+1 Block attempts, damage blocked increased by 100% of Intelligence.\nLasts 2 turns.",
         "skill_requirements": [ { "name": "melee", "level": 5 } ],
         "unarmed_allowed": true,
         "melee_allowed": true,
@@ -44,7 +43,7 @@
       {
         "id": "buff_surv_com_onkill",
         "name": "Misdirection",
-        "description": "The shock and awe of combat gives you an opportunity to slip away.\n\n+2 Block attempts, +2 Dodge attempts, movement speed increased by 100%% of Intelligence, moving generates 1/2 as much noise.\nLast 6 turns.",
+        "description": "The shock and awe of combat gives you an opportunity to slip away.\n\n+2 Block attempts, +2 Dodge attempts, movement speed increased by 100% of Intelligence, moving generates 1/2 as much noise.\nLast 6 turns.",
         "skill_requirements": [ { "name": "melee", "level": 6 } ],
         "unarmed_allowed": true,
         "melee_allowed": true,

--- a/nocts_cata_mod_DDA/Surv_help/c_item_groups.json
+++ b/nocts_cata_mod_DDA/Surv_help/c_item_groups.json
@@ -98,7 +98,7 @@
       { "group": "lmil_armor_collection", "prob": 1 },
       { "group": "mil_armor_collection", "prob": 1 },
       { "group": "hmil_armor_collection", "prob": 1 },
-      { "group": "ammo_atomic_batteries", "prob": 25 }
+      { "group": "ammo_atomic_batteries", "prob": 10 }
     ]
   },
   {
@@ -128,8 +128,7 @@
       [ "megamap", 5 ],
       [ "stim", 5 ],
       [ "boots_stealth", 3 ],
-      [ "acs_74_stealth_cloak_on", 3 ],
-      { "group": "ammo_atomic_batteries", "prob": 5 }
+      [ "acs_74_stealth_cloak_on", 3 ]
     ]
   },
   {
@@ -298,8 +297,7 @@
       [ "xarm_laser_shotgun", 2 ],
       [ "br_bolt_rifle_elec", 2 ],
       [ "mk_ionic_cannon", 2 ],
-      [ "cbm_rtg_inductor", 1 ],
-      { "group": "ammo_atomic_batteries_full", "prob": 5 }
+      [ "cbm_rtg_inductor", 1 ]
     ]
   },
   {
@@ -328,7 +326,8 @@
       [ "blood_m", 2 ],
       [ "blood_p", 2 ],
       [ "anesthetic_kit", 2 ],
-      { "group": "ammo_atomic_batteries", "prob": 10 }
+      { "group": "ammo_atomic_batteries", "prob": 10 },
+      { "group": "ammo_atomic_batteries_full", "prob": 5 }
     ]
   },
   {
@@ -777,33 +776,23 @@
     ]
   },
   {
-    "id": "electronics",
-    "type": "item_group",
-    "items": [ { "group": "ammo_atomic_batteries", "prob": 1 } ]
-  },
-  {
-    "id": "tools_science",
-    "type": "item_group",
-    "items": [ { "group": "ammo_atomic_batteries_full", "prob": 10 } ]
-  },
-  {
     "id": "ammo_atomic_batteries",
     "type": "item_group",
     "items": [
-      { "item": "light_battery_cell", "prob": 4, "charges-min": 0, "charges-max": 1000 },
-      { "item": "light_minus_atomic_battery_cell", "prob": 3, "charges-min": 0, "charges-max": 500 },
-      { "item": "medium_battery_cell", "prob": 2, "charges-min": 0, "charges-max": 5000 },
-      { "item": "heavy_battery_cell", "prob": 1, "charges-min": 0, "charges-max": 10000 }
+      { "item": "light_atomic_battery_cell", "prob": 4, "charges": [ 500, 1000 ] },
+      { "item": "light_minus_atomic_battery_cell", "prob": 3, "charges": [ 250, 500 ] },
+      { "item": "medium_atomic_battery_cell", "prob": 2, "charges": [ 2500, 5000 ] },
+      { "item": "heavy_atomic_battery_cell", "prob": 1, "charges": [ 5000, 10000 ] }
     ]
   },
   {
     "id": "ammo_atomic_batteries_full",
     "type": "item_group",
     "items": [
-      { "item": "light_battery_cell", "prob": 4, "charges-min": 1000, "charges-max": 1000 },
-      { "item": "light_minus_atomic_battery_cell", "prob": 3, "charges-min": 500, "charges-max": 500 },
-      { "item": "medium_battery_cell", "prob": 2, "charges-min": 5000, "charges-max": 5000 },
-      { "item": "heavy_battery_cell", "prob": 1, "charges-min": 10000, "charges-max": 10000 }
+      { "item": "light_atomic_battery_cell", "prob": 4, "charges": 1000 },
+      { "item": "light_minus_atomic_battery_cell", "prob": 3, "charges": 500 },
+      { "item": "medium_atomic_battery_cell", "prob": 2, "charges": 5000 },
+      { "item": "heavy_atomic_battery_cell", "prob": 1, "charges": 10000 }
     ]
   },
   {
@@ -856,6 +845,24 @@
     "type": "item_group",
     "subtype": "collection",
     "entries": [ { "item": "mil_armor" }, { "item": "mil_helm", "prob": 90, "charges": [ 0, 100 ] } ]
+  },
+  {
+    "id": "robofac_basic_trade",
+    "type": "item_group",
+    "subtype": "distribution",
+    "items": [ { "group": "ammo_atomic_batteries_full", "prob": 100 } ]
+  },
+  {
+    "id": "spider",
+    "type": "item_group",
+    "subtype": "distribution",
+    "items": [ { "group": "ammo_atomic_batteries", "prob": 5 } ]
+  },
+  {
+    "id": "teleport",
+    "type": "item_group",
+    "subtype": "distribution",
+    "items": [ { "group": "ammo_atomic_batteries", "prob": 10 }, { "group": "ammo_atomic_batteries_full", "prob": 10 } ]
   },
   {
     "id": "hmil_armor_collection",

--- a/nocts_cata_mod_DDA/Surv_help/c_martialarts.json
+++ b/nocts_cata_mod_DDA/Surv_help/c_martialarts.json
@@ -16,8 +16,7 @@
       {
         "id": "buff_surv_com_onmove",
         "name": "Elusiveness",
-        "//": "Note: Doubled percentage signs are needed for correct formatting, not a typo.",
-        "description": "Quick and fluid movements make you harder to catch.\n\n+1 Dodge attempts, Dodge skill increased by 25%% of Intelligence, immunity to knockdown.\nLasts for 1 turn.",
+        "description": "Quick and fluid movements make you harder to catch.\n\n+1 Dodge attempts, Dodge skill increased by 25% of Intelligence, immunity to knockdown.\nLasts for 1 turn.",
         "skill_requirements": [ { "name": "melee", "level": 4 } ],
         "unarmed_allowed": true,
         "melee_allowed": true,
@@ -31,7 +30,7 @@
       {
         "id": "buff_surv_com_onhit",
         "name": "Active Defense",
-        "description": "The best defense is a good offense.\n\n+1 Block attempts, damage blocked increased by 100%% of Intelligence.\nLasts 2 turns.",
+        "description": "The best defense is a good offense.\n\n+1 Block attempts, damage blocked increased by 100% of Intelligence.\nLasts 2 turns.",
         "skill_requirements": [ { "name": "melee", "level": 5 } ],
         "unarmed_allowed": true,
         "melee_allowed": true,
@@ -44,7 +43,7 @@
       {
         "id": "buff_surv_com_onkill",
         "name": "Misdirection",
-        "description": "The shock and awe of combat gives you an opportunity to slip away.\n\n+2 Block attempts, +2 Dodge attempts, movement speed increased by 100%% of Intelligence, moving generates 1/2 as much noise.\nLast 6 turns.",
+        "description": "The shock and awe of combat gives you an opportunity to slip away.\n\n+2 Block attempts, +2 Dodge attempts, movement speed increased by 100% of Intelligence, moving generates 1/2 as much noise.\nLast 6 turns.",
         "skill_requirements": [ { "name": "melee", "level": 6 } ],
         "unarmed_allowed": true,
         "melee_allowed": true,


### PR DESCRIPTION
* Removed injection of atomic batteries into vanilla itemgroups in the BN version, since it's been implemented in vanilla BN.
* Updated the spawn injections and itemgroup setup in the DDA version to match the vanilla BN implementation.
* Removed now-excess % in martial art buff descriptions, seems to not be needed anymore.