### PR TITLE
Assorted Omnitech updates

### DIFF
--- a/nocts_cata_mod_BN/Char_creation/c_classes_bw.json
+++ b/nocts_cata_mod_BN/Char_creation/c_classes_bw.json
@@ -1,5 +1,23 @@
 [
   {
+    "type": "item_group",
+    "subtype": "collection",
+    "id": "c_plut_light",
+    "entries": [ { "item": "light_atomic_battery_cell_rechargeable", "ammo-item": "battery", "charges": [ 500, 1000 ] } ]
+  },
+  {
+    "type": "item_group",
+    "subtype": "collection",
+    "id": "c_plut_medium",
+    "entries": [ { "item": "medium_atomic_battery_cell_rechargeable", "ammo-item": "battery", "charges": [ 2500, 5000 ] } ]
+  },
+  {
+    "type": "item_group",
+    "subtype": "collection",
+    "id": "c_plut_heavy",
+    "entries": [ { "item": "heavy_atomic_battery_cell_rechargeable", "ammo-item": "battery", "charges": [ 5000, 10000 ] } ]
+  },
+  {
     "type": "profession",
     "id": "failed_weapon",
     "name": "Failed Bio-Weapon",
@@ -393,17 +411,9 @@
     ],
     "items": {
       "both": {
-        "items": [
-          "helmet_liner",
-          "thermal_shirt",
-          "gloves_liner",
-          "under_armor_shorts",
-          "socks",
-          "mil_armor",
-          "mil_helm",
-          "molle_pack"
-        ],
+        "items": [ "helmet_liner", "thermal_shirt", "gloves_liner", "under_armor_shorts", "socks", "mil_helm", "molle_pack" ],
         "entries": [
+          { "item": "mil_armor", "contents-group": "c_plut_medium" },
           { "item": "two_way_radio", "contents-item": [ "battery_ups" ] },
           { "item": "arc_laser_rifle", "ammo-item": "battery", "charges": 5000, "contents-item": "shoulder_strap" },
           { "item": "knife_combat", "container-item": "sheath" },
@@ -456,7 +466,6 @@
           "gloves_liner",
           "under_armor_shorts",
           "socks",
-          "lmil_armor",
           "lmil_helm",
           "rucksack",
           "dump_pouch",
@@ -468,6 +477,7 @@
           "rollmat"
         ],
         "entries": [
+          { "item": "lmil_armor", "contents-group": "c_plut_medium" },
           { "item": "two_way_radio", "contents-item": [ "battery_ups" ] },
           { "item": "mil_mess_kit", "contents-item": [ "battery_ups" ] },
           { "item": "mx_laser_sniper", "ammo-item": "battery", "charges": 5000, "contents-item": "shoulder_strap" },
@@ -520,12 +530,12 @@
           "gloves_liner",
           "under_armor_shorts",
           "socks",
-          "lmil_armor",
           "lmil_helm",
           "molle_pack",
           "id_science"
         ],
         "entries": [
+          { "item": "lmil_armor", "contents-group": "c_plut_light" },
           { "item": "chemistry_set", "contents-item": [ "battery_ups" ] },
           { "item": "two_way_radio", "contents-item": [ "battery_ups" ] },
           { "item": "akro_laser_smg", "ammo-item": "battery", "charges": 1000, "contents-item": "shoulder_strap" },
@@ -576,8 +586,9 @@
     ],
     "items": {
       "both": {
-        "items": [ "helmet_liner", "thermal_shirt", "gloves_liner", "under_armor_shorts", "socks", "hmil_armor", "hmil_helm" ],
+        "items": [ "helmet_liner", "thermal_shirt", "gloves_liner", "under_armor_shorts", "socks", "hmil_helm" ],
         "entries": [
+          { "item": "hmil_armor", "contents-group": "c_plut_heavy" },
           { "item": "two_way_radio", "contents-item": "battery_ups" },
           { "item": "krx_laser_lmg", "ammo-item": "battery", "charges": 10000, "contents-item": "shoulder_strap" },
           { "item": "xarm_laser_shotgun_ups", "contents-item": "shoulder_strap" },

--- a/nocts_cata_mod_BN/Monsters/c_monster_drops.json
+++ b/nocts_cata_mod_BN/Monsters/c_monster_drops.json
@@ -115,8 +115,36 @@
         ],
         "prob": 80
       },
-      { "item": "arc_laser_rifle", "damage": [ 0, 3 ], "charges": [ 0, 2500 ] },
-      { "item": "medium_atomic_battery_cell_rechargeable", "damage": [ 0, 1 ], "charges": [ 0, 5000 ], "prob": 25 }
+      {
+        "distribution": [
+          {
+            "collection": [
+              { "item": "arc_laser_rifle", "damage": [ 0, 3 ], "charges": [ 0, 2500 ] },
+              {
+                "distribution": [
+                  { "item": "medium_atomic_battery_cell_rechargeable", "damage": [ 0, 1 ], "charges": [ 0, 5000 ], "prob": 50 },
+                  { "item": "medium_atomic_battery_cell", "damage": [ 0, 1 ], "charges": [ 0, 5000 ], "prob": 50 }
+                ],
+                "prob": 25
+              }
+            ],
+            "prob": 80
+          },
+          {
+            "collection": [
+              { "item": "arc_laser_rifle_ups", "damage": [ 0, 3 ] },
+              {
+                "distribution": [
+                  { "item": "UPS_off", "damage": [ 0, 1 ], "charges": [ 0, 1250 ], "prob": 50 },
+                  { "item": "adv_UPS_off", "damage": [ 0, 1 ], "charges": [ 0, 2500 ], "prob": 50 }
+                ],
+                "prob": 10
+              }
+            ],
+            "prob": 20
+          }
+        ]
+      }
     ]
   },
   {
@@ -137,8 +165,36 @@
         ],
         "prob": 80
       },
-      { "item": "xarm_laser_shotgun", "damage": [ 0, 3 ], "charges": [ 0, 2500 ] },
-      { "item": "medium_atomic_battery_cell_rechargeable", "damage": [ 0, 1 ], "charges": [ 0, 5000 ], "prob": 25 }
+      {
+        "distribution": [
+          {
+            "collection": [
+              { "item": "xarm_laser_shotgun", "damage": [ 0, 3 ], "charges": [ 0, 2500 ] },
+              {
+                "distribution": [
+                  { "item": "medium_atomic_battery_cell_rechargeable", "damage": [ 0, 1 ], "charges": [ 0, 5000 ], "prob": 50 },
+                  { "item": "medium_atomic_battery_cell", "damage": [ 0, 1 ], "charges": [ 0, 5000 ], "prob": 50 }
+                ],
+                "prob": 25
+              }
+            ],
+            "prob": 80
+          },
+          {
+            "collection": [
+              { "item": "xarm_laser_shotgun_ups", "damage": [ 0, 3 ] },
+              {
+                "distribution": [
+                  { "item": "UPS_off", "damage": [ 0, 1 ], "charges": [ 0, 1250 ], "prob": 50 },
+                  { "item": "adv_UPS_off", "damage": [ 0, 1 ], "charges": [ 0, 2500 ], "prob": 50 }
+                ],
+                "prob": 10
+              }
+            ],
+            "prob": 20
+          }
+        ]
+      }
     ]
   },
   {
@@ -160,8 +216,36 @@
         ],
         "prob": 80
       },
-      { "item": "mx_laser_sniper", "damage": [ 0, 3 ], "charges": [ 0, 2500 ] },
-      { "item": "medium_atomic_battery_cell_rechargeable", "damage": [ 0, 1 ], "charges": [ 0, 5000 ], "prob": 25 },
+      {
+        "distribution": [
+          {
+            "collection": [
+              { "item": "mx_laser_sniper", "damage": [ 0, 3 ], "charges": [ 0, 2500 ] },
+              {
+                "distribution": [
+                  { "item": "medium_atomic_battery_cell_rechargeable", "damage": [ 0, 1 ], "charges": [ 0, 5000 ], "prob": 50 },
+                  { "item": "medium_atomic_battery_cell", "damage": [ 0, 1 ], "charges": [ 0, 5000 ], "prob": 50 }
+                ],
+                "prob": 25
+              }
+            ],
+            "prob": 75
+          },
+          {
+            "collection": [
+              { "item": "mx_laser_sniper_ups", "damage": [ 0, 3 ] },
+              {
+                "distribution": [
+                  { "item": "UPS_off", "damage": [ 0, 1 ], "charges": [ 0, 1250 ], "prob": 50 },
+                  { "item": "adv_UPS_off", "damage": [ 0, 1 ], "charges": [ 0, 2500 ], "prob": 50 }
+                ],
+                "prob": 10
+              }
+            ],
+            "prob": 25
+          }
+        ]
+      },
       { "item": "e_tool", "damage": [ 0, 3 ], "prob": 50 },
       { "item": "mre_beef_box", "damage": [ 0, 3 ], "prob": 75 },
       { "item": "large_tent_kit", "damage": [ 0, 3 ], "prob": 25 },
