### PR TITLE
Fix mutagen in DDA version

### DIFF
--- a/nocts_cata_mod_DDA/Mutations/c_bio_mutation_category.json
+++ b/nocts_cata_mod_DDA/Mutations/c_bio_mutation_category.json
@@ -5,7 +5,6 @@
     "name": "Bio-Weapon",
     "threshold_mut": "THRESH_BIO-WEAPON",
     "mutagen_message": "This is a bug, report to Noctifer if you see this.",
-    "iv_message": "This is a bug, report to Noctifer if you see this.",
     "memorial_message": "All your enhancements came short of immortality."
   },
   {
@@ -23,17 +22,9 @@
     "id": "SUPER_SOLDIER",
     "name": "Sentinel",
     "threshold_mut": "THRESH_SUPER_SOLDIER",
-    "mutagen_message": "Seeing this is probably a bug.",
-    "iv_message": "You're left reeling as the chemicals make your biology reach new heights.",
-    "//": "IV stats currently identical to Alpha category.",
-    "iv_min_mutations": 1,
-    "iv_additional_mutations": 2,
-    "iv_additional_mutations_chance": 3,
-    "iv_hunger": 5,
-    "iv_thirst": 3,
-    "iv_pain": 3,
-    "iv_fatigue": 5,
-    "memorial_message": "You found your comrades and regrouped in hell."
+    "mutagen_message": "You're left reeling as the chemicals make your biology reach new heights.",
+    "memorial_message": "You found your comrades and regrouped in hell.",
+    "vitamin": "c_mutagen_super_soldier"
   },
   {
     "type": "mutation",

--- a/nocts_cata_mod_DDA/Surv_help/c_comestibles.json
+++ b/nocts_cata_mod_DDA/Surv_help/c_comestibles.json
@@ -34,9 +34,13 @@
     "healthy": -2,
     "addiction_potential": 6,
     "addiction_type": "mutagen",
-    "tool": "syringe",
     "flags": [ "NO_INGEST" ],
-    "use_action": { "type": "mutagen", "is_strong": true }
+    "use_action": {
+      "type": "consume_drug",
+      "activation_message": "You inject the mutagenic hemoampoule's contents.",
+      "tools_needed": { "syringe": -1 },
+      "vitamins": [ [ "mutagen", 450, 550 ] ]
+    }
   },
   {
     "id": "purified_ampoule",
@@ -56,7 +60,12 @@
     "addiction_type": "mutagen",
     "tool": "syringe",
     "flags": [ "NO_INGEST" ],
-    "use_action": [ "PURIFIER" ]
+    "use_action": {
+      "type": "consume_drug",
+      "activation_message": "You inject the purified hemoampoule's contents.",
+      "tools_needed": { "syringe": -1 },
+      "vitamins": [ [ "mutagen_human", 450, 550 ], [ "mutagen", 125 ] ]
+    }
   },
   {
     "id": "iv_mutagen_super_soldier",
@@ -70,6 +79,11 @@
     "charges": 2,
     "stack_size": 1,
     "healthy": -2,
-    "use_action": { "type": "mutagen_iv", "mutation_category": "SUPER_SOLDIER" }
+    "use_action": {
+      "type": "consume_drug",
+      "activation_message": "You inject the nano-mutagenic serum.",
+      "tools_needed": { "syringe": -1 },
+      "vitamins": [ [ "c_mutagen_super_soldier", 450, 550 ], [ "mutagen", 125 ] ]
+    }
   }
 ]

--- a/nocts_cata_mod_DDA/Surv_help/c_effects.json
+++ b/nocts_cata_mod_DDA/Surv_help/c_effects.json
@@ -141,5 +141,17 @@
     "type": "effect_type",
     "id": "c_bio_painrec",
     "base_mods": { "pain_min": [ -1 ], "pain_tick": [ 10 ] }
+  },
+  {
+    "type": "effect_type",
+    "id": "c_mutagen_super_soldier",
+    "name": [ "Light Nano-mutagenic Exposure", "Nano-mutagenic Exposure", "Heavy Nano-mutagenic Exposure" ],
+    "desc": [
+      "You've exposed yourself to a targeted mutagenic treatment, capable of heavily altering your body.",
+      "You've treated yourself with a potent targeted mutagenic treatment, steadily rewriting your DNA.",
+      "You've been exposed to an intensive dose of targeted mutagenic treatment, to turn yourself into something more than human."
+    ],
+    "max_intensity": 3,
+    "rating": "good"
   }
 ]

--- a/nocts_cata_mod_DDA/Surv_help/c_vitamins.json
+++ b/nocts_cata_mod_DDA/Surv_help/c_vitamins.json
@@ -1,0 +1,13 @@
+[
+  {
+    "id": "c_mutagen_super_soldier",
+    "type": "vitamin",
+    "vit_type": "counter",
+    "name": { "str": "Nano-mutagenic Serum" },
+    "excess": "c_mutagen_super_soldier",
+    "min": 0,
+    "max": 2500,
+    "rate": "1 h",
+    "disease_excess": [ [ 100, 500 ], [ 501, 2199 ], [ 2200, 2500 ] ]
+  }
+]


### PR DESCRIPTION
Per discussion in DMs with Noct, he said it's still fitting to have existing mutagenic content in Cata++ work like mutagen does now, so I can put off implementing any "better mutagenic behavior using EOC stuff" for after I test out using EOC for other stuff.