### PR TITLE
Smol typofix

### DIFF
--- a/nocts_cata_mod_BN/Surv_help/c_armor.json
+++ b/nocts_cata_mod_BN/Surv_help/c_armor.json
@@ -269,7 +269,7 @@
   {
     "id": "acs_74_stealth_cloak_on",
     "type": "TOOL_ARMOR",
-    "name": { "str": "ACS-74 stealth cloak", "str_pl": "ACS-74 stealth cloaks (on)" },
+    "name": { "str": "ACS-74 stealth cloak" },
     "description": "An experimental cloak that uses a highly sophisticated network of cameras and LEDs to render the user fully invisible.  It is powered by built-in torsion ratchets.  Due to particularities of its construction, it is very difficult to move in, hampering wearer's strength, dexterity and movement speed.",
     "weight": "1556 g",
     "volume": "3 L",

--- a/nocts_cata_mod_DDA/Surv_help/c_armor.json
+++ b/nocts_cata_mod_DDA/Surv_help/c_armor.json
@@ -356,7 +356,7 @@
   {
     "id": "acs_74_stealth_cloak_on",
     "type": "TOOL_ARMOR",
-    "name": { "str": "ACS-74 stealth cloak", "str_pl": "ACS-74 stealth cloaks (on)" },
+    "name": { "str": "ACS-74 stealth cloak" },
     "description": "An experimental cloak that uses a highly sophisticated network of cameras and LEDs to render the user fully invisible.  It is powered by built-in torsion ratchets.  Due to particularities of its construction, it is very difficult to move in, hampering wearer's strength, dexterity and movement speed.",
     "weight": "1556 g",
     "volume": "3 L",


### PR DESCRIPTION
Fixes stealth cloaks having a wrongly-pluralized plural name that still alludes to the days when you needed to switch them on and off.