### PR TITLE
Some assorted followup updates

### DIFF
--- a/nocts_cata_mod_BN/Char_creation/c_classes_r.json
+++ b/nocts_cata_mod_BN/Char_creation/c_classes_r.json
@@ -50,9 +50,7 @@
           "mre_beef_box",
           "mil_surp_pack_2"
         ],
-        "entries": [
-          { "item": "knife_rambo", "container-item": "scabbard" }
-        ]
+        "entries": [ { "item": "knife_rambo", "container-item": "scabbard" } ]
       },
       "male": [ "boxer_shorts" ],
       "female": [ "sports_bra", "boxer_shorts" ]
@@ -93,6 +91,7 @@
           "fur_rollmat",
           "press",
           "puller",
+          "pipe_cleaner",
           "pocketwatch"
         ],
         "entries": [
@@ -101,6 +100,8 @@
           { "item": "flintlock_pouch", "contents-group": "flintlock_pouch_surv_drifter" },
           { "item": "knife_hunting", "container-item": "sheath" },
           { "item": "ear_plugs", "custom-flags": [ "no_auto_equip" ] },
+          { "item": "vinegar", "container-item": "bottle_plastic_small" },
+          { "item": "lamp_oil", "container-item": "bottle_plastic_small" },
           { "item": "36navy_makeshift_magnum", "charges": 8 }
         ]
       },

--- a/nocts_cata_mod_BN/Surv_help/c_armor.json
+++ b/nocts_cata_mod_BN/Surv_help/c_armor.json
@@ -909,6 +909,6 @@
       "draw_cost": 75,
       "flags": [ "SHEATH_KNIFE", "BELT_CLIP", "SHEATH_SWORD", "MAG_COMPACT", "MAG_BULKY", "SPEEDLOADER" ]
     },
-    "flags": [ "WATER_FRIENDLY", "BELTED", "OVERSIZE" ]
+    "flags": [ "WATER_FRIENDLY", "BELTED", "OVERSIZE", "NO_QUICKDRAW" ]
   }
 ]

--- a/nocts_cata_mod_DDA/Char_creation/c_classes_r.json
+++ b/nocts_cata_mod_DDA/Char_creation/c_classes_r.json
@@ -52,7 +52,12 @@
         ],
         "entries": [
           { "item": "knife_rambo", "container-item": "scabbard" },
-          { "item": "light_disposable_cell", "ammo-item": "battery", "charges": 300, "container-item": "wearable_light" },
+          {
+            "item": "light_disposable_cell",
+            "ammo-item": "battery",
+            "charges": 300,
+            "container-item": "wearable_light"
+          },
           { "group": "charged_ref_lighter" }
         ]
       },
@@ -77,7 +82,14 @@
       { "level": 3, "name": "fabrication" },
       { "level": 2, "name": "survival" }
     ],
-    "proficiencies": [ "prof_handloading", "prof_leatherworking_basic", "prof_leatherworking", "prof_millinery", "prof_furriery", "prof_closures" ],
+    "proficiencies": [
+      "prof_handloading",
+      "prof_leatherworking_basic",
+      "prof_leatherworking",
+      "prof_millinery",
+      "prof_furriery",
+      "prof_closures"
+    ],
     "items": {
       "both": {
         "ammo": 100,
@@ -96,14 +108,22 @@
           "fur_rollmat",
           "press",
           "puller",
+          "pipe_cleaner",
           "pocketwatch"
         ],
         "entries": [
           { "item": "cowboy_hat_surv", "contents-group": "cowboy_hat_surv_surv_drifter" },
-          { "item": "colt_navy", "ammo-item": "36navy_makeshift_magnum", "charges": 6, "container-item": "XL_holster" },
+          {
+            "item": "colt_navy",
+            "ammo-item": "36navy_makeshift_magnum",
+            "charges": 6,
+            "container-item": "XL_holster"
+          },
           { "item": "flintlock_pouch", "contents-group": "flintlock_pouch_surv_drifter" },
           { "item": "knife_hunting", "container-item": "sheath" },
           { "item": "ear_plugs", "custom-flags": [ "no_auto_equip" ] },
+          { "item": "vinegar", "container-item": "bottle_plastic_small" },
+          { "item": "lamp_oil", "container-item": "bottle_plastic_small" },
           { "item": "36navy_makeshift_magnum", "charges": 8 },
           { "group": "charged_ref_lighter" }
         ]

--- a/nocts_cata_mod_DDA/Recipe/c_recipes.json
+++ b/nocts_cata_mod_DDA/Recipe/c_recipes.json
@@ -2509,35 +2509,6 @@
   },
   {
     "type": "recipe",
-    "result": "autoclave_makeshift",
-    "activity_level": "MODERATE_EXERCISE",
-    "category": "CC_ELECTRONIC",
-    "subcategory": "CSC_ELECTRONIC_TOOLS",
-    "skill_used": "fabrication",
-    "skills_required": [ [ "mechanics", 4 ], [ "firstaid", 4 ] ],
-    "difficulty": 6,
-    "time": "3 h",
-    "book_learn": [
-      [ "textbook_fabrication", 7 ],
-      [ "textbook_mechanics", 7 ],
-      [ "recipe_augs", 6 ],
-      [ "recipe_mil_augs", 6 ],
-      [ "recipe_lab_elec", 5 ]
-    ],
-    "using": [ [ "welding_standard", 50 ] ],
-    "qualities": [ { "id": "HAMMER", "level": 3 }, { "id": "WRENCH", "level": 2 }, { "id": "SAW_M", "level": 2 } ],
-    "components": [
-      [ [ "pressure_cooker", 1 ] ],
-      [ [ "i6_diesel", 1 ], [ "v6_diesel", 1 ] ],
-      [ [ "metal_tank", 1 ] ],
-      [ [ "pump_complex", 1 ] ],
-      [ [ "hose", 2 ] ],
-      [ [ "cu_pipe", 4 ] ],
-      [ [ "thermometer", 1 ] ]
-    ]
-  },
-  {
-    "type": "recipe",
     "result": "pouch_autoclave",
     "activity_level": "LIGHT_EXERCISE",
     "category": "CC_OTHER",

--- a/nocts_cata_mod_DDA/Surv_help/c_armor.json
+++ b/nocts_cata_mod_DDA/Surv_help/c_armor.json
@@ -1018,7 +1018,7 @@
       }
     ],
     "use_action": { "type": "holster", "holster_prompt": "Stash item", "holster_msg": "You stash your %s" },
