### PR TITLE
Hydrogen-related updates

### DIFF
--- a/nocts_cata_mod_BN/Monsters/c_monster_drops.json
+++ b/nocts_cata_mod_BN/Monsters/c_monster_drops.json
@@ -87,11 +87,11 @@
     "type": "item_group",
     "//": "Items a Bio-Weapon might hoard for power generation, based on the needs of the successful versions of the Project (except Delta, who lacks any overt fuel source).",
     "items": [
-      { "item": "chem_ethanol", "charges": [ 0, 2000 ], "container-item": "metal_tank_little", "prob": 10 },
-      { "item": "denat_alcohol", "charges": [ 0, 2000 ], "container-item": "metal_tank_little", "prob": 10 },
-      { "item": "chem_methanol", "charges": [ 0, 2000 ], "container-item": "metal_tank_little", "prob": 10 },
-      { "item": "gasoline", "charges": [ 0, 2000 ], "container-item": "metal_tank_little", "prob": 15 },
-      { "item": "hydrogen_tank", "charges": [ 0, 24 ], "prob": 10 },
+      { "item": "chem_ethanol", "charges": [ 1, 2000 ], "container-item": "metal_tank_little", "prob": 10 },
+      { "item": "denat_alcohol", "charges": [ 1, 2000 ], "container-item": "metal_tank_little", "prob": 10 },
+      { "item": "chem_methanol", "charges": [ 1, 2000 ], "container-item": "metal_tank_little", "prob": 10 },
+      { "item": "gasoline", "charges": [ 1, 2000 ], "container-item": "metal_tank_little", "prob": 15 },
+      { "item": "hydrogen_tank", "charges": [ 1, 24 ], "prob": 10 },
       { "item": "plasma", "charges": [ 1, 4 ], "prob": 5 },
       { "group": "ammo_any_batteries", "prob": 25 },
       { "group": "ammo_atomic_batteries", "prob": 15 }

--- a/nocts_cata_mod_BN/Surv_help/c_bionics.json
+++ b/nocts_cata_mod_BN/Surv_help/c_bionics.json
@@ -120,15 +120,29 @@
     "type": "bionic",
     "name": { "str": "Plasma Pulse Cell" },
     "//": "Spikes of power at low efficiency because the available fuels have much smaller stack sizes than most fuels.  Since hydrogen is energy-dense, power per unit is massive.",
-    "description": "Implanted in your chest is a small, advanced form of hydrogen fuel cell.  Designed to produce a spike of power production for cutting-edge military cybernetics, it is significantly less efficient than a traditional hydrogen fuel cell, but each pulse still puts out a lot of power.  Each pulse vents a jet of intense heat, making it dangerous in confined spaces.  It can store either hydrogen gas, or it can use denser military-grade hydrogen canisters.",
+    "description": "Implanted in your chest is a small, advanced form of hydrogen fuel cell.  Designed to produce a spike of power production for cutting-edge military cybernetics, it is significantly less efficient than a traditional hydrogen fuel cell, but each pulse still puts out a lot of power.  Each pulse vents a jet of intense heat, making it dangerous in confined spaces.  It has two chambers, this one is configured for military-grade hydrogen canisters.",
     "occupied_bodyparts": [ [ "torso", 15 ] ],
     "encumbrance": [ [ "torso", 5 ] ],
-    "fuel_options": [ "c_hydrogen_gas", "plasma" ],
+    "fuel_options": [ "plasma" ],
+    "fuel_capacity": 5,
+    "fuel_efficiency": 0.25,
+    "exothermic_power_gen": true,
+    "time": 1,
+    "flags": [ "BIONIC_TOGGLED", "BIONIC_POWER_SOURCE", "BIONIC_NPC_USABLE" ],
+    "included_bionics": [ "bio_plasma_cell_hydrogen" ]
+  },
+  {
+    "id": "bio_plasma_cell_hydrogen",
+    "type": "bionic",
+    "name": { "str": "Hydrogen Pulse Cell" },
+    "description": "A small, advanced form of hydrogen fuel cell, designed to produce a spike of power production for cutting-edge military cybernetics.  This is the separate chamber for burning lower-pressure hydrogen, for less intense bursts of bionic energy.",
+    "fuel_options": [ "c_hydrogen_gas" ],
     "fuel_capacity": 8,
     "fuel_efficiency": 0.25,
     "exothermic_power_gen": true,
     "time": 1,
-    "flags": [ "BIONIC_TOGGLED", "BIONIC_POWER_SOURCE", "BIONIC_NPC_USABLE" ]
+    "flags": [ "BIONIC_TOGGLED", "BIONIC_POWER_SOURCE", "BIONIC_NPC_USABLE" ],
+    "included": true
   },
   {
     "id": "bio_plasma_cell",
@@ -136,7 +150,7 @@
     "type": "BIONIC_ITEM",
     "name": { "str": "Plasma Pulse Cell CBM" },
     "looks_like": "bio_fuel_cell_gasoline",
-    "description": "This implant provides an experimental military hydrogen cell, able to produce large spikes of power for intense usage.  Its network of pressurized storage can hold 500 ml of hydrogen gas, or denser hydrogen canisters used in plasma weaponry.  The label advises not to use it in confined spaces, and to keep moving if used during a military operation, due to hazardous levels of waste heat.",
+    "description": "This implant provides an experimental military hydrogen cell, able to produce large spikes of power for intense usage.  Its network of pressurized storage has two chambers, one can hold 500 ml of hydrogen gas, the other 5 rounds of denser hydrogen canisters used in plasma weaponry.  The label advises not to use it in confined spaces, and to keep moving if used during a military operation, due to hazardous levels of waste heat.",
     "price": "4500 USD",
     "weight": "600 g",
     "difficulty": 7

--- a/nocts_cata_mod_BN/Weapons/c_ammo.json
+++ b/nocts_cata_mod_BN/Weapons/c_ammo.json
@@ -25,6 +25,8 @@
     "price_postapoc": "5 cent",
     "symbol": "=",
     "color": "white",
+    "damage": { "damage_type": "heat", "amount": 9, "armor_penetration": 2 },
+    "range": 3,
     "stack_size": 24,
     "phase": "liquid",
     "ammo_type": "c_hydrogen",
@@ -33,6 +35,7 @@
       "energy": 1000,
       "explosion_data": { "chance_hot": 2, "chance_cold": 2, "factor": 0.5, "fiery": true, "size_factor": 0.1 }
     },
