### PR TITLE
Fix wrong battery in DDA UPS spawns

### DIFF
--- a/nocts_cata_mod_DDA/Npc/NC_BIO_WEAPONS.json
+++ b/nocts_cata_mod_DDA/Npc/NC_BIO_WEAPONS.json
@@ -41,7 +41,7 @@
     "type": "item_group",
     "subtype": "collection",
     "entries": [
-      { "item": "heavy_atomic_battery_cell_rechargeable", "charges": [ 5000, 10000 ], "container-item": "UPS_off" },
+      { "item": "heavy_atomic_battery_cell", "charges": [ 5000, 10000 ], "container-item": "UPS_off" },
       { "item": "mre_veggy_box" },
       { "item": "biomap" },
       { "item": "militarymap" },

--- a/nocts_cata_mod_DDA/Npc/NC_SUPER_SOLDIERS.json
+++ b/nocts_cata_mod_DDA/Npc/NC_SUPER_SOLDIERS.json
@@ -31,7 +31,7 @@
       { "item": "protein_bar_evac", "count": [ 4, 8 ] },
       { "item": "militarymap" },
       { "item": "id_military" },
-      { "item": "heavy_atomic_battery_cell_rechargeable", "charges": [ 5000, 10000 ], "container-item": "UPS_off" }
+      { "item": "heavy_atomic_battery_cell", "charges": [ 5000, 10000 ], "container-item": "UPS_off" }
     ]
   },
   {
@@ -76,7 +76,7 @@
       { "item": "mre_veggy_box" },
       { "item": "biomap" },
       { "item": "militarymap" },
-      { "item": "heavy_atomic_battery_cell_rechargeable", "charges": [ 5000, 10000 ], "container-item": "UPS_off" },
+      { "item": "heavy_atomic_battery_cell", "charges": [ 5000, 10000 ], "container-item": "UPS_off" },
       { "group": "everyday_gear" },
       { "group": "drugs_soldier", "prob": 50 },
       { "group": "supplies_electronics", "prob": 50, "count": [ 1, 3 ] }


### PR DESCRIPTION
Easy enough, just accidentally put in rechargeable versions it seems.

Fixes https://github.com/Noctifer-de-Mortem/nocts_cata_mod/issues/422