### PR TITLE
Fix repairing steel items in DDA version

### DIFF
--- a/nocts_cata_mod_DDA/Surv_help/c_tools.json
+++ b/nocts_cata_mod_DDA/Surv_help/c_tools.json
@@ -432,7 +432,22 @@
       {
         "type": "repair_item",
         "item_action_type": "repair_metal",
-        "materials": [ "iron", "steel", "hardsteel", "aluminum", "copper", "bronze", "silver", "gold", "platinum", "superalloy" ],
+        "materials": [
+          "iron",
+          "steel",
+          "lc_steel",
+          "mc_steel",
+          "hc_steel",
+          "ch_steel",
+          "qt_steel",
+          "aluminum",
+          "copper",
+          "bronze",
+          "silver",
+          "gold",
+          "platinum",
+          "superalloy"
+        ],
         "skill": "fabrication",
         "tool_quality": 4,
         "cost_scaling": 0.1,


### PR DESCRIPTION
Update to materials repairable by can forge due to https://github.com/CleverRaven/Cataclysm-DDA/pull/55648, also allows
repairing the other clutter steels.

Amusingly, they set it so the extended toolset item can repair this fancy new tempered steel, but not any of the other useless material clutter welders can repair.

Also lel, there's actually even more clutter steels in the form of "chain" steels, which aren't repairable at all. Nevermind that I can
confirm via the generic steel chainmail items that anything that gets materials solely via `covered_by_mat` can't actually be repaired at all.

It's always something with DDA...