### PR TITLE
Implement more mi-go items to harvest

### DIFF
--- a/nocts_cata_mod_BN/Monsters/c_monster_harvest.json
+++ b/nocts_cata_mod_BN/Monsters/c_monster_harvest.json
@@ -103,23 +103,33 @@
     ]
   },
   {
-    "id": "c_mi_go_beam",
+    "id": "c_mi_go_multi_worker",
     "type": "harvest",
     "entries": [
       { "drop": "meat_tainted", "type": "flesh", "mass_ratio": 0.4 },
       { "drop": "fat_tainted", "type": "flesh", "mass_ratio": 0.1 },
       { "drop": "fat_tainted", "type": "offal", "mass_ratio": 0.1 },
-      { "drop": "c_mi_go_beam_broken", "type": "bionic", "max": 1 }
+      { "drop": "c_mi_go_advanced_dissection_worker", "type": "bionic_group", "max": 1 }
     ]
   },
   {
-    "id": "c_mi_go_claw",
+    "id": "c_mi_go_multi_slaver",
     "type": "harvest",
     "entries": [
       { "drop": "meat_tainted", "type": "flesh", "mass_ratio": 0.4 },
       { "drop": "fat_tainted", "type": "flesh", "mass_ratio": 0.1 },
       { "drop": "fat_tainted", "type": "offal", "mass_ratio": 0.1 },
-      { "drop": "c_mi_go_claw_broken", "type": "bionic", "max": 1 }
+      { "drop": "c_mi_go_advanced_dissection_slaver", "type": "bionic_group", "max": 1 }
+    ]
+  },
+  {
+    "id": "c_mi_go_multi_surgeon",
+    "type": "harvest",
+    "entries": [
+      { "drop": "meat_tainted", "type": "flesh", "mass_ratio": 0.4 },
+      { "drop": "fat_tainted", "type": "flesh", "mass_ratio": 0.1 },
+      { "drop": "fat_tainted", "type": "offal", "mass_ratio": 0.1 },
+      { "drop": "c_mi_go_advanced_dissection_surgeon", "type": "bionic_group", "max": 1 }
     ]
   },
   {
@@ -143,13 +153,13 @@
     ]
   },
   {
-    "id": "c_mi_go_rifle",
+    "id": "c_mi_go_multi_scout",
     "type": "harvest",
     "entries": [
       { "drop": "meat_tainted", "type": "flesh", "mass_ratio": 0.4 },
       { "drop": "fat_tainted", "type": "flesh", "mass_ratio": 0.1 },
       { "drop": "fat_tainted", "type": "offal", "mass_ratio": 0.1 },
-      { "drop": "c_mi_go_rifle_broken", "type": "bionic", "max": 1 }
+      { "drop": "c_mi_go_advanced_dissection_scout", "type": "bionic_group", "max": 1 }
     ]
   }
 ]

--- a/nocts_cata_mod_BN/Monsters/c_monster_override.json
+++ b/nocts_cata_mod_BN/Monsters/c_monster_override.json
@@ -87,16 +87,22 @@
     "anger_triggers": [ "PLAYER_CLOSE", "HURT", "FRIEND_ATTACKED", "FRIEND_DIED" ]
   },
   {
+    "id": "mon_mi_go",
+    "copy-from": "mon_mi_go",
+    "type": "MONSTER",
+    "harvest": "c_mi_go_multi_worker"
+  },
+  {
     "id": "mon_mi_go_slaver",
     "copy-from": "mon_mi_go_slaver",
     "type": "MONSTER",
-    "harvest": "c_mi_go_beam"
+    "harvest": "c_mi_go_multi_slaver"
   },
   {
     "id": "mon_mi_go_surgeon",
     "copy-from": "mon_mi_go_surgeon",
     "type": "MONSTER",
-    "harvest": "c_mi_go_claw"
+    "harvest": "c_mi_go_multi_surgeon"
   },
   {
     "id": "mon_mi_go_guard",
@@ -114,6 +120,6 @@
     "id": "mon_mi_go_scout",
     "copy-from": "mon_mi_go_scout",
     "type": "MONSTER",
-    "harvest": "c_mi_go_rifle"
+    "harvest": "c_mi_go_multi_scout"
   }
 ]

