### PR TITLE
Fix survivor sabatons in DDA version

### DIFF
--- a/nocts_cata_mod_DDA/Surv_help/c_armor.json
+++ b/nocts_cata_mod_DDA/Surv_help/c_armor.json
@@ -317,7 +317,7 @@
       {
         "encumbrance": 30,
         "coverage": 100,
-        "covers": [ "hand_l", "hand_r" ],
+        "covers": [ "foot_l", "foot_r" ],
         "material": [ "iron", "kevlar", "leather" ],
         "material_thickness": 5,
         "environmental_protection": 3


### PR DESCRIPTION
Simple copy-paste error during the updates to keep up with armor data
changes in DDA, easily fixed.

Fixes https://github.com/Noctifer-de-Mortem/nocts_cata_mod/issues/347