### PR TITLE
Give survivor gun cart reins instead of controls

### DIFF
--- a/nocts_cata_mod_BN/Vehicles/c_vehicles.json
+++ b/nocts_cata_mod_BN/Vehicles/c_vehicles.json
@@ -177,7 +177,7 @@
       { "x": -2, "y": 0, "parts": [ "frame_wood_cross", "seat_wood", "turret_mount", { "ammo_types": [ "reloaded_762_54R" ], "part": "surv_lmg_762R_t", "ammo": 60, "ammo_qty": [ 5, 75 ] } ] },
       { "x": -2, "y": 1, "parts": [ "frame_wood_cross", "wheel_wood_b", "wooden_aisle_vertical" ] },
       { "x": -1, "y": 0, "parts": [ "frame_wood_cross", "wood box" ] },
-      { "x": 0, "y": 0, "parts": [ "frame_wood_cross", "seat_wood", "controls" ] },
+      { "x": 0, "y": 0, "parts": [ "frame_wood_cross", "seat_wood", "reins_tackle" ] },
       { "x": 0, "y": -1, "parts": [ "frame_wood_cross", "wheel_wood_b", "wooden_aisle_vertical" ] },
       { "x": 0, "y": 1, "parts": [ "frame_wood_cross", "wheel_wood_b", "wooden_aisle_vertical" ] },
       { "x": 1, "y": 1, "part": "yoke_harness" },

--- a/nocts_cata_mod_DDA/Vehicles/c_vehicles.json
+++ b/nocts_cata_mod_DDA/Vehicles/c_vehicles.json
@@ -177,7 +177,7 @@
       { "x": -2, "y": 0, "parts": [ "frame_wood_cross", "seat_wood", "turret_mount", { "ammo_types": [ "reloaded_762_54R" ], "part": "surv_lmg_762R_t", "ammo": 60, "ammo_qty": [ 5, 75 ] } ] },
       { "x": -2, "y": 1, "parts": [ "frame_wood_cross", "wheel_wood_b", "wooden_aisle_vertical" ] },
       { "x": -1, "y": 0, "parts": [ "frame_wood_cross", "wood box" ] },
-      { "x": 0, "y": 0, "parts": [ "frame_wood_cross", "seat_wood", "controls" ] },
+      { "x": 0, "y": 0, "parts": [ "frame_wood_cross", "seat_wood", "reins_tackle" ] },
       { "x": 0, "y": -1, "parts": [ "frame_wood_cross", "wheel_wood_b", "wooden_aisle_vertical" ] },
       { "x": 0, "y": 1, "parts": [ "frame_wood_cross", "wheel_wood_b", "wooden_aisle_vertical" ] },
       { "x": 1, "y": 1, "part": "yoke_harness" },


### PR DESCRIPTION
Companion update to a BN PR, after confirming that reins and tackle actually work as vehicle controls for horse-drawn vehicles.

It does mean you can't cheese the gun cart's turret and remote-firing it by slapping a turret control unit on it, but if you can do that you can already swap the reins for vehicle controls as it is.