--- a/nocts_cata_mod_BN/Recipe/c_recipes.json
+++ b/nocts_cata_mod_BN/Recipe/c_recipes.json
@@ -2516,6 +2516,41 @@
     ]
   },
   {
+    "result": "c_mi_go_extruder_salvaged",
+    "type": "recipe",
+    "category": "CC_OTHER",
+    "subcategory": "CSC_OTHER_TOOLS",
+    "skill_used": "fabrication",
+    "difficulty": 5,
+    "skills_required": [ [ "firstaid", 4 ], [ "mechanics", 3 ], [ "cooking", 5 ] ],
+    "time": "25 m",
+    "book_learn": [ [ "evil_invitation", 4 ], [ "recipe_lab_elec", 5 ], [ "recipe_creepy", 5 ], [ "recipe_labchem", 6 ] ],
+    "using": [ [ "c_resin_molding_standard", 1 ], [ "welding_standard", 10 ], [ "steel_tiny", 1 ] ],
+    "qualities": [ { "id": "CUT_FINE", "level": 2 } ],
+    "components": [ [ [ "c_mi_go_extruder_broken", 1 ] ], [ [ "canister_empty", 1 ] ], [ [ "meat_tainted", 5 ], [ "slime_scrap", 1 ] ] ]
+  },
+  {
+    "result": "c_mi_go_wings_salvaged",
+    "type": "recipe",
+    "category": "CC_ARMOR",
+    "subcategory": "CSC_ARMOR_OTHER",
+    "skill_used": "fabrication",
+    "difficulty": 7,
+    "skills_required": [ [ "firstaid", 4 ], [ "electronics", 3 ], [ "mechanics", 3 ], [ "cooking", 5 ] ],
+    "time": "80 m",
+    "book_learn": [ [ "evil_invitation", 6 ], [ "recipe_lab_elec", 7 ], [ "recipe_creepy", 7 ], [ "recipe_labchem", 8 ] ],
+    "using": [ [ "c_resin_molding_standard", 4 ], [ "welding_standard", 20 ], [ "steel_standard", 1 ] ],
+    "qualities": [ { "id": "CUT_FINE", "level": 2 } ],
+    "components": [
+      [ [ "c_mi_go_wings_broken", 1 ] ],
+      [ [ "power_supply", 1 ] ],
+      [ [ "medium_battery_cell", 1 ] ],
+      [ [ "cable", 40 ] ],
+      [ [ "wire", 2 ] ],
+      [ [ "meat_tainted", 15 ], [ "slime_scrap", 3 ] ]
+    ]
+  },
+  {
     "result": "bikini_bottom_leather",
     "type": "recipe",
     "category": "CC_ARMOR",

--- a/nocts_cata_mod_BN/Surv_help/c_armor.json
+++ b/nocts_cata_mod_BN/Surv_help/c_armor.json
@@ -147,7 +147,7 @@
     "id": "cuirass_lightplate_surv",
     "copy-from": "cuirass_lightplate",
     "type": "ARMOR",
-    "name": { "str": "survivor cuirass" },
+    "name": { "str": "survivor cuirass", "str_pl": "survivor cuirasses" },
     "description": "A medieval steel breastplate, modified with kevlar and leather to better protect from the elements.",
     "weight": "4620 g",
     "price": "300 USD",
@@ -799,7 +799,7 @@
     "id": "c_mi_go_carapace_salvaged_on",
     "copy-from": "c_mi_go_carapace_salvaged",
     "type": "TOOL_ARMOR",
-    "name": { "str": "salvaged carapace armor (on)" },
+    "name": { "str": "salvaged carapace armor (on)", "str_pl": "salvaged carapace armors (on)" },
     "description": "A vaguely human-shaped shell of alien sinew and steel support, covered in armor plates made of resin.  Currently active, it can protect the wearer from toxic gas, serve as a rebreather, enhance strength and dexterity, enhance stamina and carry capacity, and provide some protection from outside temperature.  In exchange, being active will steadily fatigue the user and affect healthiness, plus render them more vulnerable to electric shocks.",
     "turns_per_charge": 150,
     "revert_to": "c_mi_go_carapace_salvaged",
@@ -812,6 +812,56 @@
     "encumbrance": 10,
     "weight_capacity_modifier": 2,
     "extend": { "flags": [ "WATERPROOF", "RAINPROOF", "CLIMATE_CONTROL", "GAS_PROOF", "REBREATHER" ] }
+  },
+  {
+    "id": "c_mi_go_wings_salvaged",
+    "type": "TOOL_ARMOR",
+    "symbol": "[",
+    "color": "green",
+    "name": { "str": "set of salvaged exo-wings", "str_pl": "sets of salvaged exo-wings" },
+    "description": "A set of thin, green iridescent wings, steel wires and joints meshed with thick alien nervous cords.  Salvaged using pre-cataclysm research into other living weaponry, it's been heavily altered to fit a human (or mutant) wearer.  Activating it will grant immunity to falling damage and vastly speed up movement.  It seems to recharge from sunlight, and being active will also gradually fatigue the user.",
+    "flags": [ "OVERSIZE", "STURDY", "BELTED" ],
+    "price_postapoc": "40 USD",
+    "material": [ "alien_resin", "flesh", "steel" ],
+    "weight": "2 kg",
+    "volume": "5 L",
+    "to_hit": -3,
+    "artifact_data": { "charge_type": "ARTC_SOLAR" },
+    "max_charges": 100,
+    "use_action": {
+      "type": "transform",
+      "msg": "The exo-wings whir to life, becoming a fluttering blur of green and gray.",
+      "target": "c_mi_go_wings_salvaged_on",
+      "active": true,
+      "need_charges": 1,
+      "need_charges_msg": "The exo-wings don't respond, evidently out of energy."
+    },
+    "relic_data": {
+      "passive_effects": [
+        {
+          "has": "WORN",
+          "condition": "ACTIVE",
+          "values": [ { "value": "MOVE_COST", "multiply": -0.5 }, { "value": "BONUS_DODGE", "add": 5 } ],
+          "ench_effects": [ { "effect": "c_mi_go_wings_immunity", "intensity": 1 } ]
+        }
+      ]
+    },
+    "covers": [ "torso" ],
+    "encumbrance": 10,
+    "coverage": 40,
+    "material_thickness": 2
+  },
+  {
+    "id": "c_mi_go_wings_salvaged_on",
+    "copy-from": "c_mi_go_wings_salvaged",
+    "type": "TOOL_ARMOR",
+    "name": { "str_sp": "set of salvaged exo-wings (on)", "str_pl": "sets of salvaged exo-wings (on)" },
+    "description": "A set of thin, green iridescent wings, steel wires and joints meshed with thick alien nervous cords.  They are currently buzzing with life, greatly speeding up movement and enhancing dodge as well as granting immunity to falling damage, in exchange for increased fatigue gain.",
+    "turns_per_charge": 75,
+    "revert_to": "c_mi_go_wings_salvaged",
+    "use_action": { "target": "c_mi_go_wings_salvaged", "msg": "The exo-wings go limp as they shut down.", "type": "transform" },
+    "encumbrance": 0,
+    "extend": { "flags": [ "NO_TAKEOFF" ] }
   },
   {
     "id": "cowboy_hat_surv",

--- a/nocts_cata_mod_BN/Surv_help/c_effects.json
+++ b/nocts_cata_mod_BN/Surv_help/c_effects.json
@@ -139,5 +139,12 @@
     "type": "effect_type",
     "id": "c_bio_painrec",
     "base_mods": { "pain_min": [ -1 ], "pain_tick": [ 10 ] }
+  },
+  {
+    "type": "effect_type",
+    "id": "c_mi_go_wings_immunity",
+    "removes_effects": [ "downed", "bouldering" ],
+    "base_mods": { "fatigue_min": [ 1 ], "fatigue_tick": [ 300 ] },
+    "flags": [ "EFFECT_FEATHER_FALL" ]
   }
 ]