@@ -187,8 +271,36 @@
         ],
         "prob": 80
       },
-      { "item": "krx_laser_lmg", "damage": [ 0, 3 ], "charges": [ 0, 5000 ] },
-      { "item": "heavy_atomic_battery_cell_rechargeable", "damage": [ 0, 1 ], "charges": [ 0, 10000 ], "prob": 25 }
+      {
+        "distribution": [
+          {
+            "collection": [
+              { "item": "krx_laser_lmg", "damage": [ 0, 3 ], "charges": [ 0, 5000 ] },
+              {
+                "distribution": [
+                  { "item": "heavy_atomic_battery_cell_rechargeable", "damage": [ 0, 1 ], "charges": [ 0, 10000 ], "prob": 50 },
+                  { "item": "heavy_atomic_battery_cell", "damage": [ 0, 1 ], "charges": [ 0, 10000 ], "prob": 50 }
+                ],
+                "prob": 25
+              }
+            ],
+            "prob": 95
+          },
+          {
+            "collection": [
+              { "item": "krx_laser_lmg_ups", "damage": [ 0, 3 ] },
+              {
+                "distribution": [
+                  { "item": "UPS_off", "damage": [ 0, 1 ], "charges": [ 0, 1250 ], "prob": 50 },
+                  { "item": "adv_UPS_off", "damage": [ 0, 1 ], "charges": [ 0, 2500 ], "prob": 50 }
+                ],
+                "prob": 10
+              }
+            ],
+            "prob": 5
+          }
+        ]
+      }
     ]
   },
   {
@@ -211,7 +323,14 @@
         "prob": 80
       },
       { "item": "mk_ionic_cannon", "damage": [ 0, 3 ], "charges": [ 0, 1 ] },
-      { "item": "plasma", "damage": [ 0, 1 ], "charges": [ 1, 2 ], "prob": 50 }
+      { "item": "plasma", "damage": [ 0, 1 ], "charges": [ 1, 2 ], "prob": 50 },
+      {
+        "distribution": [
+          { "item": "UPS_off", "damage": [ 0, 1 ], "charges": [ 0, 1250 ], "prob": 50 },
+          { "item": "adv_UPS_off", "damage": [ 0, 1 ], "charges": [ 0, 2500 ], "prob": 50 }
+        ],
+        "prob": 10
+      }
     ]
   },
   {
@@ -232,8 +351,42 @@
         ],
         "prob": 80
       },
-      { "item": "neo_laser_pistol", "damage": [ 0, 3 ], "charges": [ 0, 250 ] },
-      { "item": "light_atomic_battery_cell_rechargeable", "damage": [ 0, 1 ], "charges": [ 0, 500 ], "prob": 25 },
+      {
+        "distribution": [
+          {
+            "collection": [
+              { "item": "neo_laser_pistol", "damage": [ 0, 3 ], "charges": [ 0, 250 ] },
+              {
+                "distribution": [
+                  { "item": "light_atomic_battery_cell_rechargeable", "damage": [ 0, 1 ], "charges": [ 0, 1000 ], "prob": 50 },
+                  { "item": "light_atomic_battery_cell", "damage": [ 0, 1 ], "charges": [ 0, 1000 ], "prob": 25 },
+                  {
+                    "item": "light_minus_atomic_battery_cell",
+                    "damage": [ 0, 1 ],
+                    "charges": [ 0, 1000 ],
+                    "prob": 25
+                  }
+                ],
+                "prob": 25
+              }
+            ],
+            "prob": 50
+          },
+          {
+            "collection": [
+              { "item": "neo_laser_pistol_ups", "damage": [ 0, 3 ] },
+              {
+                "distribution": [
+                  { "item": "UPS_off", "damage": [ 0, 1 ], "charges": [ 0, 1250 ], "prob": 50 },
+                  { "item": "adv_UPS_off", "damage": [ 0, 1 ], "charges": [ 0, 2500 ], "prob": 50 }
+                ],
+                "prob": 10
+              }
+            ],
+            "prob": 50
+          }
+        ]
+      },
       { "item": "chemistry_set", "damage": [ 0, 1 ], "prob": 90 },
       { "item": "id_science", "damage": [ 0, 1 ], "prob": 25 },
       {
@@ -260,8 +413,42 @@
         ],
         "prob": 80
       },