+    "effects": [ "INCENDIARY" ],
     "flags": [ "NO_DROP", "IRREMOVABLE" ]
   },
   {

--- a/nocts_cata_mod_DDA/Monsters/c_monster_drops.json
+++ b/nocts_cata_mod_DDA/Monsters/c_monster_drops.json
@@ -87,11 +87,11 @@
     "type": "item_group",
     "//": "Items a Bio-Weapon might hoard for power generation, based on the needs of the successful versions of the Project (except Delta, who lacks any overt fuel source).",
     "items": [
-      { "item": "chem_ethanol", "charges": [ 0, 2000 ], "container-item": "metal_tank_little", "prob": 10 },
-      { "item": "denat_alcohol", "charges": [ 0, 2000 ], "container-item": "metal_tank_little", "prob": 10 },
-      { "item": "chem_methanol", "charges": [ 0, 2000 ], "container-item": "metal_tank_little", "prob": 10 },
-      { "item": "gasoline", "charges": [ 0, 2000 ], "container-item": "metal_tank_little", "prob": 15 },
-      { "item": "hydrogen_tank", "charges": [ 0, 24 ], "prob": 10 },
+      { "item": "chem_ethanol", "charges": [ 1, 2000 ], "container-item": "metal_tank_little", "prob": 10 },
+      { "item": "denat_alcohol", "charges": [ 1, 2000 ], "container-item": "metal_tank_little", "prob": 10 },
+      { "item": "chem_methanol", "charges": [ 1, 2000 ], "container-item": "metal_tank_little", "prob": 10 },
+      { "item": "gasoline", "charges": [ 1, 2000 ], "container-item": "metal_tank_little", "prob": 15 },
+      { "item": "hydrogen_tank", "charges": [ 1, 24 ], "prob": 10 },
       { "item": "plasma", "charges": [ 1, 4 ], "prob": 5 },
       { "group": "ammo_any_batteries", "prob": 25 },
       { "group": "ammo_atomic_batteries", "prob": 15 }

--- a/nocts_cata_mod_DDA/Surv_help/c_bionics.json
+++ b/nocts_cata_mod_DDA/Surv_help/c_bionics.json
@@ -120,15 +120,29 @@
     "type": "bionic",
     "name": { "str": "Plasma Pulse Cell" },
     "//": "Spikes of power at low efficiency because the available fuels have much smaller stack sizes than most fuels.  Since hydrogen is energy-dense, power per unit is massive.",
-    "description": "Implanted in your chest is a small, advanced form of hydrogen fuel cell.  Designed to produce a spike of power production for cutting-edge military cybernetics, it is significantly less efficient than a traditional hydrogen fuel cell, but each pulse still puts out a lot of power.  Each pulse vents a jet of intense heat, making it dangerous in confined spaces.  It can store either hydrogen gas, or it can use denser military-grade hydrogen canisters.",
+    "description": "Implanted in your chest is a small, advanced form of hydrogen fuel cell.  Designed to produce a spike of power production for cutting-edge military cybernetics, it is significantly less efficient than a traditional hydrogen fuel cell, but each pulse still puts out a lot of power.  Each pulse vents a jet of intense heat, making it dangerous in confined spaces.  It has two chambers, this one is configured for military-grade hydrogen canisters.",
     "occupied_bodyparts": [ [ "torso", 15 ] ],
     "encumbrance": [ [ "torso", 5 ] ],
-    "fuel_options": [ "c_hydrogen_gas", "hydrogen_cell" ],
+    "fuel_options": [ "hydrogen_cell" ],
+    "fuel_capacity": 5,
+    "fuel_efficiency": 0.25,
+    "exothermic_power_gen": true,
+    "time": 1,
+    "flags": [ "BIONIC_TOGGLED", "BIONIC_POWER_SOURCE", "BIONIC_NPC_USABLE" ],
+    "included_bionics": [ "bio_plasma_cell_hydrogen" ]
+  },
+  {
+    "id": "bio_plasma_cell_hydrogen",
+    "type": "bionic",
+    "name": { "str": "Hydrogen Pulse Cell" },
+    "description": "A small, advanced form of hydrogen fuel cell, designed to produce a spike of power production for cutting-edge military cybernetics.  This is the separate chamber for burning lower-pressure hydrogen, for less intense bursts of bionic energy.",
+    "fuel_options": [ "c_hydrogen_gas" ],
     "fuel_capacity": 8,
     "fuel_efficiency": 0.25,
     "exothermic_power_gen": true,
     "time": 1,
-    "flags": [ "BIONIC_TOGGLED", "BIONIC_POWER_SOURCE", "BIONIC_NPC_USABLE" ]
+    "flags": [ "BIONIC_TOGGLED", "BIONIC_POWER_SOURCE", "BIONIC_NPC_USABLE" ],
+    "included": true
   },
   {
     "id": "bio_plasma_cell",
@@ -136,7 +150,7 @@
     "type": "BIONIC_ITEM",
     "name": { "str": "Plasma Pulse Cell CBM" },
     "looks_like": "bio_fuel_cell_gasoline",
-    "description": "This implant provides an experimental military hydrogen cell, able to produce large spikes of power for intense usage.  Its network of pressurized storage can hold 500 ml of hydrogen gas, or denser hydrogen canisters used in plasma weaponry.  The label advises not to use it in confined spaces, and to keep moving if used during a military operation, due to hazardous levels of waste heat.",
+    "description": "This implant provides an experimental military hydrogen cell, able to produce large spikes of power for intense usage.  Its network of pressurized storage has two chambers, one can hold 500 ml of hydrogen gas, the other 5 rounds of denser hydrogen canisters used in plasma weaponry.  The label advises not to use it in confined spaces, and to keep moving if used during a military operation, due to hazardous levels of waste heat.",
     "price": "4500 USD",
     "weight": "600 g",
     "difficulty": 7

--- a/nocts_cata_mod_DDA/Weapons/c_ammo.json
+++ b/nocts_cata_mod_DDA/Weapons/c_ammo.json
@@ -25,10 +25,13 @@
     "price_postapoc": "5 cent",
     "symbol": "=",
     "color": "white",
+    "damage": { "damage_type": "heat", "amount": 9, "armor_penetration": 2 },
+    "range": 3,
     "stack_size": 24,
     "material": [ "c_hydrogen_gas" ],
     "phase": "liquid",
     "ammo_type": "c_hydrogen",
+    "effects": [ "INCENDIARY" ],
     "flags": [ "NO_DROP", "IRREMOVABLE" ]
   },
   {


### PR DESCRIPTION
* Did a similar fix to what I did with Arcana's Essence Surge Cell, splitting the Plasma Pulse Cell bionic into the main version for plasma canisters, and a sub-bionic included on installation specifically for loading hydrogen gas separately. This fixes the fact that loading the bionic with one of the ammo types breaks being able to use the other type at all until you've drained the tank dry, which is a big pain in the ass if the ammotype options have wildly different energy values.
* Set fuel spawns dropped by augmented abominations to have a minimum of one instead of zero. I'm at least somewhat confident this will fix the rare occurrence where an error message will sometimes print concerning hydrogen tanks, but hard to tell for sure since I've yet to find any way to reliably reproduce it.
* Gave hydrogen gas ammo stats roughly one-fourth that of plasma cells. It's not used right now, but one idea that came up for the future was possibly a form of craftable plasma gun that can use hydrogen as an alternative.