--- a/nocts_cata_mod_BN/Surv_help/c_item_groups.json
+++ b/nocts_cata_mod_BN/Surv_help/c_item_groups.json
@@ -884,6 +884,24 @@
   },
   {
     "type": "item_group",
+    "id": "c_mi_go_advanced_dissection_worker",
+    "subtype": "distribution",
+    "items": [ [ "c_mi_go_extruder_broken", 1 ], [ "c_mi_go_wings_broken", 1 ] ]
+  },
+  {
+    "type": "item_group",
+    "id": "c_mi_go_advanced_dissection_slaver",
+    "subtype": "distribution",
+    "items": [ [ "c_mi_go_beam_broken", 3 ], [ "c_mi_go_wings_broken", 1 ] ]
+  },
+  {
+    "type": "item_group",
+    "id": "c_mi_go_advanced_dissection_surgeon",
+    "subtype": "distribution",
+    "items": [ [ "c_mi_go_claw_broken", 3 ], [ "c_mi_go_wings_broken", 1 ] ]
+  },
+  {
+    "type": "item_group",
     "id": "c_mi_go_advanced_dissection_guard",
     "subtype": "distribution",
     "items": [ [ "c_mi_go_carapace_broken", 2 ], [ "c_mi_go_beam_broken", 1 ] ]
@@ -893,6 +911,12 @@
     "id": "c_mi_go_advanced_dissection_myrmidon",
     "subtype": "distribution",
     "items": [ [ "c_mi_go_carapace_broken", 3 ], [ "c_mi_go_beam_broken", 1 ], [ "c_mi_go_claw_broken", 1 ] ]
+  },
+  {
+    "type": "item_group",
+    "id": "c_mi_go_advanced_dissection_scout",
+    "subtype": "distribution",
+    "items": [ [ "c_mi_go_rifle_broken", 3 ], [ "c_mi_go_wings_broken", 1 ] ]
   },
   {
     "id": "sewer",

--- a/nocts_cata_mod_BN/Surv_help/c_spells.json
+++ b/nocts_cata_mod_BN/Surv_help/c_spells.json
@@ -177,5 +177,18 @@
     "min_damage": -2,
     "max_damage": -5,
     "flags": [ "RANDOM_DAMAGE", "SILENT" ]
+  },
+  {
+    "id": "c_resin_create",
+    "type": "SPELL",
+    "name": { "str": "Extrude Resin" },
+    "description": "Creates a random number of alien resin chunks.",
+    "valid_targets": [ "self" ],
+    "message": "",
+    "flags": [ "SILENT", "PERMANENT", "NO_HANDS", "NO_LEGS", "RANDOM_DAMAGE" ],
+    "effect": "spawn_item",
+    "effect_str": "resin_chunk",
+    "min_duration": 1,
+    "max_duration": 2
   }
 ]

--- a/nocts_cata_mod_BN/Surv_help/c_tools.json
+++ b/nocts_cata_mod_BN/Surv_help/c_tools.json
@@ -1088,5 +1088,81 @@
     "weight": "35 kg",
     "volume": "40 L",
     "flags": [ "TRADER_AVOID", "NO_REPAIR" ]