-      { "item": "akro_laser_smg", "damage": [ 0, 3 ], "charges": [ 0, 500 ] },
-      { "item": "light_atomic_battery_cell_rechargeable", "damage": [ 0, 1 ], "charges": [ 500, 1000 ], "prob": 25 },
+      {
+        "distribution": [
+          {
+            "collection": [
+              { "item": "akro_laser_smg", "damage": [ 0, 3 ], "charges": [ 0, 500 ] },
+              {
+                "distribution": [
+                  { "item": "light_atomic_battery_cell_rechargeable", "damage": [ 0, 1 ], "charges": [ 0, 1000 ], "prob": 50 },
+                  { "item": "light_atomic_battery_cell", "damage": [ 0, 1 ], "charges": [ 0, 1000 ], "prob": 25 },
+                  {
+                    "item": "light_minus_atomic_battery_cell",
+                    "damage": [ 0, 1 ],
+                    "charges": [ 0, 1000 ],
+                    "prob": 25
+                  }
+                ],
+                "prob": 25
+              }
+            ],
+            "prob": 50
+          },
+          {
+            "collection": [
+              { "item": "akro_laser_smg_ups", "damage": [ 0, 3 ] },
+              {
+                "distribution": [
+                  { "item": "UPS_off", "damage": [ 0, 1 ], "charges": [ 0, 1250 ], "prob": 50 },
+                  { "item": "adv_UPS_off", "damage": [ 0, 1 ], "charges": [ 0, 2500 ], "prob": 50 }
+                ],
+                "prob": 10
+              }
+            ],
+            "prob": 50
+          }
+        ]
+      },
       { "item": "chemistry_set", "damage": [ 0, 1 ], "prob": 90 },
       { "item": "id_science", "damage": [ 0, 1 ], "prob": 25 },
       {

--- a/nocts_cata_mod_BN/Recipe/c_recipes.json
+++ b/nocts_cata_mod_BN/Recipe/c_recipes.json
@@ -1712,6 +1712,8 @@
     "difficulty": 2,
     "skills_required": [ [ "fabrication", 2 ], [ "mechanics", 2 ] ],
     "time": "12 m",
+    "reversible": true,
+    "decomp_learn": 4,
     "book_learn": [ [ "omnitech_weapon_ups_manual", 2 ] ],
     "tools": [ [ [ "omnitech_weapon_ups_kit", -1 ] ] ],
     "components": [ [ [ "neo_laser_pistol", 1 ] ] ]
@@ -1725,6 +1727,8 @@
     "difficulty": 2,
     "skills_required": [ [ "fabrication", 2 ], [ "mechanics", 2 ] ],
     "time": "12 m",
+    "reversible": true,
+    "decomp_learn": 4,
     "book_learn": [ [ "omnitech_weapon_ups_manual", 2 ] ],
     "tools": [ [ [ "omnitech_weapon_ups_kit", -1 ] ] ],
     "components": [ [ [ "akro_laser_smg", 1 ] ] ]
@@ -1738,6 +1742,8 @@
     "difficulty": 2,
     "skills_required": [ [ "fabrication", 2 ], [ "mechanics", 2 ] ],
     "time": "12 m",
+    "reversible": true,
+    "decomp_learn": 4,
     "book_learn": [ [ "omnitech_weapon_ups_manual", 2 ] ],
     "tools": [ [ [ "omnitech_weapon_ups_kit", -1 ] ] ],
     "components": [ [ [ "arc_laser_rifle", 1 ] ] ]
@@ -1751,6 +1757,8 @@
     "difficulty": 2,
     "skills_required": [ [ "fabrication", 2 ], [ "mechanics", 2 ] ],
     "time": "12 m",
+    "reversible": true,
+    "decomp_learn": 4,
     "book_learn": [ [ "omnitech_weapon_ups_manual", 2 ] ],
     "tools": [ [ [ "omnitech_weapon_ups_kit", -1 ] ] ],
     "components": [ [ [ "krx_laser_lmg", 1 ] ] ]
@@ -1764,6 +1772,8 @@
     "difficulty": 2,
     "skills_required": [ [ "fabrication", 2 ], [ "mechanics", 2 ] ],
     "time": "12 m",
+    "reversible": true,
+    "decomp_learn": 4,
     "book_learn": [ [ "omnitech_weapon_ups_manual", 2 ] ],
     "tools": [ [ [ "omnitech_weapon_ups_kit", -1 ] ] ],
     "components": [ [ [ "mx_laser_sniper", 1 ] ] ]
@@ -1777,6 +1787,8 @@
     "difficulty": 2,
     "skills_required": [ [ "fabrication", 2 ], [ "mechanics", 2 ] ],
     "time": "12 m",
+    "reversible": true,
+    "decomp_learn": 4,
     "book_learn": [ [ "omnitech_weapon_ups_manual", 2 ] ],
     "tools": [ [ [ "omnitech_weapon_ups_kit", -1 ] ] ],
     "components": [ [ [ "xarm_laser_shotgun", 1 ] ] ]

--- a/nocts_cata_mod_BN/Surv_help/c_item_groups.json
+++ b/nocts_cata_mod_BN/Surv_help/c_item_groups.json
@@ -319,12 +319,24 @@
     "id": "science",
     "type": "item_group",
     "items": [
-      [ "neo_laser_pistol", 2 ],
-      [ "akro_laser_smg", 2 ],
-      [ "arc_laser_rifle", 2 ],
-      [ "krx_laser_lmg", 2 ],
-      [ "mx_laser_sniper", 2 ],
-      [ "xarm_laser_shotgun", 2 ],
+      {
+        "distribution": [ { "item": "neo_laser_pistol", "prob": 50 }, { "item": "neo_laser_pistol_ups", "prob": 50 } ], "prob": 2
+      },
+      {
+        "distribution": [ { "item": "akro_laser_smg", "prob": 50 }, { "item": "akro_laser_smg_ups", "prob": 50 } ], "prob": 2
+      },
+      {
+        "distribution": [ { "item": "arc_laser_rifle", "prob": 50 }, { "item": "arc_laser_rifle_ups", "prob": 50 } ], "prob": 2
+      },
+      {
+        "distribution": [ { "item": "krx_laser_lmg", "prob": 50 }, { "item": "krx_laser_lmg_ups", "prob": 50 } ], "prob": 2
+      },
+      {
+        "distribution": [ { "item": "mx_laser_sniper", "prob": 50 }, { "item": "mx_laser_sniper_ups", "prob": 50 } ], "prob": 2
+      },
+      {
+        "distribution": [ { "item": "xarm_laser_shotgun", "prob": 50 }, { "item": "xarm_laser_shotgun_ups", "prob": 50 } ], "prob": 2
+      },
       [ "br_bolt_rifle_elec", 2 ],
       [ "mk_ionic_cannon", 2 ],
       [ "megamap", 2 ],
@@ -347,12 +359,24 @@
     "id": "rare",
     "type": "item_group",
     "items": [
-      [ "neo_laser_pistol", 2 ],
-      [ "akro_laser_smg", 2 ],
-      [ "arc_laser_rifle", 2 ],
-      [ "krx_laser_lmg", 2 ],
-      [ "mx_laser_sniper", 2 ],
-      [ "xarm_laser_shotgun", 2 ],
+      {
+        "distribution": [ { "item": "neo_laser_pistol", "prob": 50 }, { "item": "neo_laser_pistol_ups", "prob": 50 } ], "prob": 2
+      },
+      {
+        "distribution": [ { "item": "akro_laser_smg", "prob": 50 }, { "item": "akro_laser_smg_ups", "prob": 50 } ], "prob": 2
+      },
+      {
+        "distribution": [ { "item": "arc_laser_rifle", "prob": 50 }, { "item": "arc_laser_rifle_ups", "prob": 50 } ], "prob": 2
+      },
+      {
+        "distribution": [ { "item": "krx_laser_lmg", "prob": 50 }, { "item": "krx_laser_lmg_ups", "prob": 50 } ], "prob": 2
+      },
+      {
+        "distribution": [ { "item": "mx_laser_sniper", "prob": 50 }, { "item": "mx_laser_sniper_ups", "prob": 50 } ], "prob": 2
+      },
+      {
+        "distribution": [ { "item": "xarm_laser_shotgun", "prob": 50 }, { "item": "xarm_laser_shotgun_ups", "prob": 50 } ], "prob": 2
+      },
       [ "br_bolt_rifle_elec", 2 ],
       [ "mk_ionic_cannon", 2 ],
       [ "megamap", 2 ],
@@ -614,12 +638,24 @@
     "type": "item_group",
     "items": [
       [ "mk_ionic_cannon", 1 ],
-      { "item": "neo_laser_pistol", "prob": 1, "charges-min": 0, "charges-max": 500 },
-      { "item": "akro_laser_smg", "prob": 1, "charges-min": 0, "charges-max": 1000 },
-      { "item": "arc_laser_rifle", "prob": 1, "charges-min": 0, "charges-max": 5000 },
-      { "item": "krx_laser_lmg", "prob": 1, "charges-min": 0, "charges-max": 10000 },
-      { "item": "mx_laser_sniper", "prob": 1, "charges-min": 0, "charges-max": 5000 },
-      { "item": "xarm_laser_shotgun", "prob": 1, "charges-min": 0, "charges-max": 5000 }
+      {
+        "distribution": [ { "item": "neo_laser_pistol", "prob": 50, "charges": [ 0, 500 ] }, { "item": "neo_laser_pistol_ups", "prob": 50 } ], "prob": 1
+      },
+      {
+        "distribution": [ { "item": "akro_laser_smg", "prob": 50, "charges": [ 0, 1000 ] }, { "item": "akro_laser_smg_ups", "prob": 50 } ], "prob": 1
+      },
+      {
+        "distribution": [ { "item": "arc_laser_rifle", "prob": 50, "charges": [ 0, 5000 ] }, { "item": "arc_laser_rifle_ups", "prob": 50 } ], "prob": 1
+      },
+      {
+        "distribution": [ { "item": "krx_laser_lmg", "prob": 50, "charges": [ 0, 10000 ] }, { "item": "krx_laser_lmg_ups", "prob": 50 } ], "prob": 1
+      },
+      {
+        "distribution": [ { "item": "mx_laser_sniper", "prob": 50, "charges": [ 0, 5000 ] }, { "item": "mx_laser_sniper_ups", "prob": 50 } ], "prob": 1
+      },
+      {
+        "distribution": [ { "item": "xarm_laser_shotgun", "prob": 50, "charges": [ 0, 5000 ] }, { "item": "xarm_laser_shotgun_ups", "prob": 50 } ], "prob": 1
+      }
     ]
   },
   {

--- a/nocts_cata_mod_BN/Weapons/c_ranged.json
+++ b/nocts_cata_mod_BN/Weapons/c_ranged.json
@@ -1102,7 +1102,7 @@
     "magazines": [
       [
         "battery",
-        [ "light_atomic_battery_cell_rechargeable", "light_atomic_battery_cell", "light_minus_atomic_battery_cell" ]
+        [ "light_minus_atomic_battery_cell", "light_atomic_battery_cell", "light_atomic_battery_cell_rechargeable" ]
       ]
     ]
   },
@@ -1168,8 +1168,7 @@
     "durability": 10,
     "modes": [ [ "DEFAULT", "semi", 1 ], [ "BURST", "spray", 10 ], [ "AUTO", "auto", 15 ] ],
     "reload": 200,
-    "default_mods": [ "rail_laser_sight", "pistol_grip" ],
-    "built_in_mods": [ "grip" ],
+    "built_in_mods": [ "rail_laser_sight", "pistol_grip", "grip" ],
     "valid_mod_locations": [
       [ "accessories", 2 ],
       [ "sling", 1 ],
@@ -1185,7 +1184,7 @@
     "magazines": [
       [
         "battery",
-        [ "light_atomic_battery_cell_rechargeable", "light_atomic_battery_cell", "light_minus_atomic_battery_cell" ]
+        [ "light_atomic_battery_cell", "light_minus_atomic_battery_cell", "light_atomic_battery_cell_rechargeable" ]
       ]
     ]
   },
@@ -1214,8 +1213,7 @@
     "durability": 10,
     "modes": [ [ "DEFAULT", "semi", 1 ], [ "BURST", "spray", 10 ], [ "AUTO", "auto", 15 ] ],
     "ups_charges": 20,
-    "default_mods": [ "rail_laser_sight", "pistol_grip" ],
-    "built_in_mods": [ "grip" ],
+    "built_in_mods": [ "rail_laser_sight", "pistol_grip", "grip" ],
     "valid_mod_locations": [
       [ "accessories", 2 ],
       [ "sling", 1 ],
@@ -1254,7 +1252,7 @@
     "durability": 10,
     "modes": [ [ "DEFAULT", "semi", 1 ], [ "BURST", "burst", 3 ], [ "AUTO", "auto", 10 ] ],
     "reload": 200,
-    "default_mods": [ "pistol_grip", "grip" ],
+    "built_in_mods": [ "pistol_grip", "grip" ],
     "valid_mod_locations": [
       [ "accessories", 4 ],
       [ "sling", 1 ],
@@ -1267,7 +1265,7 @@
       [ "lens", 1 ]
     ],
     "magazine_well": "300 ml",
-    "magazines": [ [ "battery", [ "medium_atomic_battery_cell_rechargeable", "medium_atomic_battery_cell" ] ] ]
+    "magazines": [ [ "battery", [ "medium_atomic_battery_cell", "medium_atomic_battery_cell_rechargeable" ] ] ]
   },
   {
     "id": "arc_laser_rifle_ups",
@@ -1294,7 +1292,7 @@
     "durability": 10,
     "modes": [ [ "DEFAULT", "semi", 1 ], [ "BURST", "burst", 3 ], [ "AUTO", "auto", 10 ] ],
     "ups_charges": 50,
-    "default_mods": [ "pistol_grip", "grip" ],
+    "built_in_mods": [ "pistol_grip", "grip" ],
     "valid_mod_locations": [
       [ "accessories", 4 ],
       [ "sling", 1 ],
@@ -1345,7 +1343,7 @@
       [ "lens", 1 ]
     ],
     "magazine_well": "600 ml",
-    "magazines": [ [ "battery", [ "heavy_atomic_battery_cell_rechargeable", "heavy_atomic_battery_cell" ] ] ]
+    "magazines": [ [ "battery", [ "heavy_atomic_battery_cell", "heavy_atomic_battery_cell_rechargeable" ] ] ]
   },
   {
     "id": "krx_laser_lmg_ups",
@@ -1408,8 +1406,7 @@
     "loudness": 20,
     "durability": 10,
     "reload": 300,
-    "default_mods": [ "bipod" ],
-    "built_in_mods": [ "rifle_scope" ],
+    "built_in_mods": [ "bipod", "rifle_scope" ],
     "valid_mod_locations": [
       [ "accessories", 2 ],
       [ "sling", 1 ],
@@ -1422,7 +1419,7 @@
       [ "lens", 1 ]
     ],
     "magazine_well": "300 ml",
-    "magazines": [ [ "battery", [ "medium_atomic_battery_cell_rechargeable", "medium_atomic_battery_cell" ] ] ]
+    "magazines": [ [ "battery", [ "medium_atomic_battery_cell", "medium_atomic_battery_cell_rechargeable" ] ] ]
   },
   {
     "id": "mx_laser_sniper_ups",
@@ -1448,8 +1445,7 @@
     "loudness": 20,
     "durability": 10,
     "ups_charges": 100,
-    "default_mods": [ "bipod" ],
-    "built_in_mods": [ "rifle_scope" ],
+    "built_in_mods": [ "bipod", "rifle_scope" ],
     "valid_mod_locations": [
       [ "accessories", 2 ],
       [ "sling", 1 ],
@@ -1487,7 +1483,7 @@
     "loudness": 14,
     "dispersion": 300,
     "durability": 8,
-    "default_mods": [ "rail_laser_sight", "pistol_grip" ],
+    "built_in_mods": [ "rail_laser_sight", "pistol_grip" ],
     "modes": [ [ "DEFAULT", "semi", 1 ], [ "BURST", "double-barrel", 2 ] ],
     "reload": 250,
     "valid_mod_locations": [
@@ -1502,7 +1498,7 @@
       [ "lens", 1 ]
     ],
     "magazine_well": "300 ml",
-    "magazines": [ [ "battery", [ "medium_atomic_battery_cell_rechargeable", "medium_atomic_battery_cell" ] ] ]
+    "magazines": [ [ "battery", [ "medium_atomic_battery_cell", "medium_atomic_battery_cell_rechargeable" ] ] ]
   },
   {
     "id": "xarm_laser_shotgun_ups",
@@ -1528,7 +1524,7 @@
     "loudness": 14,
     "dispersion": 300,
     "durability": 8,
-    "default_mods": [ "rail_laser_sight", "pistol_grip" ],
+    "built_in_mods": [ "rail_laser_sight", "pistol_grip" ],
     "modes": [ [ "DEFAULT", "semi", 1 ], [ "BURST", "double-barrel", 2 ] ],
     "ups_charges": 100,
     "valid_mod_locations": [

--- a/nocts_cata_mod_DDA/Char_creation/c_classes_bw.json
+++ b/nocts_cata_mod_DDA/Char_creation/c_classes_bw.json
@@ -1,5 +1,23 @@
 [
   {
+    "type": "item_group",
+    "subtype": "collection",
+    "id": "c_plut_light",
+    "entries": [ { "item": "light_atomic_battery_cell_rechargeable", "ammo-item": "battery", "charges": [ 500, 1000 ] } ]
+  },
+  {
+    "type": "item_group",
+    "subtype": "collection",
+    "id": "c_plut_medium",
+    "entries": [ { "item": "medium_atomic_battery_cell_rechargeable", "ammo-item": "battery", "charges": [ 2500, 5000 ] } ]
+  },
+  {
+    "type": "item_group",
+    "subtype": "collection",
+    "id": "c_plut_heavy",
+    "entries": [ { "item": "heavy_atomic_battery_cell_rechargeable", "ammo-item": "battery", "charges": [ 5000, 10000 ] } ]
+  },
+  {
     "type": "profession",
     "id": "failed_weapon",
     "name": "Failed Bio-Weapon",
@@ -394,17 +412,9 @@
     "proficiencies": [ "prof_gunsmithing_basic", "prof_traps", "prof_disarming", "prof_spotting" ],
     "items": {
       "both": {
-        "items": [
-          "helmet_liner",
-          "thermal_shirt",
-          "gloves_liner",
-          "under_armor_shorts",
-          "socks",
-          "mil_armor",
-          "mil_helm",
-          "molle_pack"
-        ],
+        "items": [ "helmet_liner", "thermal_shirt", "gloves_liner", "under_armor_shorts", "socks", "mil_helm", "molle_pack" ],
         "entries": [
+          { "item": "mil_armor", "contents-group": "c_plut_medium" },
           { "item": "two_way_radio", "contents-item": [ "battery_ups" ] },
           { "item": "arc_laser_rifle", "ammo-item": "battery", "charges": 5000, "contents-item": "shoulder_strap" },
           { "item": "knife_combat", "container-item": "sheath" },
@@ -458,7 +468,6 @@
           "gloves_liner",
           "under_armor_shorts",
           "socks",
-          "lmil_armor",
           "lmil_helm",
           "rucksack",
           "dump_pouch",
@@ -470,6 +479,7 @@
           "rollmat"
         ],
         "entries": [
+          { "item": "lmil_armor", "contents-group": "c_plut_medium" },
           { "item": "two_way_radio", "contents-item": [ "battery_ups" ] },
           { "item": "mil_mess_kit", "contents-item": [ "battery_ups" ] },
           { "item": "mx_laser_sniper", "ammo-item": "battery", "charges": 5000, "contents-item": "shoulder_strap" },
@@ -523,12 +533,12 @@
           "gloves_liner",
           "under_armor_shorts",
           "socks",
-          "lmil_armor",
           "lmil_helm",
           "molle_pack",
           "id_science"
         ],
         "entries": [
+          { "item": "lmil_armor", "contents-group": "c_plut_light" },
           { "item": "chemistry_set", "contents-item": [ "battery_ups" ] },
           { "item": "two_way_radio", "contents-item": [ "battery_ups" ] },
           { "item": "akro_laser_smg", "ammo-item": "battery", "charges": 1000, "contents-item": "shoulder_strap" },
@@ -579,8 +589,9 @@
     "proficiencies": [ "prof_gunsmithing_basic", "prof_traps", "prof_disarming", "prof_spotting" ],
     "items": {
       "both": {
-        "items": [ "helmet_liner", "thermal_shirt", "gloves_liner", "under_armor_shorts", "socks", "hmil_armor", "hmil_helm" ],
+        "items": [ "helmet_liner", "thermal_shirt", "gloves_liner", "under_armor_shorts", "socks", "hmil_helm" ],
         "entries": [
+          { "item": "hmil_armor", "contents-group": "c_plut_heavy" },
           { "item": "two_way_radio", "contents-item": "battery_ups" },
           { "item": "krx_laser_lmg", "ammo-item": "battery", "charges": 10000, "contents-item": "shoulder_strap" },
           { "item": "xarm_laser_shotgun_ups", "contents-item": "shoulder_strap" },

--- a/nocts_cata_mod_DDA/Monsters/c_monster_drops.json
+++ b/nocts_cata_mod_DDA/Monsters/c_monster_drops.json
@@ -115,8 +115,36 @@
         ],
         "prob": 80
       },
-      { "item": "arc_laser_rifle", "damage": [ 0, 3 ], "charges": [ 0, 2500 ] },
-      { "item": "medium_atomic_battery_cell_rechargeable", "damage": [ 0, 1 ], "charges": [ 0, 5000 ], "prob": 25 }
+      {
+        "distribution": [
+          {
+            "collection": [
+              { "item": "arc_laser_rifle", "damage": [ 0, 3 ], "charges": [ 0, 2500 ] },
+              {
+                "distribution": [
+                  { "item": "medium_atomic_battery_cell_rechargeable", "damage": [ 0, 1 ], "charges": [ 0, 5000 ], "prob": 50 },
+                  { "item": "medium_atomic_battery_cell", "damage": [ 0, 1 ], "charges": [ 0, 5000 ], "prob": 50 }
+                ],
+                "prob": 25
+              }
+            ],
+            "prob": 80
+          },
+          {
+            "collection": [
+              { "item": "arc_laser_rifle_ups", "damage": [ 0, 3 ] },
+              {
+                "distribution": [
+                  { "item": "UPS_off", "damage": [ 0, 1 ], "charges": [ 0, 1250 ], "prob": 50 },
+                  { "item": "adv_UPS_off", "damage": [ 0, 1 ], "charges": [ 0, 2500 ], "prob": 50 }
+                ],
+                "prob": 10
+              }
+            ],
+            "prob": 20
+          }
+        ]
+      }
     ]
   },
   {
@@ -137,8 +165,36 @@
         ],
         "prob": 80
       },
-      { "item": "xarm_laser_shotgun", "damage": [ 0, 3 ], "charges": [ 0, 2500 ] },
-      { "item": "medium_atomic_battery_cell_rechargeable", "damage": [ 0, 1 ], "charges": [ 0, 5000 ], "prob": 25 }
+      {
+        "distribution": [
+          {
+            "collection": [
+              { "item": "xarm_laser_shotgun", "damage": [ 0, 3 ], "charges": [ 0, 2500 ] },
+              {
+                "distribution": [
+                  { "item": "medium_atomic_battery_cell_rechargeable", "damage": [ 0, 1 ], "charges": [ 0, 5000 ], "prob": 50 },
+                  { "item": "medium_atomic_battery_cell", "damage": [ 0, 1 ], "charges": [ 0, 5000 ], "prob": 50 }
+                ],
+                "prob": 25
+              }
+            ],
+            "prob": 80
+          },
+          {
+            "collection": [
+              { "item": "xarm_laser_shotgun_ups", "damage": [ 0, 3 ] },
+              {
+                "distribution": [
+                  { "item": "UPS_off", "damage": [ 0, 1 ], "charges": [ 0, 1250 ], "prob": 50 },
+                  { "item": "adv_UPS_off", "damage": [ 0, 1 ], "charges": [ 0, 2500 ], "prob": 50 }
+                ],
+                "prob": 10
+              }
+            ],
+            "prob": 20
+          }
+        ]
+      }
     ]
   },
   {
@@ -160,8 +216,36 @@
         ],
         "prob": 80
       },
-      { "item": "mx_laser_sniper", "damage": [ 0, 3 ], "charges": [ 0, 2500 ] },
-      { "item": "medium_atomic_battery_cell_rechargeable", "damage": [ 0, 1 ], "charges": [ 0, 5000 ], "prob": 25 },
+      {
+        "distribution": [
+          {
+            "collection": [
+              { "item": "mx_laser_sniper", "damage": [ 0, 3 ], "charges": [ 0, 2500 ] },
+              {
+                "distribution": [
+                  { "item": "medium_atomic_battery_cell_rechargeable", "damage": [ 0, 1 ], "charges": [ 0, 5000 ], "prob": 50 },
+                  { "item": "medium_atomic_battery_cell", "damage": [ 0, 1 ], "charges": [ 0, 5000 ], "prob": 50 }
+                ],
+                "prob": 25
+              }
+            ],
+            "prob": 75
+          },
+          {
+            "collection": [
+              { "item": "mx_laser_sniper_ups", "damage": [ 0, 3 ] },
+              {
+                "distribution": [
+                  { "item": "UPS_off", "damage": [ 0, 1 ], "charges": [ 0, 1250 ], "prob": 50 },
+                  { "item": "adv_UPS_off", "damage": [ 0, 1 ], "charges": [ 0, 2500 ], "prob": 50 }
+                ],
+                "prob": 10
+              }
+            ],
+            "prob": 25
+          }
+        ]
+      },
       { "item": "e_tool", "damage": [ 0, 3 ], "prob": 50 },
       { "item": "mre_beef_box", "damage": [ 0, 3 ], "prob": 75 },
       { "item": "large_tent_kit", "damage": [ 0, 3 ], "prob": 25 },
@@ -187,8 +271,36 @@
         ],
         "prob": 80
       },
-      { "item": "krx_laser_lmg", "damage": [ 0, 3 ], "charges": [ 0, 5000 ] },
-      { "item": "heavy_atomic_battery_cell_rechargeable", "damage": [ 0, 1 ], "charges": [ 0, 10000 ], "prob": 25 }
+      {
+        "distribution": [
+          {
+            "collection": [
+              { "item": "krx_laser_lmg", "damage": [ 0, 3 ], "charges": [ 0, 5000 ] },
+              {
+                "distribution": [
+                  { "item": "heavy_atomic_battery_cell_rechargeable", "damage": [ 0, 1 ], "charges": [ 0, 10000 ], "prob": 50 },
+                  { "item": "heavy_atomic_battery_cell", "damage": [ 0, 1 ], "charges": [ 0, 10000 ], "prob": 50 }
+                ],
+                "prob": 25
+              }
+            ],
+            "prob": 95
+          },
+          {
+            "collection": [
+              { "item": "krx_laser_lmg_ups", "damage": [ 0, 3 ] },
+              {
+                "distribution": [
+                  { "item": "UPS_off", "damage": [ 0, 1 ], "charges": [ 0, 1250 ], "prob": 50 },
+                  { "item": "adv_UPS_off", "damage": [ 0, 1 ], "charges": [ 0, 2500 ], "prob": 50 }
+                ],
+                "prob": 10
+              }
+            ],
+            "prob": 5
+          }
+        ]
+      }
     ]
   },
   {
@@ -211,7 +323,14 @@
         "prob": 80
       },
       { "item": "mk_ionic_cannon", "damage": [ 0, 3 ], "charges": [ 0, 1 ] },
-      { "item": "plasma", "damage": [ 0, 1 ], "charges": [ 1, 2 ], "prob": 50 }
+      { "item": "plasma", "damage": [ 0, 1 ], "charges": [ 1, 2 ], "prob": 50 },
+      {
+        "distribution": [
+          { "item": "UPS_off", "damage": [ 0, 1 ], "charges": [ 0, 1250 ], "prob": 50 },
+          { "item": "adv_UPS_off", "damage": [ 0, 1 ], "charges": [ 0, 2500 ], "prob": 50 }
+        ],
+        "prob": 10
+      }
     ]
   },
   {
@@ -232,8 +351,42 @@
         ],
         "prob": 80
       },
