### PR TITLE
Belatedly update glare quality in DDA version

### DIFF
--- a/nocts_cata_mod_DDA/Recipe/c_recipes.json
+++ b/nocts_cata_mod_DDA/Recipe/c_recipes.json
@@ -991,7 +991,7 @@
       { "id": "SAW_M_FINE", "level": 1 },
       { "id": "SCREW", "level": 1 },
       { "id": "SCREW_FINE", "level": 1 },
-      { "id": "GLARE", "level": 2 }
+      { "id": "GLARE", "level": 1 }
     ],
     "tools": [ [ [ "welder", 30 ], [ "welder_crude", 60 ], [ "soldering_iron", 60 ], [ "toolset", 60 ] ] ],
     "components": [
@@ -1015,7 +1015,7 @@
     "skills_required": [ [ "gun", 2 ], [ "fabrication", 4 ], [ "mechanics", 3 ] ],
     "time": "25 m",
     "book_learn": [ [ "advanced_electronics", 7 ], [ "textbook_electronics", 7 ], [ "manual_electronics", 7 ], [ "recipe_surv", 6 ] ],
-    "qualities": [ { "id": "SCREW_FINE", "level": 1 }, { "id": "GLARE", "level": 2 } ],
+    "qualities": [ { "id": "SCREW_FINE", "level": 1 }, { "id": "GLARE", "level": 1 } ],
     "tools": [ [ [ "welder", 10 ], [ "welder_crude", 10 ], [ "soldering_iron", 10 ], [ "toolset", 10 ] ] ],
     "components": [
       [ [ "light_plus_battery_cell", 2 ], [ "light_battery_cell", 3 ], [ "light_minus_battery_cell", 6 ] ],
@@ -1039,7 +1039,7 @@
     "decomp_learn": 2,
     "autolearn": false,
     "book_learn": [ [ "advanced_electronics", 3 ], [ "textbook_electronics", 3 ], [ "manual_electronics", 3 ], [ "recipe_surv", 2 ] ],
-    "qualities": [ { "id": "SCREW", "level": 1 }, { "id": "SCREW_FINE", "level": 1 }, { "id": "GLARE", "level": 2 } ],
+    "qualities": [ { "id": "SCREW", "level": 1 }, { "id": "SCREW_FINE", "level": 1 }, { "id": "GLARE", "level": 1 } ],
     "tools": [ [ [ "soldering_iron", 30 ], [ "toolset", 5 ] ] ],
     "components": [
       [ [ "antenna", 1 ] ],
@@ -1063,7 +1063,7 @@
     "decomp_learn": 2,
     "autolearn": false,
     "book_learn": [ [ "advanced_electronics", 4 ], [ "textbook_electronics", 4 ], [ "manual_electronics", 4 ], [ "recipe_surv", 3 ] ],
-    "qualities": [ { "id": "SCREW", "level": 1 }, { "id": "SCREW_FINE", "level": 1 }, { "id": "GLARE", "level": 2 } ],
+    "qualities": [ { "id": "SCREW", "level": 1 }, { "id": "SCREW_FINE", "level": 1 }, { "id": "GLARE", "level": 1 } ],
     "tools": [ [ [ "soldering_iron", 60 ], [ "toolset", 10 ] ] ],
     "components": [
       [ [ "antenna", 1 ] ],


### PR DESCRIPTION
Easy recipe update, not needed for BN version since it still uses level-2 glare.

Fixes https://github.com/Noctifer-de-Mortem/nocts_cata_mod/issues/374