+  },
+  {
+    "type": "GENERIC",
+    "id": "c_mi_go_extruder_broken",
+    "symbol": ";",
+    "color": "green",
+    "name": { "str": "alien spinneret" },
+    "description": "A fist-sized clump of gore and torn muscle fibers, from which jut three thin spines of what seems to be synthetic bone, or possibly keratin.  In between the spines are countless thin strands of what looks like brilliant green fiberglass, most likely alien resin.  This seems to be used for either producing or shaping this strange substance, potentially useful but right now it's of little use to anyone like this, human or alien.",
+    "category": "other",
+    "material": [ "alien_resin", "flesh" ],
+    "weight": "750 g",
+    "volume": "500 ml",
+    "flags": [ "TRADER_AVOID", "NO_REPAIR" ]
+  },
+  {
+    "type": "GENERIC",
+    "id": "c_mi_go_wings_broken",
+    "symbol": ";",
+    "color": "green",
+    "name": { "str": "set of iridescent wings", "str_pl": "sets of iridescent wings" },
+    "description": "Several pairs of glossy insect-like wings, thin green iridescent flesh flushed with congealed fluid in what seem to be veins, weaving a spider-web pattern of pale grey all throughout.  They blend together into a mangled cluster of chitinous plates covering off-white nervous cords, provoking rather strong convulsions when pulled the wrong way.  Whether they fly through the void of space on these or use them for something else, it's evident these wings were manufactured as much as evolved.",
+    "category": "other",
+    "material": [ "alien_resin", "flesh" ],
+    "weight": "4 kg",
+    "volume": "10 L",
+    "flags": [ "TRADER_AVOID", "NO_REPAIR" ]
+  },
+  {
+    "id": "c_mi_go_extruder_salvaged",
+    "type": "TOOL",
+    "symbol": "/",
+    "color": "green",
+    "name": { "str": "salvaged resin extruder" },
+    "description": "A strange device made of alien flesh blended with technology.  Three thin spines of synthetic ivory surround some sort of nozzle, its contents steadily regenerating.  It can be activated to produce shards of resin, for whatever use you may have for such a thing.  Activate it will set it to apply resin more slowly, letting it be used for repairing salvaged mi-go biotechnlogy.",
+    "price_postapoc": "25 USD",
+    "material": [ "alien_resin", "flesh", "steel" ],
+    "weight": "300 g",
+    "volume": "250 ml",
+    "artifact_data": { "charge_type": "ARTC_TIME" },
+    "max_charges": 100,
+    "charges_per_use": 25,
+    "use_action": [
+      { "type": "cast_spell", "spell_id": "c_resin_create", "no_fail": true, "level": 0 },
+      {
+        "type": "transform",
+        "msg": "You switch the %s to weaving mode",
+        "target": "c_mi_go_extruder_salvaged_alt",
+        "menu_text": "switch mode"
+      }
+    ]
+  },
+  {
+    "id": "c_mi_go_extruder_salvaged_alt",
+    "copy-from": "c_mi_go_extruder_salvaged",
+    "type": "TOOL",
+    "color": "green",
+    "name": { "str": "salvaged resin extruder (alternate mode)", "str_pl": "salvaged resin extruders (alternate mode)" },
+    "description": "A strange device made of alien flesh blended with technology.  Three thin spines of synthetic ivory surround some sort of nozzle, its contents steadily regenerating.  It's currently set to apply resin more slowly, letting it be used for repairing salvaged mi-go biotechnlogy.  Activate it to switch back to its normal mode, for creating larger shards of resin for other purposes.",
+    "charges_per_use": 1,
+    "use_action": [
+      {
+        "type": "repair_item",
+        "item_action_type": "repair_metal",
+        "materials": [ "alien_resin" ],
+        "skill": "fabrication",
+        "tool_quality": 10,
+        "cost_scaling": 0.1,
+        "move_cost": 500
+      },
+      {
+        "type": "transform",
+        "msg": "You switch the %s to its normal mode",
+        "target": "c_mi_go_extruder_salvaged",
+        "menu_text": "switch mode"
+      }
+    ]
   }
 ]

--- a/nocts_cata_mod_DDA/Monsters/c_monster_harvest.json
+++ b/nocts_cata_mod_DDA/Monsters/c_monster_harvest.json
@@ -213,23 +213,33 @@
     ]
   },
   {
-    "id": "c_mi_go_beam",
+    "id": "c_mi_go_multi_worker",
     "type": "harvest",
     "entries": [
       { "drop": "meat_tainted", "type": "flesh", "mass_ratio": 0.4 },
       { "drop": "fat_tainted", "type": "flesh", "mass_ratio": 0.1 },
       { "drop": "fat_tainted", "type": "offal", "mass_ratio": 0.1 },
-      { "drop": "c_mi_go_beam_broken", "type": "bionic", "max": 1 }
+      { "drop": "c_mi_go_advanced_dissection_worker", "type": "bionic_group", "max": 1 }
     ]
   },
   {
-    "id": "c_mi_go_claw",
+    "id": "c_mi_go_multi_slaver",
     "type": "harvest",
     "entries": [
       { "drop": "meat_tainted", "type": "flesh", "mass_ratio": 0.4 },
       { "drop": "fat_tainted", "type": "flesh", "mass_ratio": 0.1 },
       { "drop": "fat_tainted", "type": "offal", "mass_ratio": 0.1 },
-      { "drop": "c_mi_go_claw_broken", "type": "bionic", "max": 1 }
+      { "drop": "c_mi_go_advanced_dissection_slaver", "type": "bionic_group", "max": 1 }
+    ]
+  },
+  {
+    "id": "c_mi_go_multi_surgeon",
+    "type": "harvest",
+    "entries": [
+      { "drop": "meat_tainted", "type": "flesh", "mass_ratio": 0.4 },
+      { "drop": "fat_tainted", "type": "flesh", "mass_ratio": 0.1 },
+      { "drop": "fat_tainted", "type": "offal", "mass_ratio": 0.1 },
+      { "drop": "c_mi_go_advanced_dissection_surgeon", "type": "bionic_group", "max": 1 }
     ]
   },
   {
@@ -253,13 +263,13 @@
     ]
   },
   {
-    "id": "c_mi_go_rifle",
+    "id": "c_mi_go_multi_scout",
     "type": "harvest",
     "entries": [
       { "drop": "meat_tainted", "type": "flesh", "mass_ratio": 0.4 },
       { "drop": "fat_tainted", "type": "flesh", "mass_ratio": 0.1 },
       { "drop": "fat_tainted", "type": "offal", "mass_ratio": 0.1 },
-      { "drop": "c_mi_go_rifle_broken", "type": "bionic", "max": 1 }
+      { "drop": "c_mi_go_advanced_dissection_scout", "type": "bionic_group", "max": 1 }
     ]
   }
 ]