-      { "item": "neo_laser_pistol", "damage": [ 0, 3 ], "charges": [ 0, 250 ] },
-      { "item": "light_atomic_battery_cell_rechargeable", "damage": [ 0, 1 ], "charges": [ 0, 500 ], "prob": 25 },
+      {
+        "distribution": [
+          {
+            "collection": [
+              { "item": "neo_laser_pistol", "damage": [ 0, 3 ], "charges": [ 0, 250 ] },
+              {
+                "distribution": [
+                  { "item": "light_atomic_battery_cell_rechargeable", "damage": [ 0, 1 ], "charges": [ 0, 1000 ], "prob": 50 },
+                  { "item": "light_atomic_battery_cell", "damage": [ 0, 1 ], "charges": [ 0, 1000 ], "prob": 25 },
+                  {
+                    "item": "light_minus_atomic_battery_cell",
+                    "damage": [ 0, 1 ],
+                    "charges": [ 0, 1000 ],
+                    "prob": 25
+                  }
+                ],
+                "prob": 25
+              }
+            ],
+            "prob": 50
+          },
+          {
+            "collection": [
+              { "item": "neo_laser_pistol_ups", "damage": [ 0, 3 ] },
+              {
+                "distribution": [
+                  { "item": "UPS_off", "damage": [ 0, 1 ], "charges": [ 0, 1250 ], "prob": 50 },
+                  { "item": "adv_UPS_off", "damage": [ 0, 1 ], "charges": [ 0, 2500 ], "prob": 50 }
+                ],
+                "prob": 10
+              }
+            ],
+            "prob": 50
+          }
+        ]
+      },
       { "item": "chemistry_set", "damage": [ 0, 1 ], "prob": 90 },
       { "item": "id_science", "damage": [ 0, 1 ], "prob": 25 },
       {
@@ -260,8 +413,42 @@
         ],
         "prob": 80
       },
