### PR TITLE
Fix error message caused by gladiators with Toe Talons

### DIFF
--- a/nocts_cata_mod_BN/Npc/c_classes.json
+++ b/nocts_cata_mod_BN/Npc/c_classes.json
@@ -161,7 +161,6 @@
       [ "FANGS", 50 ],
       [ "CHITIN", 50 ],
       [ "NAILS", 75 ],
-      [ "RAP_TALONS", 75 ],
       [ "WEB_WALKER", 25 ],
       [ "SLIT_NOSTRILS", 25 ],
       [ "WHISKERS", 25 ],

--- a/nocts_cata_mod_DDA/Npc/c_classes.json
+++ b/nocts_cata_mod_DDA/Npc/c_classes.json
@@ -158,7 +158,6 @@
       [ "FANGS", 50 ],
       [ "CHITIN", 50 ],
       [ "NAILS", 75 ],
-      [ "RAP_TALONS", 75 ],
       [ "WEB_WALKER", 25 ],
       [ "SLIT_NOSTRILS", 25 ],
       [ "WHISKERS", 25 ],


### PR DESCRIPTION
Simple fix, the random chance to spawn with Toe Talons would interact badly with potentially spawning boots.