### PR TITLE
Martial Arts Updates

### DIFF
--- a/nocts_cata_mod_BN/Surv_help/c_martialarts.json
+++ b/nocts_cata_mod_BN/Surv_help/c_martialarts.json
@@ -16,7 +16,7 @@
       {
         "id": "buff_surv_com_onmove",
         "name": "Elusiveness",
-        "description": "Quick and fluid movements make you harder to catch.\n\n+1 Dodge attempts, Dodge skill increased by 25% of Intelligence, immunity to knockdown.\nLasts 3 turns, stacks 2 turns.",
+        "description": "Quick and fluid movements make you harder to catch.\n\n+1 Dodge attempts, Dodge skill increased by 25% of Intelligence, immunity to knockdown.\nLasts 3 turns, stacks 2 times.",
         "skill_requirements": [ { "name": "melee", "level": 4 } ],
         "unarmed_allowed": true,
         "melee_allowed": true,
@@ -45,7 +45,7 @@
       {
         "id": "buff_surv_com_onkill",
         "name": "Misdirection",
-        "description": "The shock and awe of combat gives you an opportunity to slip away.\n\n+2 Block attempts, +2 Dodge attempts, movement speed increased by 100% of Intelligence, moving generates 1/2 as much noise.\nLast 6 turns.",
+        "description": "The shock and awe of combat gives you an opportunity to slip away.\n\n+2 Block attempts, +2 Dodge attempts, Dodge skill increased by 50% of Intelligence, movement speed increased by 200% of Intelligence, moving generates 1/2 as much noise.\nLast 6 turns.",
         "skill_requirements": [ { "name": "melee", "level": 6 } ],
         "unarmed_allowed": true,
         "melee_allowed": true,
@@ -53,7 +53,7 @@
         "buff_duration": 6,
         "bonus_dodges": 2,
         "bonus_blocks": 2,
-        "flat_bonuses": [ { "stat": "speed", "scaling-stat": "int", "scale": 1.0 } ]
+        "flat_bonuses": [ { "stat": "dodge", "scaling-stat": "int", "scale": 0.5 }, { "stat": "speed", "scaling-stat": "int", "scale": 2.0 } ]
       }
     ],
     "techniques": [
@@ -76,31 +76,32 @@
       {
         "id": "buff_mut_com_static",
         "name": "Large And In Charge",
-        "description": "Your stance makes better use of your might to compensate for poor footwork.\nAccuracy increased by 15% of strength, -10 move cost.",
+        "description": "Your stance makes better use of your might to compensate for poor footwork.\nAccuracy increased by 15% of strength, -10% move cost.",
         "skill_requirements": [ { "name": "melee", "level": 6 } ],
         "unarmed_allowed": true,
         "melee_allowed": true,
-        "flat_bonuses": [ { "stat": "hit", "scaling-stat": "str", "scale": 0.15 }, { "stat": "movecost", "scale": -10.0 } ]
+        "flat_bonuses": [ { "stat": "hit", "scaling-stat": "str", "scale": 0.15 } ],
+        "mult_bonuses": [ { "stat": "movecost", "scale": 0.9 } ]
       }
     ],
     "onpause_buffs": [
       {
         "id": "buff_mut_com_onpause",
         "name": "Stored Potential",
-        "description": "Conserving your energy and focusing your mind will permit explosive bursts of action.\n\n-10 move cost.\nLasts 2 turns, stacks 3 times.",
+        "description": "Conserving your energy and focusing your mind will permit explosive bursts of action.\n\n-10% move cost.\nLasts 3 turns, stacks 3 times.",
         "skill_requirements": [ { "name": "melee", "level": 5 } ],
         "unarmed_allowed": true,
         "melee_allowed": true,
         "buff_duration": 3,
         "max_stacks": 3,
-        "flat_bonuses": [ { "stat": "movecost", "scale": -10.0 } ]
+        "mult_bonuses": [ { "stat": "movecost", "scale": 0.9 } ]
       }
     ],
     "onmove_buffs": [
       {
         "id": "buff_mut_com_onmove",
         "name": "Bull Rush",
-        "description": "When you get enough momentum going, they're going to feel it.\n\nMovement speed increased by 45% of strength, bash damage increased by 15% of strength.  Enables \"Battering Ram\" technique.\nLasts 2 turns, stacks 3 times.",
+        "description": "When you get enough momentum going, they're going to feel it.\n\nMovement speed increased by 45% of strength, bash damage increased by 15% of strength.  Enables \"Battering Ram\" technique.\nLasts 3 turns, stacks 3 times.",
         "skill_requirements": [ { "name": "melee", "level": 4 } ],
         "unarmed_allowed": true,
         "melee_allowed": true,

--- a/nocts_cata_mod_DDA/Surv_help/c_martialarts.json
+++ b/nocts_cata_mod_DDA/Surv_help/c_martialarts.json
@@ -22,7 +22,7 @@
         "melee_allowed": true,
         "throw_immune": true,
         "buff_duration": 3,
-        "max_stacks": 2,
+        "max_stacks": 3,
         "bonus_dodges": 1,
         "flat_bonuses": [ { "stat": "dodge", "scaling-stat": "int", "scale": 0.25 } ]
       }
@@ -36,7 +36,7 @@
         "unarmed_allowed": true,
         "melee_allowed": true,
         "buff_duration": 2,
-        "max_stacks": 2,
+        "max_stacks": 3,
         "bonus_blocks": 1,
         "flat_bonuses": [ { "stat": "block", "scaling-stat": "int", "scale": 1.0 } ]
       }