-      { "item": "akro_laser_smg", "damage": [ 0, 3 ], "charges": [ 0, 500 ] },
-      { "item": "light_atomic_battery_cell_rechargeable", "damage": [ 0, 1 ], "charges": [ 500, 1000 ], "prob": 25 },
+      {
+        "distribution": [
+          {
+            "collection": [
+              { "item": "akro_laser_smg", "damage": [ 0, 3 ], "charges": [ 0, 500 ] },
+              {
+                "distribution": [
+                  { "item": "light_atomic_battery_cell_rechargeable", "damage": [ 0, 1 ], "charges": [ 0, 1000 ], "prob": 50 },
+                  { "item": "light_atomic_battery_cell", "damage": [ 0, 1 ], "charges": [ 0, 1000 ], "prob": 25 },
+                  {
+                    "item": "light_minus_atomic_battery_cell",
+                    "damage": [ 0, 1 ],
+                    "charges": [ 0, 1000 ],
+                    "prob": 25
+                  }
+                ],
+                "prob": 25
+              }
+            ],
+            "prob": 50
+          },
+          {
+            "collection": [
+              { "item": "akro_laser_smg_ups", "damage": [ 0, 3 ] },
+              {
+                "distribution": [
+                  { "item": "UPS_off", "damage": [ 0, 1 ], "charges": [ 0, 1250 ], "prob": 50 },
+                  { "item": "adv_UPS_off", "damage": [ 0, 1 ], "charges": [ 0, 2500 ], "prob": 50 }
+                ],
+                "prob": 10
+              }
+            ],
+            "prob": 50
+          }
+        ]
+      },
       { "item": "chemistry_set", "damage": [ 0, 1 ], "prob": 90 },
       { "item": "id_science", "damage": [ 0, 1 ], "prob": 25 },
       {

--- a/nocts_cata_mod_DDA/Recipe/c_recipes.json
+++ b/nocts_cata_mod_DDA/Recipe/c_recipes.json
@@ -1797,6 +1797,8 @@
     "difficulty": 2,
     "skills_required": [ [ "fabrication", 2 ], [ "mechanics", 2 ] ],
     "time": "12 m",
+    "reversible": true,
+    "decomp_learn": 4,
     "book_learn": [ [ "omnitech_weapon_ups_manual", 2 ] ],
     "tools": [ [ [ "omnitech_weapon_ups_kit", -1 ] ] ],
     "components": [ [ [ "neo_laser_pistol", 1 ] ] ]
@@ -1811,6 +1813,8 @@
     "difficulty": 2,
     "skills_required": [ [ "fabrication", 2 ], [ "mechanics", 2 ] ],
     "time": "12 m",
+    "reversible": true,
+    "decomp_learn": 4,
     "book_learn": [ [ "omnitech_weapon_ups_manual", 2 ] ],
     "tools": [ [ [ "omnitech_weapon_ups_kit", -1 ] ] ],
     "components": [ [ [ "akro_laser_smg", 1 ] ] ]
@@ -1825,6 +1829,8 @@
     "difficulty": 2,
     "skills_required": [ [ "fabrication", 2 ], [ "mechanics", 2 ] ],
     "time": "12 m",
+    "reversible": true,
+    "decomp_learn": 4,
     "book_learn": [ [ "omnitech_weapon_ups_manual", 2 ] ],
     "tools": [ [ [ "omnitech_weapon_ups_kit", -1 ] ] ],
     "components": [ [ [ "arc_laser_rifle", 1 ] ] ]
@@ -1839,6 +1845,8 @@
     "difficulty": 2,
     "skills_required": [ [ "fabrication", 2 ], [ "mechanics", 2 ] ],
     "time": "12 m",
+    "reversible": true,
+    "decomp_learn": 4,
     "book_learn": [ [ "omnitech_weapon_ups_manual", 2 ] ],
     "tools": [ [ [ "omnitech_weapon_ups_kit", -1 ] ] ],
     "components": [ [ [ "krx_laser_lmg", 1 ] ] ]
@@ -1853,6 +1861,8 @@
     "difficulty": 2,
     "skills_required": [ [ "fabrication", 2 ], [ "mechanics", 2 ] ],
     "time": "12 m",
+    "reversible": true,
+    "decomp_learn": 4,
     "book_learn": [ [ "omnitech_weapon_ups_manual", 2 ] ],
     "tools": [ [ [ "omnitech_weapon_ups_kit", -1 ] ] ],
     "components": [ [ [ "mx_laser_sniper", 1 ] ] ]
@@ -1867,6 +1877,8 @@
     "difficulty": 2,
     "skills_required": [ [ "fabrication", 2 ], [ "mechanics", 2 ] ],
     "time": "12 m",
+    "reversible": true,
+    "decomp_learn": 4,
     "book_learn": [ [ "omnitech_weapon_ups_manual", 2 ] ],
     "tools": [ [ [ "omnitech_weapon_ups_kit", -1 ] ] ],
     "components": [ [ [ "xarm_laser_shotgun", 1 ] ] ]

--- a/nocts_cata_mod_DDA/Surv_help/c_armor.json
+++ b/nocts_cata_mod_DDA/Surv_help/c_armor.json
@@ -422,7 +422,8 @@
         "max_contains_volume": "525 ml",
         "max_contains_weight": "5 kg",
         "holster": true,
-        "flag_restriction": [ "MAG_COMPACT" ]
+        "flag_restriction": [ "MAG_COMPACT" ],
+        "item_restriction": [ "light_atomic_battery_cell", "medium_atomic_battery_cell" ]
       },
       {
         "moves": 40,
@@ -430,7 +431,8 @@
         "max_contains_volume": "525 ml",
         "max_contains_weight": "5 kg",
         "holster": true,
-        "flag_restriction": [ "MAG_COMPACT" ]
+        "flag_restriction": [ "MAG_COMPACT" ],
+        "item_restriction": [ "light_atomic_battery_cell", "medium_atomic_battery_cell" ]
       }
     ],
     "use_action": { "type": "holster", "holster_prompt": "Stash magazine", "holster_msg": "You stash your %s" },