--- a/nocts_cata_mod_DDA/Monsters/c_monster_override.json
+++ b/nocts_cata_mod_DDA/Monsters/c_monster_override.json
@@ -88,16 +88,22 @@
     "anger_triggers": [ "PLAYER_CLOSE", "HURT", "FRIEND_ATTACKED", "FRIEND_DIED" ]
   },
   {
+    "id": "mon_mi_go",
+    "copy-from": "mon_mi_go",
+    "type": "MONSTER",
+    "harvest": "c_mi_go_multi_worker"
+  },
+  {
     "id": "mon_mi_go_slaver",
     "copy-from": "mon_mi_go_slaver",
     "type": "MONSTER",
-    "harvest": "c_mi_go_beam"
+    "harvest": "c_mi_go_multi_slaver"
   },
   {
     "id": "mon_mi_go_surgeon",
     "copy-from": "mon_mi_go_surgeon",
     "type": "MONSTER",
-    "harvest": "c_mi_go_claw"
+    "harvest": "c_mi_go_multi_surgeon"
   },
   {
     "id": "mon_mi_go_guard",
@@ -115,6 +121,6 @@
     "id": "mon_mi_go_scout",
     "copy-from": "mon_mi_go_scout",
     "type": "MONSTER",
-    "harvest": "c_mi_go_rifle"
+    "harvest": "c_mi_go_multi_scout"
   }
 ]

--- a/nocts_cata_mod_DDA/Recipe/c_recipes.json
+++ b/nocts_cata_mod_DDA/Recipe/c_recipes.json
@@ -2664,6 +2664,43 @@
     ]
   },
   {
+    "result": "c_mi_go_extruder_salvaged",
+    "type": "recipe",
+    "activity_level": "LIGHT_EXERCISE",
+    "category": "CC_OTHER",
+    "subcategory": "CSC_OTHER_TOOLS",
+    "skill_used": "fabrication",
+    "difficulty": 5,
+    "skills_required": [ [ "firstaid", 4 ], [ "mechanics", 3 ], [ "cooking", 5 ] ],
+    "time": "25 m",
+    "book_learn": [ [ "evil_invitation", 4 ], [ "recipe_lab_elec", 5 ], [ "recipe_creepy", 5 ], [ "recipe_labchem", 6 ] ],
+    "using": [ [ "c_resin_molding_standard", 1 ], [ "welding_standard", 10 ], [ "steel_tiny", 1 ] ],
+    "qualities": [ { "id": "CUT_FINE", "level": 2 } ],
+    "components": [ [ [ "c_mi_go_extruder_broken", 1 ] ], [ [ "canister_empty", 1 ] ], [ [ "meat_tainted", 5 ], [ "slime_scrap", 1 ] ] ]
+  },
+  {
+    "result": "c_mi_go_wings_salvaged",
+    "type": "recipe",
+    "activity_level": "LIGHT_EXERCISE",
+    "category": "CC_ARMOR",
+    "subcategory": "CSC_ARMOR_OTHER",
+    "skill_used": "fabrication",
+    "difficulty": 7,
+    "skills_required": [ [ "firstaid", 4 ], [ "electronics", 3 ], [ "mechanics", 3 ], [ "cooking", 5 ] ],
+    "time": "80 m",
+    "book_learn": [ [ "evil_invitation", 6 ], [ "recipe_lab_elec", 7 ], [ "recipe_creepy", 7 ], [ "recipe_labchem", 8 ] ],
+    "using": [ [ "c_resin_molding_standard", 4 ], [ "welding_standard", 20 ], [ "steel_standard", 1 ] ],
+    "qualities": [ { "id": "CUT_FINE", "level": 2 } ],
+    "components": [
+      [ [ "c_mi_go_wings_broken", 1 ] ],
+      [ [ "power_supply", 1 ] ],
+      [ [ "medium_battery_cell", 1 ] ],
+      [ [ "cable", 40 ] ],
+      [ [ "wire", 2 ] ],
+      [ [ "meat_tainted", 15 ], [ "slime_scrap", 3 ] ]
+    ]
+  },
+  {
     "result": "bikini_bottom_leather",
     "type": "recipe",
     "activity_level": "LIGHT_EXERCISE",

--- a/nocts_cata_mod_DDA/Surv_help/c_armor.json
+++ b/nocts_cata_mod_DDA/Surv_help/c_armor.json
@@ -179,7 +179,7 @@
     "id": "cuirass_lightplate_surv",
     "copy-from": "cuirass_lightplate",
     "type": "ARMOR",
-    "name": { "str": "survivor cuirass" },
+    "name": { "str": "survivor cuirass", "str_pl": "survivor cuirasses" },
     "description": "A medieval steel breastplate, modified with kevlar and leather to better protect from the elements.",
     "weight": "4620 g",
     "price": "300 USD",
@@ -886,7 +886,7 @@
     "id": "c_mi_go_carapace_salvaged_on",
     "copy-from": "c_mi_go_carapace_salvaged",
     "type": "TOOL_ARMOR",
-    "name": { "str": "salvaged carapace armor (on)" },
+    "name": { "str": "salvaged carapace armor (on)", "str_pl": "salvaged carapace armors (on)" },
     "description": "A vaguely human-shaped shell of alien sinew and steel support, covered in armor plates made of resin.  Salvaged using pre-cataclysm research into other living weaponry, it's been practically mutilated to fit a human (or mutant) wearer.  Activating it will reduce the suit's encumbrance, enhance strength and dexterity, protect the wearer from toxic gas, serve as a rebreather, enhance stamina and carry capacity, and provide some protection from outside temperature.  It seems to recharge from sunlight, and being active will also gradually fatigue the user and affect healthiness, plus render them more vulnerable to electric shocks.",
     "turns_per_charge": 150,
     "revert_to": "c_mi_go_carapace_salvaged",
@@ -895,7 +895,7 @@
       "msg": "The suit's sinews go slack, releasing you from its grasp.",
       "type": "transform"
     },
