### PR TITLE
Remove redundant mutations from Bio-Weapon Alpha

### DIFF
--- a/nocts_cata_mod_BN/Char_creation/c_classes_bw.json
+++ b/nocts_cata_mod_BN/Char_creation/c_classes_bw.json
@@ -166,9 +166,6 @@
       "HUNGER_BIOWEAPON",
       "STAMINA_BIOWEAPON",
       "NEURO_BAD_BIOWEAPON",
-      "STRONGSTOMACH",
-      "EATDEAD",
-      "PARAIMMUNE",
       "BIO_WEAPON_ALPHA"
     ],
     "skills": [ { "level": 5, "name": "dodge" }, { "level": 5, "name": "melee" }, { "level": 5, "name": "unarmed" } ],

--- a/nocts_cata_mod_BN/Mutations/c_bio_mutation.json
+++ b/nocts_cata_mod_BN/Mutations/c_bio_mutation.json
@@ -105,7 +105,7 @@
     "name": { "str": "Metabolic Instability" },
     "points": 0,
     "mixed_effect": true,
-    "description": "Your body requires more resources than normal, burning calories and requiring more food in exchange for warming you up more easily.",
+    "description": "Your body requires more resources than normal, burning calories and requiring more food in exchange for warming you up more easily.  You can also better tolerate mutant toxins.",
     "valid": false,
     "purifiable": false,
     "profession": true,
@@ -113,7 +113,8 @@
     "cancels": [ "THIRST" ],
     "bodytemp_modifiers": [ 0, 2000 ],
     "metabolism_modifier": 1.25,
-    "thirst_modifier": 0.75
+    "thirst_modifier": 0.75,
+    "vitamins_absorb_multi": [ [ "all", [ [ "mutant_toxin", 0.25 ] ] ] ]
   },
   {
     "type": "mutation",

--- a/nocts_cata_mod_DDA/Char_creation/c_classes_bw.json
+++ b/nocts_cata_mod_DDA/Char_creation/c_classes_bw.json
@@ -166,9 +166,6 @@
       "HUNGER_BIOWEAPON",
       "STAMINA_BIOWEAPON",
       "NEURO_BAD_BIOWEAPON",
-      "STRONGSTOMACH",
-      "EATDEAD",
-      "PARAIMMUNE",
       "BIO_WEAPON_ALPHA"
     ],
     "skills": [ { "level": 5, "name": "dodge" }, { "level": 5, "name": "melee" }, { "level": 5, "name": "unarmed" } ],

--- a/nocts_cata_mod_DDA/Mutations/c_bio_mutation.json
+++ b/nocts_cata_mod_DDA/Mutations/c_bio_mutation.json
@@ -104,7 +104,7 @@
     "name": { "str": "Metabolic Instability" },
     "points": 0,
     "mixed_effect": true,
-    "description": "Your body requires more resources than normal, burning calories and requiring more food in exchange for warming you up more easily.",
+    "description": "Your body requires more resources than normal, burning calories and requiring more food in exchange for warming you up more easily.  You can also better tolerate mutant toxins.",
     "valid": false,
     "purifiable": false,
     "profession": true,
@@ -112,7 +112,8 @@
     "cancels": [ "THIRST" ],
     "bodytemp_modifiers": [ 0, 2000 ],
     "metabolism_modifier": 1.25,
-    "thirst_modifier": 0.75
+    "thirst_modifier": 0.75,
+    "vitamins_absorb_multi": [ [ "all", [ [ "mutant_toxin", 0.25 ] ] ] ]
   },
   {
     "type": "mutation",


### PR DESCRIPTION
Turns out that in both BN and DDA, the Expanded Digestion bionic covers all the effects of several metabolic mutations Alpha was given, so we can trim yet more mandatory trait points. As a bonus, gave the Metabolic Instability trait an effect that mitigates mutant toxins. Compared to Arcana's pending changes to Metabolic Resilience and Metabolic Adaptability, Metabolic Instability gains no extra toxin processing but does get even better reduction in toxin absorption, 25% instead of a max of 50%.

Fixes https://github.com/Noctifer-de-Mortem/nocts_cata_mod/issues/389