@@ -470,7 +472,8 @@
         "max_contains_volume": "525 ml",
         "max_contains_weight": "5 kg",
         "holster": true,
-        "flag_restriction": [ "MAG_COMPACT" ]
+        "flag_restriction": [ "MAG_COMPACT" ],
+        "item_restriction": [ "light_atomic_battery_cell", "medium_atomic_battery_cell" ]
       },
       {
         "moves": 40,
@@ -478,7 +481,8 @@
         "max_contains_volume": "525 ml",
         "max_contains_weight": "5 kg",
         "holster": true,
-        "flag_restriction": [ "MAG_COMPACT" ]
+        "flag_restriction": [ "MAG_COMPACT" ],
+        "item_restriction": [ "light_atomic_battery_cell", "medium_atomic_battery_cell" ]
       }
     ],
     "use_action": { "type": "holster", "holster_prompt": "Stash magazine", "holster_msg": "You stash your %s" },
@@ -510,7 +514,7 @@
     "warmth": 30,
     "material_thickness": 1,
     "environmental_protection": 5,
-    "//": "Designed to be able to hold military light and medium atomic cells.",
+    "//": "Designed to be able to hold military medium and heavy atomic cells.",
     "pocket_data": [
       {
         "moves": 40,
@@ -518,7 +522,8 @@
         "max_contains_volume": "1500 ml",
         "max_contains_weight": "5 kg",
         "holster": true,
-        "flag_restriction": [ "MAG_COMPACT", "MAG_BULKY" ]
+        "flag_restriction": [ "MAG_COMPACT", "MAG_BULKY" ],
+        "item_restriction": [ "medium_atomic_battery_cell", "heavy_atomic_battery_cell" ]
       },
       {
         "moves": 40,
@@ -526,7 +531,8 @@
         "max_contains_volume": "1500 ml",
         "max_contains_weight": "5 kg",
         "holster": true,
-        "flag_restriction": [ "MAG_COMPACT", "MAG_BULKY" ]
+        "flag_restriction": [ "MAG_COMPACT", "MAG_BULKY" ],
+        "item_restriction": [ "medium_atomic_battery_cell", "heavy_atomic_battery_cell" ]
       }
     ],
     "use_action": { "type": "holster", "holster_prompt": "Stash magazine", "holster_msg": "You stash your %s" },