-    "extend": { "flags": [ "WATERPROOF", "RAINPROOF", "CLIMATE_CONTROL", "GAS_PROOF", "REBREATHER" ] },
+    "extend": { "flags": [ "WATERPROOF", "RAINPROOF", "CLIMATE_CONTROL", "GAS_PROOF", "REBREATHER", "NO_TAKEOFF" ] },
     "material": [ "alien_resin", "flesh", "steel" ],
     "material_thickness": 4,
     "environmental_protection": 15,
@@ -906,6 +906,55 @@
         "covers": [ "head", "mouth", "eyes", "torso", "arm_l", "arm_r", "hand_l", "hand_r", "leg_l", "leg_r", "foot_l", "foot_r" ]
       }
     ]
+  },
+  {
+    "id": "c_mi_go_wings_salvaged",
+    "type": "TOOL_ARMOR",
+    "symbol": "[",
+    "color": "green",
+    "name": { "str": "set of salvaged exo-wings", "str_pl": "sets of salvaged exo-wings" },
+    "description": "A set of thin, green iridescent wings, steel wires and joints meshed with thick alien nervous cords.  Salvaged using pre-cataclysm research into other living weaponry, it's been heavily altered to fit a human (or mutant) wearer.  Activating it will grant immunity to falling damage and vastly speed up movement.  It seems to recharge from sunlight, and being active will also gradually fatigue the user.",
+    "flags": [ "OVERSIZE", "STURDY", "BELTED" ],
+    "price_postapoc": "40 USD",
+    "material": [ "alien_resin", "flesh", "steel" ],
+    "weight": "2 kg",
+    "volume": "5 L",
+    "to_hit": -3,
+    "ammo": [ "battery" ],
+    "pocket_data": [ { "pocket_type": "MAGAZINE", "rigid": true, "ammo_restriction": { "battery": 100 } } ],
+    "use_action": {
+      "type": "transform",
+      "msg": "The exo-wings whir to life, becoming a fluttering blur of green and gray.",
+      "target": "c_mi_go_wings_salvaged_on",
+      "active": true,
+      "need_charges": 1,
+      "need_charges_msg": "The exo-wings don't respond, evidently out of energy."
+    },
+    "relic_data": {
+      "charge_info": { "recharge_type": "solar_sunny", "time": "10 m", "regenerate_ammo": true },
+      "passive_effects": [
+        {
+          "has": "WORN",
+          "condition": "ACTIVE",
+          "values": [ { "value": "MOVE_COST", "multiply": -0.5 }, { "value": "BONUS_DODGE", "add": 5 } ],
+          "ench_effects": [ { "effect": "c_mi_go_wings_immunity", "intensity": 1 } ]
+        }
+      ]
+    },
+    "material_thickness": 2,
+    "armor": [ { "encumbrance": 10, "coverage": 40, "covers": [ "torso" ] } ]
+  },
+  {
+    "id": "c_mi_go_wings_salvaged_on",
+    "copy-from": "c_mi_go_wings_salvaged",
+    "type": "TOOL_ARMOR",
+    "name": { "str_sp": "set of salvaged exo-wings (on)", "str_pl": "sets of salvaged exo-wings (on)" },
+    "description": "A set of thin, green iridescent wings, steel wires and joints meshed with thick alien nervous cords.  They are currently buzzing with life, greatly speeding up movement and enhancing dodge as well as granting immunity to falling damage, in exchange for increased fatigue gain.",
+    "turns_per_charge": 75,
+    "revert_to": "c_mi_go_wings_salvaged",
+    "use_action": { "target": "c_mi_go_wings_salvaged", "msg": "The exo-wings go limp as they shut down.", "type": "transform" },
+    "extend": { "flags": [ "NO_TAKEOFF" ] },
+    "armor": [ { "encumbrance": 0, "coverage": 40, "covers": [ "torso" ] } ]
   },
   {
     "id": "cowboy_hat_surv",

--- a/nocts_cata_mod_DDA/Surv_help/c_effects.json
+++ b/nocts_cata_mod_DDA/Surv_help/c_effects.json
@@ -147,6 +147,15 @@
     "id": "c_nano_mutagen_trigger",
     "max_duration": "10 s",
     "name": [ "Test Effect Name" ],
-    "desc": [ "This is just to ensure nano-mutagen is working right.  If you see this on your effects screen DDA likely fucked up again." ]
+    "desc": [
+      "This is just to ensure nano-mutagen is working right.  If you see this on your effects screen DDA likely fucked up again."
+    ]
+  },
+  {
+    "type": "effect_type",
+    "id": "c_mi_go_wings_immunity",
+    "removes_effects": [ "downed", "bouldering" ],
+    "base_mods": { "fatigue_min": [ 1 ], "fatigue_tick": [ 300 ] },
+    "flags": [ "EFFECT_FEATHER_FALL" ]
   }
 ]

