### PR TITLE
Consistency updates for Omnitech fire rates

### DIFF
--- a/nocts_cata_mod_BN/Weapons/c_ranged.json
+++ b/nocts_cata_mod_BN/Weapons/c_ranged.json
@@ -1181,7 +1181,7 @@
     "recoil": 10,
     "loudness": 8,
     "durability": 10,
-    "modes": [ [ "DEFAULT", "semi", 1 ], [ "BURST", "spray", 10 ], [ "AUTO", "auto", 15 ] ],
+    "modes": [ [ "DEFAULT", "semi", 1 ], [ "BURST", "burst", 5 ], [ "AUTO", "auto", 10 ] ],
     "reload": 200,
     "built_in_mods": [ "rail_laser_sight", "pistol_grip", "grip" ],
     "valid_mod_locations": [
@@ -1226,7 +1226,7 @@
     "recoil": 10,
     "loudness": 8,
     "durability": 10,
-    "modes": [ [ "DEFAULT", "semi", 1 ], [ "BURST", "spray", 10 ], [ "AUTO", "auto", 15 ] ],
+    "modes": [ [ "DEFAULT", "semi", 1 ], [ "BURST", "spray", 5 ], [ "AUTO", "auto", 10 ] ],
     "ups_charges": 20,
     "built_in_mods": [ "rail_laser_sight", "pistol_grip", "grip" ],
     "valid_mod_locations": [
@@ -1265,7 +1265,7 @@
     "recoil": 10,
     "loudness": 14,
     "durability": 10,
-    "modes": [ [ "DEFAULT", "semi", 1 ], [ "BURST", "burst", 3 ], [ "AUTO", "auto", 10 ] ],
+    "modes": [ [ "DEFAULT", "semi", 1 ], [ "BURST", "burst", 3 ], [ "AUTO", "auto", 5 ] ],
     "reload": 200,
     "built_in_mods": [ "pistol_grip", "grip" ],
     "valid_mod_locations": [
@@ -1305,7 +1305,7 @@
     "recoil": 10,
     "loudness": 14,
     "durability": 10,
-    "modes": [ [ "DEFAULT", "semi", 1 ], [ "BURST", "burst", 3 ], [ "AUTO", "auto", 10 ] ],
+    "modes": [ [ "DEFAULT", "semi", 1 ], [ "BURST", "burst", 3 ], [ "AUTO", "auto", 5 ] ],
     "ups_charges": 50,
     "built_in_mods": [ "pistol_grip", "grip" ],
     "valid_mod_locations": [
@@ -1346,7 +1346,7 @@
     "recoil": 5,
     "loudness": 14,
     "durability": 8,
-    "modes": [ [ "DEFAULT", "low auto", 10 ], [ "BURST", "medium auto", 15 ], [ "AUTO", "high auto", 25 ] ],
+    "modes": [ [ "DEFAULT", "semi", 1 ], [ "BURST", "low auto", 10 ], [ "AUTO", "high auto", 20 ] ],
     "reload": 500,
     "valid_mod_locations": [
       [ "accessories", 2 ],
@@ -1384,7 +1384,7 @@
     "recoil": 5,
     "loudness": 14,
     "durability": 8,
-    "modes": [ [ "DEFAULT", "low auto", 10 ], [ "BURST", "medium auto", 15 ], [ "AUTO", "high auto", 25 ] ],
+    "modes": [ [ "DEFAULT", "semi", 1 ], [ "BURST", "low auto", 10 ], [ "AUTO", "high auto", 20 ] ],
     "ups_charges": 50,
     "valid_mod_locations": [
       [ "accessories", 2 ],

--- a/nocts_cata_mod_DDA/Weapons/c_ranged.json
+++ b/nocts_cata_mod_DDA/Weapons/c_ranged.json
@@ -1364,7 +1364,7 @@
     "recoil": 10,
     "loudness": 8,
     "durability": 10,
-    "modes": [ [ "DEFAULT", "semi", 1 ], [ "BURST", "spray", 10 ], [ "AUTO", "auto", 15 ] ],
+    "modes": [ [ "DEFAULT", "semi", 1 ], [ "BURST", "burst", 5 ], [ "AUTO", "auto", 10 ] ],
     "reload": 200,
     "built_in_mods": [ "rail_laser_sight", "pistol_grip", "grip" ],
     "valid_mod_locations": [
@@ -1412,7 +1412,7 @@
     "recoil": 10,
     "loudness": 8,
     "durability": 10,
-    "modes": [ [ "DEFAULT", "semi", 1 ], [ "BURST", "spray", 10 ], [ "AUTO", "auto", 15 ] ],
+    "modes": [ [ "DEFAULT", "semi", 1 ], [ "BURST", "burst", 5 ], [ "AUTO", "auto", 10 ] ],
     "ups_charges": 20,
     "built_in_mods": [ "rail_laser_sight", "pistol_grip", "grip" ],
     "valid_mod_locations": [
@@ -1452,7 +1452,7 @@
     "recoil": 10,
     "loudness": 14,
     "durability": 10,
-    "modes": [ [ "DEFAULT", "semi", 1 ], [ "BURST", "burst", 3 ], [ "AUTO", "auto", 10 ] ],
+    "modes": [ [ "DEFAULT", "semi", 1 ], [ "BURST", "burst", 3 ], [ "AUTO", "auto", 5 ] ],
     "reload": 200,
     "built_in_mods": [ "pistol_grip", "grip" ],
     "valid_mod_locations": [
@@ -1500,7 +1500,7 @@
     "recoil": 10,
     "loudness": 14,
     "durability": 10,
-    "modes": [ [ "DEFAULT", "semi", 1 ], [ "BURST", "burst", 3 ], [ "AUTO", "auto", 10 ] ],
+    "modes": [ [ "DEFAULT", "semi", 1 ], [ "BURST", "burst", 3 ], [ "AUTO", "auto", 5 ] ],
     "ups_charges": 50,
     "built_in_mods": [ "pistol_grip", "grip" ],
     "valid_mod_locations": [
@@ -1542,7 +1542,7 @@
     "recoil": 5,
     "loudness": 14,
     "durability": 8,
-    "modes": [ [ "DEFAULT", "low auto", 10 ], [ "BURST", "medium auto", 15 ], [ "AUTO", "high auto", 25 ] ],
+    "modes": [ [ "DEFAULT", "semi", 1 ], [ "BURST", "low auto", 10 ], [ "AUTO", "high auto", 20 ] ],
     "reload": 500,
     "valid_mod_locations": [
       [ "accessories", 2 ],
@@ -1588,7 +1588,7 @@
     "recoil": 5,
     "loudness": 14,
     "durability": 8,
-    "modes": [ [ "DEFAULT", "low auto", 10 ], [ "BURST", "medium auto", 15 ], [ "AUTO", "high auto", 25 ] ],
+    "modes": [ [ "DEFAULT", "semi", 1 ], [ "BURST", "low auto", 10 ], [ "AUTO", "high auto", 20 ] ],
     "ups_charges": 50,
     "valid_mod_locations": [
       [ "accessories", 2 ],


### PR DESCRIPTION
Sets it so the fire modes of the ARC, AKRO, and KRX are a bit more consistent and less overkill. ARC gets shortest burst sizes, then AKRO, then KRX, also ensured the LMG has a semi-auto mode. Other side benefit of this is fire modes are now all sane fractions of expected battery capacity sizes.

Only real exception is the laser SMG can still accept ultra-light plutonium cells which gives only 25 shots worth of power, but it'd need burst side nerfed down even further for that to work sanely, when this degree of nerf still at least makes its max burst size a sane fraction of the light plutonium battery's capacity.