### PR TITLE
Update NPC lasers in DDA version, headgear fix

### DIFF
--- a/nocts_cata_mod_BN/Char_creation/c_classes_bw.json
+++ b/nocts_cata_mod_BN/Char_creation/c_classes_bw.json
@@ -77,7 +77,10 @@
       "bio_armor_eyes"
     ],
     "items": {
-      "both": [ "badge_bio_weapon", "subsuit_xl", "footrags", "hat_noise_cancelling" ],
+      "both": {
+        "items": [ "badge_bio_weapon", "subsuit_xl", "footrags" ],
+        "entries": [ { "item": "hat_noise_cancelling", "custom-flags": [ "no_auto_equip" ] } ]
+      },
       "male": [ "briefs" ],
       "female": [ "bra", "panties" ]
     },

--- a/nocts_cata_mod_DDA/Char_creation/c_classes_bw.json
+++ b/nocts_cata_mod_DDA/Char_creation/c_classes_bw.json
@@ -77,7 +77,10 @@
       "bio_armor_eyes"
     ],
     "items": {
-      "both": [ "badge_bio_weapon", "subsuit_xl", "footrags", "hat_noise_cancelling" ],
+      "both": {
+        "items": [ "badge_bio_weapon", "subsuit_xl", "footrags" ],
+        "entries": [ { "item": "hat_noise_cancelling", "custom-flags": [ "no_auto_equip" ] } ]
+      },
       "male": [ "briefs" ],
       "female": [ "bra", "panties" ]
     },

--- a/nocts_cata_mod_DDA/Npc/NC_BIO_WEAPONS.json
+++ b/nocts_cata_mod_DDA/Npc/NC_BIO_WEAPONS.json
@@ -27,9 +27,7 @@
     "type": "item_group",
     "//": "Bio-Weapon Sigma's weapon, don't think you can define weapon overrides any other way.",
     "subtype": "collection",
-    "magazine": 100,
-    "ammo": 100,
-    "entries": [ { "item": "arc_laser_rifle" } ]
+    "entries": [ { "item": "arc_laser_rifle_ups" } ]
   },
   {
     "id": "NC_BIO_WEAPON_L_weapon",
@@ -43,12 +41,7 @@
     "type": "item_group",
     "subtype": "collection",
     "entries": [
-      {
-        "distribution": [
-          { "item": "medium_atomic_battery_cell", "prob": 50 },
-          { "item": "medium_atomic_battery_cell_rechargeable", "prob": 50 }
-        ]
-      },
+      { "item": "heavy_atomic_battery_cell_rechargeable", "charges": [ 5000, 10000 ], "container-item": "UPS_off" },
       { "item": "mre_veggy_box" },
       { "item": "biomap" },
       { "item": "militarymap" },

--- a/nocts_cata_mod_DDA/Npc/NC_SUPER_SOLDIERS.json
+++ b/nocts_cata_mod_DDA/Npc/NC_SUPER_SOLDIERS.json
@@ -27,39 +27,24 @@
     "id": "NC_SUPER_SOLDIER_carry",
     "type": "item_group",
     "subtype": "collection",
-    "ammo": 100,
     "entries": [
       { "item": "protein_bar_evac", "count": [ 4, 8 ] },
       { "item": "militarymap" },
       { "item": "id_military" },
-      {
-        "distribution": [
-          { "item": "medium_atomic_battery_cell", "prob": 50 },
-          { "item": "medium_atomic_battery_cell_rechargeable", "prob": 50 }
-        ]
-      },
-      {
-        "distribution": [
-          { "item": "medium_atomic_battery_cell", "prob": 50 },
-          { "item": "medium_atomic_battery_cell_rechargeable", "prob": 50 }
-        ],
-        "prob": 50
-      }
+      { "item": "heavy_atomic_battery_cell_rechargeable", "charges": [ 5000, 10000 ], "container-item": "UPS_off" }
     ]
   },
   {
     "id": "NC_SUPER_SOLDIER_weapon",
     "type": "item_group",
     "subtype": "collection",
-    "magazine": 100,
-    "ammo": 100,
     "//": "Randomly picks any of the medium-power super soldier energy weapons.",
     "entries": [
       {
         "distribution": [
-          { "item": "arc_laser_rifle", "prob": 50 },
-          { "item": "xarm_laser_shotgun", "prob": 30 },
-          { "item": "mx_laser_sniper", "prob": 20 }
+          { "item": "arc_laser_rifle_ups", "prob": 50 },
+          { "item": "xarm_laser_shotgun_ups", "prob": 30 },
+          { "item": "mx_laser_sniper_ups", "prob": 20 }
         ]
       }
     ]
@@ -86,25 +71,14 @@
     "id": "NC_BIO_HUNTER_E_carry",
     "type": "item_group",
     "subtype": "collection",
-    "magazine": 100,
-    "ammo": 100,
     "entries": [
       { "item": "mre_veggy_box" },
       { "item": "biomap" },
       { "item": "militarymap" },
-      { "group": "NC_BIO_HUNTER_E_battery", "count": [ 5, 10 ] },
+      { "item": "heavy_atomic_battery_cell_rechargeable", "charges": [ 5000, 10000 ], "container-item": "UPS_off" },
       { "group": "everyday_gear" },
       { "group": "drugs_soldier", "prob": 50 },
       { "group": "supplies_electronics", "prob": 50, "count": [ 1, 3 ] }
-    ]
-  },
-  {
-    "id": "NC_BIO_HUNTER_E_battery",
-    "type": "item_group",
-    "subtype": "distribution",
-    "entries": [
-      { "item": "light_atomic_battery_cell", "prob": 50 },
-      { "item": "light_atomic_battery_cell_rechargeable", "prob": 50 }
     ]
   },
   {
@@ -112,8 +86,6 @@
     "type": "item_group",
     "//": "Evelynn Rose's weapon, don't think you can define weapon overrides any other way.",
     "subtype": "collection",
-    "magazine": 100,
-    "ammo": 100,
-    "entries": [ { "item": "akro_laser_smg" } ]
+    "entries": [ { "item": "akro_laser_smg_ups" } ]
   }
 ]


### PR DESCRIPTION
In the DDA version, set it so the bio-weapon/super soldier NPCs use the UPS versions of their relevant weapons. Turns out battery-fed weapons bug out and cause an AI loop for nested-container reasons in DDA, while UPS weapons work right in DDA (for now, given how unreliable NPC use of UPS weapons was even without nested containers being a buggy mess, I'd keep an eye on this and be prepared to start swapping in P90s and Rivtech guns if it breaks again).

Since I confirmed it's the other way around in BN (no reload loop, but NPCs treat UPS guns as melee weapons), left them unchanged in the BN version.

Also misc fix while I'm at it, set it so the failed bio-weapon profession doesn't start off wearing their makeshift earpro, in both versions.

Fixes https://github.com/Noctifer-de-Mortem/nocts_cata_mod/issues/402