--- a/nocts_cata_mod_DDA/Surv_help/c_item_groups.json
+++ b/nocts_cata_mod_DDA/Surv_help/c_item_groups.json
@@ -349,6 +349,24 @@
   },
   {
     "type": "item_group",
+    "id": "c_mi_go_advanced_dissection_worker",
+    "subtype": "distribution",
+    "items": [ [ "c_mi_go_extruder_broken", 1 ], [ "c_mi_go_wings_broken", 1 ] ]
+  },
+  {
+    "type": "item_group",
+    "id": "c_mi_go_advanced_dissection_slaver",
+    "subtype": "distribution",
+    "items": [ [ "c_mi_go_beam_broken", 3 ], [ "c_mi_go_wings_broken", 1 ] ]
+  },
+  {
+    "type": "item_group",
+    "id": "c_mi_go_advanced_dissection_surgeon",
+    "subtype": "distribution",
+    "items": [ [ "c_mi_go_claw_broken", 3 ], [ "c_mi_go_wings_broken", 1 ] ]
+  },
+  {
+    "type": "item_group",
     "id": "c_mi_go_advanced_dissection_guard",
     "subtype": "distribution",
     "items": [ [ "c_mi_go_carapace_broken", 2 ], [ "c_mi_go_beam_broken", 1 ] ]
@@ -358,5 +376,11 @@
     "id": "c_mi_go_advanced_dissection_myrmidon",
     "subtype": "distribution",
     "items": [ [ "c_mi_go_carapace_broken", 3 ], [ "c_mi_go_beam_broken", 1 ], [ "c_mi_go_claw_broken", 1 ] ]
+  },
+  {
+    "type": "item_group",
+    "id": "c_mi_go_advanced_dissection_scout",
+    "subtype": "distribution",
+    "items": [ [ "c_mi_go_rifle_broken", 3 ], [ "c_mi_go_wings_broken", 1 ] ]
   }
 ]

--- a/nocts_cata_mod_DDA/Surv_help/c_spells.json
+++ b/nocts_cata_mod_DDA/Surv_help/c_spells.json
@@ -221,5 +221,19 @@
     "max_aoe": 1,
     "shape": "blast",
     "extra_effects": [ { "id": "death_pouf", "hit_self": true }, { "id": "death_acid", "hit_self": true } ]
+  },
+  {
+    "id": "c_resin_create",
+    "type": "SPELL",
+    "name": { "str": "Extrude Resin" },
+    "description": "Creates a random number of alien resin chunks.",
+    "valid_targets": [ "self" ],
+    "message": "",
+    "flags": [ "SILENT", "PERMANENT", "NO_HANDS", "NO_LEGS", "RANDOM_DAMAGE" ],
+    "effect": "spawn_item",
+    "shape": "blast",
+    "effect_str": "resin_chunk",
+    "min_duration": 1,
+    "max_duration": 2
   }
 ]

--- a/nocts_cata_mod_DDA/Surv_help/c_tools.json
+++ b/nocts_cata_mod_DDA/Surv_help/c_tools.json
@@ -1104,5 +1104,82 @@
     "weight": "35 kg",
     "volume": "40 L",
     "flags": [ "TRADER_AVOID", "NO_REPAIR" ]