--- a/nocts_cata_mod_DDA/Surv_help/c_item_groups_vanilla.json
+++ b/nocts_cata_mod_DDA/Surv_help/c_item_groups_vanilla.json
@@ -303,12 +303,25 @@
     "type": "item_group",
     "extend": {
       "items": [
-        [ "neo_laser_pistol", 2 ],
-        [ "akro_laser_smg", 2 ],
-        [ "arc_laser_rifle", 2 ],
-        [ "krx_laser_lmg", 2 ],
-        [ "mx_laser_sniper", 2 ],
-        [ "xarm_laser_shotgun", 2 ],
+      {
+        "distribution": [ { "item": "neo_laser_pistol", "prob": 50 }, { "item": "neo_laser_pistol_ups", "prob": 50 } ], "prob": 2
+      },
+      {
+        "distribution": [ { "item": "akro_laser_smg", "prob": 50 }, { "item": "akro_laser_smg_ups", "prob": 50 } ], "prob": 2
+      },
+      {
+        "distribution": [ { "item": "arc_laser_rifle", "prob": 50 }, { "item": "arc_laser_rifle_ups", "prob": 50 } ], "prob": 2
+      },
+      {
+        "distribution": [ { "item": "krx_laser_lmg", "prob": 50 }, { "item": "krx_laser_lmg_ups", "prob": 50 } ], "prob": 2
+      },
+      {
+        "distribution": [ { "item": "mx_laser_sniper", "prob": 50 }, { "item": "mx_laser_sniper_ups", "prob": 50 } ], "prob": 2
+      },
+      {
+        "distribution": [ { "item": "xarm_laser_shotgun", "prob": 50 }, { "item": "xarm_laser_shotgun_ups", "prob": 50 } ], "prob": 2
+      },
+
         [ "br_bolt_rifle_elec", 2 ],
         [ "mk_ionic_cannon", 2 ],
         [ "megamap", 2 ],
@@ -336,12 +349,24 @@
     "type": "item_group",
     "extend": {
       "items": [
-        [ "neo_laser_pistol", 2 ],
-        [ "akro_laser_smg", 2 ],
-        [ "arc_laser_rifle", 2 ],
-        [ "krx_laser_lmg", 2 ],
-        [ "mx_laser_sniper", 2 ],
-        [ "xarm_laser_shotgun", 2 ],
+      {
+        "distribution": [ { "item": "neo_laser_pistol", "prob": 50 }, { "item": "neo_laser_pistol_ups", "prob": 50 } ], "prob": 2
+      },
+      {
+        "distribution": [ { "item": "akro_laser_smg", "prob": 50 }, { "item": "akro_laser_smg_ups", "prob": 50 } ], "prob": 2
+      },
+      {
+        "distribution": [ { "item": "arc_laser_rifle", "prob": 50 }, { "item": "arc_laser_rifle_ups", "prob": 50 } ], "prob": 2
+      },
+      {
+        "distribution": [ { "item": "krx_laser_lmg", "prob": 50 }, { "item": "krx_laser_lmg_ups", "prob": 50 } ], "prob": 2
+      },
+      {
+        "distribution": [ { "item": "mx_laser_sniper", "prob": 50 }, { "item": "mx_laser_sniper_ups", "prob": 50 } ], "prob": 2
+      },
+      {
+        "distribution": [ { "item": "xarm_laser_shotgun", "prob": 50 }, { "item": "xarm_laser_shotgun_ups", "prob": 50 } ], "prob": 2
+      },
         [ "br_bolt_rifle_elec", 2 ],
         [ "mk_ionic_cannon", 2 ],
         [ "megamap", 2 ],
@@ -615,12 +640,24 @@
     "extend": {
       "items": [
         [ "mk_ionic_cannon", 1 ],
-        { "item": "neo_laser_pistol", "prob": 1, "charges-min": 0, "charges-max": 500 },
-        { "item": "akro_laser_smg", "prob": 1, "charges-min": 0, "charges-max": 1000 },
-        { "item": "arc_laser_rifle", "prob": 1, "charges-min": 0, "charges-max": 5000 },
-        { "item": "krx_laser_lmg", "prob": 1, "charges-min": 0, "charges-max": 10000 },
-        { "item": "mx_laser_sniper", "prob": 1, "charges-min": 0, "charges-max": 5000 },
-        { "item": "xarm_laser_shotgun", "prob": 1, "charges-min": 0, "charges-max": 5000 }
+      {
+        "distribution": [ { "item": "neo_laser_pistol", "prob": 50, "charges": [ 0, 500 ] }, { "item": "neo_laser_pistol_ups", "prob": 50 } ], "prob": 1
+      },
+      {
+        "distribution": [ { "item": "akro_laser_smg", "prob": 50, "charges": [ 0, 1000 ] }, { "item": "akro_laser_smg_ups", "prob": 50 } ], "prob": 1
+      },
+      {
+        "distribution": [ { "item": "arc_laser_rifle", "prob": 50, "charges": [ 0, 5000 ] }, { "item": "arc_laser_rifle_ups", "prob": 50 } ], "prob": 1
+      },
+      {
+        "distribution": [ { "item": "krx_laser_lmg", "prob": 50, "charges": [ 0, 10000 ] }, { "item": "krx_laser_lmg_ups", "prob": 50 } ], "prob": 1
+      },
+      {
+        "distribution": [ { "item": "mx_laser_sniper", "prob": 50, "charges": [ 0, 5000 ] }, { "item": "mx_laser_sniper_ups", "prob": 50 } ], "prob": 1
+      },
+      {
+        "distribution": [ { "item": "xarm_laser_shotgun", "prob": 50, "charges": [ 0, 5000 ] }, { "item": "xarm_laser_shotgun_ups", "prob": 50 } ], "prob": 1
+      }
       ]
     }
   },

--- a/nocts_cata_mod_DDA/Weapons/c_ranged.json
+++ b/nocts_cata_mod_DDA/Weapons/c_ranged.json
@@ -1244,7 +1244,7 @@
         "holster": true,
         "max_contains_volume": "20 L",
         "max_contains_weight": "20 kg",
-        "item_restriction": [ "light_atomic_battery_cell_rechargeable", "light_atomic_battery_cell", "light_minus_atomic_battery_cell" ]
+        "item_restriction": [ "light_minus_atomic_battery_cell", "light_atomic_battery_cell", "light_atomic_battery_cell_rechargeable" ]
       }
     ]
   },
