### PR TITLE
Updates to augmented undead soldiers

### DIFF
--- a/nocts_cata_mod_BN/Monsters/c_monsters.json
+++ b/nocts_cata_mod_BN/Monsters/c_monsters.json
@@ -528,7 +528,19 @@
     "anger_triggers": [ "FRIEND_DIED", "HURT", "PLAYER_CLOSE", "STALK" ],
     "death_drops": "wild_bio_knight_lmg",
     "death_function": [ "NORMAL" ],
-    "flags": [ "SEES", "HEARS", "SMELLS", "POISON", "NO_BREATHE", "BONES", "FILTHY", "BASHES", "PUSH_MON", "PUSH_VEH" ]
+    "flags": [
+      "SEES",
+      "HEARS",
+      "SMELLS",
+      "POISON",
+      "NO_BREATHE",
+      "BONES",
+      "FILTHY",
+      "BASHES",
+      "PUSH_MON",
+      "PUSH_VEH",
+      "PATH_AVOID_FIRE"
+    ]
   },
   {
     "id": "mon_zombie_bio_knight_lauhcher",
@@ -596,7 +608,19 @@
     "anger_triggers": [ "FRIEND_DIED", "HURT", "PLAYER_CLOSE", "STALK" ],
     "death_drops": "wild_bio_knight_launcher",
     "death_function": [ "NORMAL" ],
-    "flags": [ "SEES", "HEARS", "SMELLS", "POISON", "NO_BREATHE", "BONES", "FILTHY", "BASHES", "PUSH_MON", "PUSH_VEH" ]
+    "flags": [
+      "SEES",
+      "HEARS",
+      "SMELLS",
+      "POISON",
+      "NO_BREATHE",
+      "BONES",
+      "FILTHY",
+      "BASHES",
+      "PUSH_MON",
+      "PUSH_VEH",
+      "PATH_AVOID_FIRE"
+    ]
   },
   {
     "id": "mon_zombie_bio_scout_sniper",

--- a/nocts_cata_mod_DDA/Monsters/c_monsters.json
+++ b/nocts_cata_mod_DDA/Monsters/c_monsters.json
@@ -530,7 +530,19 @@
     "special_when_hit": [ "ZAPBACK", 60 ],
     "anger_triggers": [ "FRIEND_DIED", "HURT", "PLAYER_CLOSE", "STALK" ],
     "death_drops": "wild_bio_knight_lmg",
-    "flags": [ "SEES", "HEARS", "SMELLS", "POISON", "NO_BREATHE", "BONES", "FILTHY", "BASHES", "PUSH_MON", "PUSH_VEH" ]
+    "flags": [
+      "SEES",
+      "HEARS",
+      "SMELLS",
+      "POISON",
+      "NO_BREATHE",
+      "BONES",
+      "FILTHY",
+      "BASHES",
+      "PUSH_MON",
+      "PUSH_VEH",
+      "PATH_AVOID_FIRE"
+    ]
   },
   {
     "id": "mon_zombie_bio_knight_lauhcher",
@@ -597,7 +609,19 @@
     "special_when_hit": [ "ZAPBACK", 60 ],
     "anger_triggers": [ "FRIEND_DIED", "HURT", "PLAYER_CLOSE", "STALK" ],
     "death_drops": "wild_bio_knight_launcher",
-    "flags": [ "SEES", "HEARS", "SMELLS", "POISON", "NO_BREATHE", "BONES", "FILTHY", "BASHES", "PUSH_MON", "PUSH_VEH" ]
+    "flags": [
+      "SEES",
+      "HEARS",
+      "SMELLS",
+      "POISON",
+      "NO_BREATHE",
+      "BONES",
+      "FILTHY",
+      "BASHES",
+      "PUSH_MON",
+      "PUSH_VEH",
+      "PATH_AVOID_FIRE"
+    ]
   },
   {
     "id": "mon_zombie_bio_scout_sniper",

--- a/nocts_cata_mod_DDA/Monsters/c_ranged_monster.json
+++ b/nocts_cata_mod_DDA/Monsters/c_ranged_monster.json
@@ -8,7 +8,8 @@
     "dispersion": 2000,
     "sight_dispersion": 500,
     "ranged_damage": { "damage_type": "bullet", "amount": 16, "armor_penetration": 5 },
-    "delete": { "ammo_effects": [ "INCENDIARY" ], "flags": [ "FIRE_20" ] }
+    "delete": { "ammo_effects": [ "INCENDIARY" ] },
+    "ammo_to_fire": 1
   },
   {
     "id": "akro_laser_smg_monster",
@@ -19,7 +20,8 @@
     "dispersion": 3000,
     "sight_dispersion": 500,
     "ranged_damage": { "damage_type": "bullet", "amount": 16, "armor_penetration": 5 },
-    "delete": { "ammo_effects": [ "INCENDIARY" ], "flags": [ "FIRE_20" ] }
+    "delete": { "ammo_effects": [ "INCENDIARY" ] },
+    "ammo_to_fire": 1
   },
   {
     "id": "arc_laser_rifle_monster",
@@ -30,7 +32,8 @@
     "dispersion": 4000,
     "sight_dispersion": 500,
     "ranged_damage": { "damage_type": "bullet", "amount": 40, "armor_penetration": 10 },
-    "delete": { "ammo_effects": [ "INCENDIARY" ], "flags": [ "FIRE_50" ] }
+    "delete": { "ammo_effects": [ "INCENDIARY" ] },
+    "ammo_to_fire": 1
   },
   {
     "id": "krx_laser_lmg_monster",
@@ -41,7 +44,8 @@
     "dispersion": 5000,
     "sight_dispersion": 500,
     "ranged_damage": { "damage_type": "bullet", "amount": 40, "armor_penetration": 10 },
-    "delete": { "ammo_effects": [ "INCENDIARY" ], "flags": [ "FIRE_50" ] }
+    "delete": { "ammo_effects": [ "INCENDIARY" ] },
+    "ammo_to_fire": 1
   },
   {
     "id": "laser_sniper_monster",
@@ -52,7 +56,8 @@
     "dispersion": 6000,
     "sight_dispersion": 250,
     "ranged_damage": { "damage_type": "bullet", "amount": 80, "armor_penetration": 20 },
-    "delete": { "ammo_effects": [ "INCENDIARY" ], "flags": [ "FIRE_100" ] }
+    "delete": { "ammo_effects": [ "INCENDIARY" ] },
+    "ammo_to_fire": 1
   },
   {
     "id": "xarm_laser_shotgun_monster",
@@ -63,7 +68,8 @@
     "dispersion": 2000,
     "sight_dispersion": 250,
     "ranged_damage": { "damage_type": "bullet", "amount": 80, "armor_penetration": 5 },
-    "delete": { "ammo_effects": [ "INCENDIARY" ], "flags": [ "FIRE_50" ] }
+    "delete": { "ammo_effects": [ "INCENDIARY" ] },
+    "ammo_to_fire": 1
   },
   {
     "id": "mk_ionic_cannon_monster",
@@ -75,7 +81,7 @@
     "dispersion": 6000,
     "sight_dispersion": 500,
     "ammo_effects": [ "PLASMA", "EXPLOSIVE_HUGE", "STREAM_BIG", "WIDE", "EMP", "FLASHBANG" ],
-    "delete": { "flags": [ "FIRE_100" ] }
+    "ammo_to_fire": 1
   },
   {
     "id": "bio_laser_minigun_monster",


### PR DESCRIPTION
* Fixed augmented undead soldiers in the DDA version using the old workaround for monster ranged attacks not playing well with `FIRE_X` flags, now that `ammo_to_fire` is a thing. Since I dunno if it'll still work right it's easy to just update the workaround to use the newer method of specifying ammo per shot.
* Also have the augmented undead juggernauts the pathing flag to at least avoid fire, since the launcher version tends to have trouble with that.

Fixes https://github.com/Noctifer-de-Mortem/nocts_cata_mod/issues/355