+  },
+  {
+    "type": "GENERIC",
+    "id": "c_mi_go_extruder_broken",
+    "symbol": ";",
+    "color": "green",
+    "name": { "str": "alien spinneret" },
+    "description": "A fist-sized clump of gore and torn muscle fibers, from which jut three thin spines of what seems to be synthetic bone, or possibly keratin.  In between the spines are countless thin strands of what looks like brilliant green fiberglass, most likely alien resin.  This seems to be used for either producing or shaping this strange substance, potentially useful but right now it's of little use to anyone like this, human or alien.",
+    "category": "other",
+    "material": [ "alien_resin", "flesh" ],
+    "weight": "750 g",
+    "volume": "500 ml",
+    "flags": [ "TRADER_AVOID", "NO_REPAIR" ]
+  },
+  {
+    "type": "GENERIC",
+    "id": "c_mi_go_wings_broken",
+    "symbol": ";",
+    "color": "green",
+    "name": { "str": "set of iridescent wings", "str_pl": "sets of iridescent wings" },
+    "description": "Several pairs of glossy insect-like wings, thin green iridescent flesh flushed with congealed fluid in what seem to be veins, weaving a spider-web pattern of pale grey all throughout.  They blend together into a mangled cluster of chitinous plates covering off-white nervous cords, provoking rather strong convulsions when pulled the wrong way.  Whether they fly through the void of space on these or use them for something else, it's evident these wings were manufactured as much as evolved.",
+    "category": "other",
+    "material": [ "alien_resin", "flesh" ],
+    "weight": "4 kg",
+    "volume": "10 L",
+    "flags": [ "TRADER_AVOID", "NO_REPAIR" ]
+  },
+  {
+    "id": "c_mi_go_extruder_salvaged",
+    "type": "TOOL",
+    "symbol": "/",
+    "color": "green",
+    "name": { "str": "salvaged resin extruder" },
+    "description": "A strange device made of alien flesh blended with technology.  Three thin spines of synthetic ivory surround some sort of nozzle, its contents steadily regenerating.  It can be activated to produce shards of resin, for whatever use you may have for such a thing.  Activate it will set it to apply resin more slowly, letting it be used for repairing salvaged mi-go biotechnlogy.",
+    "price_postapoc": "25 USD",
+    "material": [ "alien_resin", "flesh", "steel" ],
+    "weight": "300 g",
+    "volume": "250 ml",
+    "ammo": [ "battery" ],
+    "relic_data": { "charge_info": { "recharge_type": "periodic", "time": "1 h", "regenerate_ammo": true } },
+    "pocket_data": [ { "pocket_type": "MAGAZINE", "ammo_restriction": { "battery": 100 } } ],
+    "charges_per_use": 25,
+    "use_action": [
+      { "type": "cast_spell", "spell_id": "c_resin_create", "no_fail": true, "level": 0 },
+      {
+        "type": "transform",
+        "msg": "You switch the %s to weaving mode",
+        "target": "c_mi_go_extruder_salvaged_alt",
+        "menu_text": "switch mode"
+      }
+    ]
+  },
+  {
+    "id": "c_mi_go_extruder_salvaged_alt",
+    "copy-from": "c_mi_go_extruder_salvaged",
+    "type": "TOOL",
+    "color": "green",
+    "name": { "str": "salvaged resin extruder (alternate mode)", "str_pl": "salvaged resin extruders (alternate mode)" },
+    "description": "A strange device made of alien flesh blended with technology.  Three thin spines of synthetic ivory surround some sort of nozzle, its contents steadily regenerating.  It's currently set to apply resin more slowly, letting it be used for repairing salvaged mi-go biotechnlogy.  Activate it to switch back to its normal mode, for creating larger shards of resin for other purposes.",
+    "charges_per_use": 1,
+    "use_action": [
+      {
+        "type": "repair_item",
+        "item_action_type": "repair_metal",
+        "materials": [ "alien_resin" ],
+        "skill": "fabrication",
+        "tool_quality": 10,
+        "cost_scaling": 0.1,
+        "move_cost": 500
+      },
+      {
+        "type": "transform",
+        "msg": "You switch the %s to its normal mode",
+        "target": "c_mi_go_extruder_salvaged",
+        "menu_text": "switch mode"
+      }
+    ]
   }
 ]


### PR DESCRIPTION
* Added two new potential bits of mi-go biotech to salvage. One's implied to be a biomechanical spinneret for working with resin, the other would be what's left of the wings torn from a mi-go.
* Salvaging the spinneret yields an item that steadily regains charges over time, like the RTG inductive charger. It has two modes that can be swapped via transforming it, one to create a handful of resin chunks for crafting uses, the other mode serves as a repair item for items made of resin.
* Salvaging the wings yields an armor item that regenerates over time like the carapace armor does. When activated it lowers its encumbrance and grants a bonus to move cost and dodge, along with an effect that negates falling damage and a couple other related status effects. Active state also steadily drains fatigue like the carapace armor, but no other side effects.
* Implemented harvest override for regular mi-gos, making them a source of either the spinneret or the wings.
* Updated the harvest overrides for mi-go slavers, surgeons, and scouts, adding a smaller chance of yielding the wings. Idea was the guard and myrmidon are likely to have had their wings removed to integrate their carapace armor.
* Misc: Fixed plural name for carapace armor, fixed lack of NO_TAKEOFF for active version.
* Misc: Also fixed plural of survivor cuirass.