@@ -1311,8 +1311,7 @@
     "durability": 10,
     "modes": [ [ "DEFAULT", "semi", 1 ], [ "BURST", "spray", 10 ], [ "AUTO", "auto", 15 ] ],
     "reload": 200,
-    "default_mods": [ "rail_laser_sight", "pistol_grip" ],
-    "built_in_mods": [ "grip" ],
+    "built_in_mods": [ "rail_laser_sight", "pistol_grip", "grip" ],
     "valid_mod_locations": [
       [ "accessories", 2 ],
       [ "sling", 1 ],
@@ -1331,7 +1330,7 @@
         "holster": true,
         "max_contains_volume": "20 L",
         "max_contains_weight": "20 kg",
-        "item_restriction": [ "light_atomic_battery_cell_rechargeable", "light_minus_atomic_battery_cell", "light_atomic_battery_cell" ]
+        "item_restriction": [ "light_atomic_battery_cell", "light_minus_atomic_battery_cell", "light_atomic_battery_cell_rechargeable" ]
       }
     ]
   },
@@ -1360,8 +1359,7 @@
     "durability": 10,
     "modes": [ [ "DEFAULT", "semi", 1 ], [ "BURST", "spray", 10 ], [ "AUTO", "auto", 15 ] ],
     "ups_charges": 20,
-    "default_mods": [ "rail_laser_sight", "pistol_grip" ],
-    "built_in_mods": [ "grip" ],
+    "built_in_mods": [ "rail_laser_sight", "pistol_grip", "grip" ],
     "valid_mod_locations": [
       [ "accessories", 2 ],
       [ "sling", 1 ],
@@ -1401,7 +1399,7 @@
     "durability": 10,
     "modes": [ [ "DEFAULT", "semi", 1 ], [ "BURST", "burst", 3 ], [ "AUTO", "auto", 10 ] ],
     "reload": 200,
-    "default_mods": [ "pistol_grip", "grip" ],
+    "built_in_mods": [ "pistol_grip", "grip" ],
     "valid_mod_locations": [
       [ "accessories", 4 ],
       [ "sling", 1 ],
@@ -1420,7 +1418,7 @@
         "holster": true,
         "max_contains_volume": "20 L",
         "max_contains_weight": "20 kg",
-        "item_restriction": [ "medium_atomic_battery_cell_rechargeable", "medium_atomic_battery_cell" ]
+        "item_restriction": [ "medium_atomic_battery_cell", "medium_atomic_battery_cell_rechargeable" ]
       }
     ]
   },
@@ -1449,7 +1447,7 @@
     "durability": 10,
     "modes": [ [ "DEFAULT", "semi", 1 ], [ "BURST", "burst", 3 ], [ "AUTO", "auto", 10 ] ],
     "ups_charges": 50,
-    "default_mods": [ "pistol_grip", "grip" ],
+    "built_in_mods": [ "pistol_grip", "grip" ],
     "valid_mod_locations": [
       [ "accessories", 4 ],
       [ "sling", 1 ],
@@ -1507,7 +1505,7 @@
         "holster": true,
         "max_contains_volume": "20 L",
         "max_contains_weight": "20 kg",
-        "item_restriction": [ "heavy_atomic_battery_cell_rechargeable", "heavy_atomic_battery_cell" ]
+        "item_restriction": [ "heavy_atomic_battery_cell", "heavy_atomic_battery_cell_rechargeable" ]
       }
     ]
   },
@@ -1573,8 +1571,7 @@
     "loudness": 20,
     "durability": 10,
     "reload": 300,
-    "default_mods": [ "bipod" ],
-    "built_in_mods": [ "rifle_scope" ],
+    "built_in_mods": [ "bipod", "rifle_scope" ],
     "valid_mod_locations": [
       [ "accessories", 2 ],
       [ "sling", 1 ],
@@ -1593,7 +1590,7 @@
         "holster": true,
         "max_contains_volume": "20 L",
         "max_contains_weight": "20 kg",
-        "item_restriction": [ "medium_atomic_battery_cell_rechargeable", "medium_atomic_battery_cell" ]
+        "item_restriction": [ "medium_atomic_battery_cell", "medium_atomic_battery_cell_rechargeable" ]
       }
     ]
   },
@@ -1621,8 +1618,7 @@
     "loudness": 20,
     "durability": 10,
     "ups_charges": 100,
-    "default_mods": [ "bipod" ],
-    "built_in_mods": [ "rifle_scope" ],
+    "built_in_mods": [ "bipod", "rifle_scope" ],
     "valid_mod_locations": [
       [ "accessories", 2 ],
       [ "sling", 1 ],
@@ -1661,7 +1657,7 @@
     "loudness": 14,
     "dispersion": 300,
     "durability": 8,
-    "default_mods": [ "rail_laser_sight", "pistol_grip" ],
+    "built_in_mods": [ "rail_laser_sight", "pistol_grip" ],
     "modes": [ [ "DEFAULT", "semi", 1 ], [ "BURST", "double-barrel", 2 ] ],
     "reload": 250,
     "valid_mod_locations": [
@@ -1682,7 +1678,7 @@
         "holster": true,
         "max_contains_volume": "20 L",
         "max_contains_weight": "20 kg",
-        "item_restriction": [ "medium_atomic_battery_cell_rechargeable", "medium_atomic_battery_cell" ]
+        "item_restriction": [ "medium_atomic_battery_cell", "medium_atomic_battery_cell_rechargeable" ]
       }
     ]
   },
@@ -1710,7 +1706,7 @@
     "loudness": 14,
     "dispersion": 300,
     "durability": 8,
-    "default_mods": [ "rail_laser_sight", "pistol_grip" ],
+    "built_in_mods": [ "rail_laser_sight", "pistol_grip" ],
     "modes": [ [ "DEFAULT", "semi", 1 ], [ "BURST", "double-barrel", 2 ] ],
     "ups_charges": 100,
     "valid_mod_locations": [


### PR DESCRIPTION
* Set the Ominitech weapons to have all their default mods built-in. This fixes an exploit where you could remove their default mods, convert them to UPS, and have it regenerate fresh new default gunmods to remove.
* Set it so you can reverse conversion of the Omnitech weapons from UPS back to plutonium-powered, allow learning the recipe this way.
* Added the possibility for the UPS versions of Omnitech weapons to spawn. Generally about 50/50 in scientific settings, less often from augmented undead soldiers. Also allows the spare batteries on them to be either recharging or non-recharging. When the UPS version spawns, it also comes with a (reduced) chance to spawn a UPS, since sustained use might encourage supplementing the bionic UPS with an external one.
* Set it so non-recharging plutonium batteries are the default magazine for the Omnitech weapons again, which means augmented undead soldiers are no longer a 100% guaranteed source of rechargeable plutonium cells. To compensate for this since it'd strongly affect the profession versions, the professions now spawn with one spare rechargeable plutonium battery, at a random charge level.
* Also set it so you can stash the relevant vanilla plutonium batteries in milsuit pockets in the DDA version. I have a plan for a BN PR that will accomplish the same thing from BN's end.