@@ -45,15 +45,15 @@
       {
         "id": "buff_surv_com_onkill",
         "name": "Misdirection",
-        "description": "The shock and awe of combat gives you an opportunity to slip away.\n\n+2 Block attempts, +2 Dodge attempts, movement speed increased by 100% of Intelligence, moving generates 1/2 as much noise.\nLast 6 turns.",
+        "description": "The shock and awe of combat gives you an opportunity to slip away.\n\n+2 Block attempts, +2 Dodge attempts, Dodge skill increased by 50% of Intelligence, movement speed increased by 200% of Intelligence, moving generates 1/2 as much noise.\nLast 6 turns.",
         "skill_requirements": [ { "name": "melee", "level": 6 } ],
         "unarmed_allowed": true,
         "melee_allowed": true,
         "stealthy": true,
         "buff_duration": 6,
-        "bonus_dodges": 2,
+        "bonus_dodges": 3,
         "bonus_blocks": 2,
-        "flat_bonuses": [ { "stat": "speed", "scaling-stat": "int", "scale": 1.0 } ]
+        "flat_bonuses": [ { "stat": "dodge", "scaling-stat": "int", "scale": 0.5 }, { "stat": "speed", "scaling-stat": "int", "scale": 2.0 } ]
       }
     ],
     "techniques": [
@@ -76,31 +76,32 @@
       {
         "id": "buff_mut_com_static",
         "name": "Large And In Charge",
-        "description": "Your stance makes better use of your might to compensate for poor footwork.\nAccuracy increased by 15% of strength, -10 move cost.",
+        "description": "Your stance makes better use of your might to compensate for poor footwork.\nAccuracy increased by 15% of strength, -10% move cost.",
         "skill_requirements": [ { "name": "melee", "level": 6 } ],
         "unarmed_allowed": true,
         "melee_allowed": true,
-        "flat_bonuses": [ { "stat": "hit", "scaling-stat": "str", "scale": 0.15 }, { "stat": "movecost", "scale": -10.0 } ]
+        "flat_bonuses": [ { "stat": "hit", "scaling-stat": "str", "scale": 0.15 } ],
+        "mult_bonuses": [ { "stat": "movecost", "scale": 0.9 } ]
       }
     ],
     "onpause_buffs": [
       {
         "id": "buff_mut_com_onpause",
         "name": "Stored Potential",
-        "description": "Conserving your energy and focusing your mind will permit explosive bursts of action.\n\n-10 move cost.\nLasts 2 turns, stacks 3 times.",
+        "description": "Conserving your energy and focusing your mind will permit explosive bursts of action.\n\n-10% move cost.\nLasts 3 turns, stacks 3 times.",
         "skill_requirements": [ { "name": "melee", "level": 5 } ],
         "unarmed_allowed": true,
         "melee_allowed": true,
         "buff_duration": 3,
         "max_stacks": 3,
-        "flat_bonuses": [ { "stat": "movecost", "scale": -10.0 } ]
+        "mult_bonuses": [ { "stat": "movecost", "scale": 0.9 } ]
       }
     ],
     "onmove_buffs": [
       {
         "id": "buff_mut_com_onmove",
         "name": "Bull Rush",
-        "description": "When you get enough momentum going, they're going to feel it.\n\nMovement speed increased by 45% of strength, bash damage increased by 15% of strength.  Enables \"Battering Ram\" technique.\nLasts 2 turns, stacks 3 times.",
+        "description": "When you get enough momentum going, they're going to feel it.\n\nMovement speed increased by 45% of strength, bash damage increased by 15% of strength.  Enables \"Battering Ram\" technique.\nLasts 3 turns, stacks 3 times.",
         "skill_requirements": [ { "name": "melee", "level": 4 } ],
         "unarmed_allowed": true,
         "melee_allowed": true,


### PR DESCRIPTION
* Changed the movecost bonuses for Post-Human Combatives from fixed -10 bonuses to 90% multipliers. This makes it more useful with the super-slow weapons while making it less OP when using it unarmed or with other fast weapons.
* Fixed descriptions of two Post-Human Combatives buffs claiming them to be a turn shorter than they actually were.
* Survivor Combatives' main stacking buffs allowed to stack 3 times instead of just 2, to be more consistent with Post-Human Combatives.
* Survivor Combatives' onkill buff set to give more of a speed boost to match the much more potent onmove speed buff Post-Human Combatives gets, and a secondary dodge buff added to it.