### PR TITLE
Add attack vectors to DDA version

### DIFF
--- a/nocts_cata_mod_DDA/Surv_help/c_techniques.json
+++ b/nocts_cata_mod_DDA/Surv_help/c_techniques.json
@@ -26,7 +26,8 @@
       { "stat": "damage", "type": "cut", "scale": 0.5 },
       { "stat": "damage", "type": "stab", "scale": 0.5 }
     ],
-    "down_dur": 1
+    "down_dur": 1,
+    "attack_vectors": [ "WEAPON", "HAND" ]
   },
   {
     "type": "technique",
@@ -45,7 +46,8 @@
       { "stat": "damage", "type": "stab", "scale": 0.5 }
     ],
     "knockback_dist": 1,
-    "stun_dur": 1
+    "stun_dur": 1,
+    "attack_vectors": [ "WEAPON", "HAND" ]
   },
   {
     "type": "technique",
@@ -66,7 +68,8 @@
     "skill_requirements": [ { "name": "melee", "level": 9 } ],
     "unarmed_allowed": true,
     "melee_allowed": true,
-    "disarms": true
+    "disarms": true,
+    "attack_vectors": [ "WEAPON", "HAND" ]
   },
   {
     "type": "technique",
@@ -80,7 +83,8 @@
     "crit_tec": true,
     "stun_dur": 2,
     "knockback_dist": 4,
-    "powerful_knockback": true
+    "powerful_knockback": true,
+    "attack_vectors": [ "WEAPON", "HAND" ]
   },
   {
     "type": "technique",
@@ -92,7 +96,8 @@
     "melee_allowed": true,
     "crit_tec": true,
     "down_dur": 2,
-    "mult_bonuses": [ { "stat": "movecost", "scale": 0.9 } ]
+    "mult_bonuses": [ { "stat": "movecost", "scale": 0.9 } ],
+    "attack_vectors": [ "WEAPON", "HAND" ]
   },
   {
     "type": "technique",
@@ -105,7 +110,8 @@
     "downed_target": true,
     "stun_dur": 1,
     "flat_bonuses": [ { "stat": "arpen", "type": "bash", "scaling-stat": "str", "scale": 0.9 } ],
-    "mult_bonuses": [ { "stat": "damage", "type": "bash", "scale": 1.3 } ]
+    "mult_bonuses": [ { "stat": "damage", "type": "bash", "scale": 1.3 } ],
+    "attack_vectors": [ "HAND" ]
   },
   {
     "type": "technique",


### PR DESCRIPTION
Evidently needed for attacks to work in the DDA version.

Grab breaks and feints seem to not need it at least.