-    "flags": [ "WATER_FRIENDLY", "BELTED", "OVERSIZE" ],
+    "flags": [ "WATER_FRIENDLY", "BELTED", "OVERSIZE", "NO_QUICKDRAW" ],
     "armor": [
       {
         "encumbrance": [ 2, 6 ],

--- a/nocts_cata_mod_DDA/Surv_help/c_tools.json
+++ b/nocts_cata_mod_DDA/Surv_help/c_tools.json
@@ -1013,41 +1013,6 @@
     "flags": [ "BELT_CLIP", "FRAGILE_MELEE" ]
   },
   {
-    "id": "autoclave_makeshift",
-    "type": "TOOL",
-    "name": { "str": "makeshift autoclave" },
-    "description": "This oversized pressure cooker uses diesel or other readily-available fuels to power a high-pressure sterilization chamber.  Less efficient than a commercial battery-powered autoclave and incompatible with a vehicle power grid, it does the job if nothing else is available.",
-    "weight": "200 kg",
-    "volume": "80 L",
-    "price": "800 USD",
-    "price_postapoc": "20 USD",
-    "to_hit": -6,
-    "bashing": 12,
-    "material": [ "steel" ],
-    "symbol": "A",
-    "color": "yellow",
-    "use_action": [ "AUTOCLAVE" ],
-    "flags": [ "ALLOWS_REMOTE_USE" ],
-    "power_draw": 3000000,
-    "looks_like": "autoclave",
-    "ammo": [ "diesel", "lamp_oil", "motor_oil", "jp8" ],
-    "pocket_data": [
-      {
-        "pocket_type": "MAGAZINE",
-        "rigid": true,
-        "watertight": true,
-        "ammo_restriction": { "diesel": 60000, "lamp_oil": 60000, "motor_oil": 60000, "jp8": 60000 }
-      },
-      {
-        "pocket_type": "CONTAINER",
-        "holster": true,
-        "max_contains_volume": "20 L",
-        "max_contains_weight": "20 kg",
-        "flag_restriction": [ "CBM" ]
-      }
-    ]
-  },
-  {
     "type": "GENERIC",
     "id": "c_mi_go_claw_broken",
     "symbol": ";",

--- a/nocts_cata_mod_DDA/legacy.json
+++ b/nocts_cata_mod_DDA/legacy.json
@@ -211,5 +211,15 @@
     ],
     "max_intensity": 3,
     "rating": "good"
+  },
+  {
+    "id": "autoclave_makeshift",
+    "type": "MIGRATION",
+    "replace": "autoclave"
+  },
+  {
+    "type": "recipe",
+    "result": "autoclave_makeshift",
+    "obsolete": true
   }
 ]


### PR DESCRIPTION
* Belatedly added some gun cleaning items to wasteland drifter like what the vanilla renactors start with, after confirming that yes the pistol does eventually foul.
* Added `NO_QUICKDRAW` flag to survivor's leg rig, because the "press f, opt to draw gun" thing doesn't work right if the gun in question isn't basically the last item added, when multi-holster items are involved.
* Obsoleted and migrated makeshift autoclaves from the DDA version. They might get a similar treatment in BN if I end up tinkering with the suggestion of making them craftable, but for now main focus is on fixing a bug.

Fixes https://github.com/Noctifer-de-Mortem/nocts_cata_mod/issues/384

Existing makeshift autoclaves will complain about not being able to fit the diesel when first loaded in, but this error can be skipped and it resolves itself afterward.