### PR TITLE
Update blood loss recovery in DDA version

### DIFF
--- a/nocts_cata_mod_DDA/Mutations/c_bio_mutation_super_soldier.json
+++ b/nocts_cata_mod_DDA/Mutations/c_bio_mutation_super_soldier.json
@@ -18,7 +18,7 @@
     "weight_capacity_modifier": 1.25,
     "healing_awake": 0.1,
     "healing_resting": 0.25,
-    "vitamin_rates": [ [ "blood", 1 ], [ "redcells", 1 ] ],
+    "vitamin_rates": [ [ "blood", -1 ], [ "redcells", -1 ] ],
     "mending_modifier": 1.0,
     "metabolism_modifier": 0.25,
     "thirst_modifier": 0.25
@@ -43,7 +43,7 @@
     "healing_awake": 0.2,
     "healing_resting": 0.5,
     "mending_modifier": 2.0,
-    "vitamin_rates": [ [ "blood", 2 ], [ "redcells", 2 ] ],
+    "vitamin_rates": [ [ "blood", -2 ], [ "redcells", -2 ] ],
     "metabolism_modifier": 0.5,
     "thirst_modifier": 0.5
   },
@@ -67,7 +67,7 @@
     "healing_awake": 0.4,
     "healing_resting": 1.0,
     "mending_modifier": 4.0,
-    "vitamin_rates": [ [ "blood", 4 ], [ "redcells", 4 ] ],
+    "vitamin_rates": [ [ "blood", -4 ], [ "redcells", -4 ] ],
     "metabolism_modifier": 1.0,
     "thirst_modifier": 1.0
   },


### PR DESCRIPTION
Easy fix, evidently they flipped blood loss vitamin_rate stuff to be backwards or whatever now.