### PR TITLE
Assorted NPC fixes

### DIFF
--- a/nocts_cata_mod_BN/Npc/NC_BIO_WEAPONS.json
+++ b/nocts_cata_mod_BN/Npc/NC_BIO_WEAPONS.json
@@ -42,6 +42,7 @@
     "id": "NC_BIO_WEAPON_carry",
     "type": "item_group",
     "subtype": "collection",
+    "ammo": 100,
     "entries": [
       {
         "distribution": [

--- a/nocts_cata_mod_BN/Npc/c_factions.json
+++ b/nocts_cata_mod_BN/Npc/c_factions.json
@@ -36,7 +36,7 @@
         "knows your voice": true
       },
       "old_guard": { "watch your back": true, "guard your stuff": true, "defends your space": true, "knows your voice": true },
-      "your_followers": { "watch your back": true, "guard your stuff": true, "knows your voice": true },
+      "your_followers": { "knows your voice": true },
       "hells_raiders": { "kill on sight": true }
     },
     "description": "Members of the Command Center seeking refuge from ...something.  They have intel and some connections to the Old Guard."
@@ -71,7 +71,7 @@
       },
       "bio_weapons": { "watch your back": true, "guard your stuff": true, "defends your space": true, "knows your voice": true },
       "old_guard": { "watch your back": true, "guard your stuff": true, "defends your space": true, "knows your voice": true },
-      "your_followers": { "watch your back": true, "guard your stuff": true, "knows your voice": true },
+      "your_followers": { "knows your voice": true },
       "hells_raiders": { "kill on sight": true }
     },
     "description": "Ragtag branch of the military that survived the initial cataclysm.   Allied to the command center, they seek leadership in this new world."
@@ -130,7 +130,7 @@
       },
       "super_soldiers": { "watch your back": true, "guard your stuff": true, "defends your space": true, "knows your voice": true },
       "old_guard": { "watch your back": true, "guard your stuff": true, "defends your space": true, "knows your voice": true },
-      "your_followers": { "watch your back": true, "guard your stuff": true, "knows your voice": true },
+      "your_followers": { "knows your voice": true },
       "hells_raiders": { "kill on sight": true }
     },
     "description": "Creations of an unknown project with links to the cataclysm.  Allied to the command center since they are their creation."
@@ -155,7 +155,7 @@
         "defends your space": true,
         "knows your voice": true
       },
-      "your_followers": { "watch your back": true, "guard your stuff": true, "knows your voice": true },
+      "your_followers": { "knows your voice": true },
       "slave_fighter": { "kill on sight": true }
     },
     "description": "People who all their lives have seen nothing but fighting in a ring for the amusement of the rich.  Most of the saner captives and new meat end up in Blue Team, pitted against hardened and \"broken in\" combatants."

--- a/nocts_cata_mod_DDA/Npc/NC_BIO_WEAPONS.json
+++ b/nocts_cata_mod_DDA/Npc/NC_BIO_WEAPONS.json
@@ -27,7 +27,9 @@
     "type": "item_group",
     "//": "Bio-Weapon Sigma's weapon, don't think you can define weapon overrides any other way.",
     "subtype": "collection",
-    "entries": [ { "item": "arc_laser_rifle_ups" } ]
+    "magazine": 100,
+    "ammo": 100,
+    "entries": [ { "item": "arc_laser_rifle" } ]
   },
   {
     "id": "NC_BIO_WEAPON_L_weapon",
@@ -40,9 +42,15 @@
     "id": "NC_BIO_WEAPON_carry",
     "type": "item_group",
     "subtype": "collection",
+    "ammo": 100,
     "entries": [
-      { "item": "heavy_atomic_battery_cell", "charges": [ 5000, 10000 ], "container-item": "UPS_off" },
-      { "item": "mre_veggy_box" },
+      {
+        "distribution": [
+          { "item": "medium_atomic_battery_cell", "prob": 50 },
+          { "item": "medium_atomic_battery_cell_rechargeable", "prob": 50 }
+        ]
+      },
+      { "group": "mre_full_pack" },
       { "item": "biomap" },
       { "item": "militarymap" },
       { "group": "everyday_gear" },

--- a/nocts_cata_mod_DDA/Npc/NC_SUPER_SOLDIERS.json
+++ b/nocts_cata_mod_DDA/Npc/NC_SUPER_SOLDIERS.json
@@ -27,24 +27,39 @@
     "id": "NC_SUPER_SOLDIER_carry",
     "type": "item_group",
     "subtype": "collection",
+    "ammo": 100,
     "entries": [
       { "item": "protein_bar_evac", "count": [ 4, 8 ] },
       { "item": "militarymap" },
       { "item": "id_military" },
-      { "item": "heavy_atomic_battery_cell", "charges": [ 5000, 10000 ], "container-item": "UPS_off" }
+      {
+        "distribution": [
+          { "item": "medium_atomic_battery_cell", "prob": 50 },
+          { "item": "medium_atomic_battery_cell_rechargeable", "prob": 50 }
+        ]
+      },
+      {
+        "distribution": [
+          { "item": "medium_atomic_battery_cell", "prob": 50 },
+          { "item": "medium_atomic_battery_cell_rechargeable", "prob": 50 }
+        ],
+        "prob": 50
+      }
     ]
   },
   {
     "id": "NC_SUPER_SOLDIER_weapon",
     "type": "item_group",
     "subtype": "collection",
+    "magazine": 100,
+    "ammo": 100,
     "//": "Randomly picks any of the medium-power super soldier energy weapons.",
     "entries": [
       {
         "distribution": [
-          { "item": "arc_laser_rifle_ups", "prob": 50 },
-          { "item": "xarm_laser_shotgun_ups", "prob": 30 },
-          { "item": "mx_laser_sniper_ups", "prob": 20 }
+          { "item": "arc_laser_rifle", "prob": 50 },
+          { "item": "xarm_laser_shotgun", "prob": 30 },
+          { "item": "mx_laser_sniper", "prob": 20 }
         ]
       }
     ]
@@ -73,13 +88,22 @@
     "subtype": "collection",
     "entries": [
       { "item": "badge_bio_weapon_evy" },
-      { "item": "mre_veggy_box" },
+      { "group": "mre_full_pack" },
       { "item": "biomap" },
       { "item": "militarymap" },
-      { "item": "heavy_atomic_battery_cell", "charges": [ 5000, 10000 ], "container-item": "UPS_off" },
+      { "group": "NC_BIO_HUNTER_E_battery", "count": [ 5, 10 ] },
       { "group": "everyday_gear" },
       { "group": "drugs_soldier", "prob": 50 },
       { "group": "supplies_electronics", "prob": 50, "count": [ 1, 3 ] }
+    ]
+  },
+  {
+    "id": "NC_BIO_HUNTER_E_battery",
+    "type": "item_group",
+    "subtype": "distribution",
+    "entries": [
+      { "item": "light_atomic_battery_cell", "prob": 50 },
+      { "item": "light_atomic_battery_cell_rechargeable", "prob": 50 }
     ]
   },
   {
@@ -87,6 +111,8 @@
     "type": "item_group",
     "//": "Evelynn Rose's weapon, don't think you can define weapon overrides any other way.",
     "subtype": "collection",
-    "entries": [ { "item": "akro_laser_smg_ups" } ]
+    "magazine": 100,
+    "ammo": 100,
+    "entries": [ { "item": "akro_laser_smg" } ]
   }
 ]

--- a/nocts_cata_mod_DDA/Npc/c_factions.json
+++ b/nocts_cata_mod_DDA/Npc/c_factions.json
@@ -36,7 +36,7 @@
         "knows your voice": true
       },
       "old_guard": { "watch your back": true, "guard your stuff": true, "defends your space": true, "knows your voice": true },
-      "your_followers": { "watch your back": true, "guard your stuff": true, "knows your voice": true },
+      "your_followers": { "knows your voice": true },
       "hells_raiders": { "kill on sight": true }
     },
     "description": "Members of the Command Center seeking refuge from ...something.  They have intel and some connections to the Old Guard."
@@ -71,7 +71,7 @@
       },
       "bio_weapons": { "watch your back": true, "guard your stuff": true, "defends your space": true, "knows your voice": true },
       "old_guard": { "watch your back": true, "guard your stuff": true, "defends your space": true, "knows your voice": true },
-      "your_followers": { "watch your back": true, "guard your stuff": true, "knows your voice": true },
+      "your_followers": { "knows your voice": true },
       "hells_raiders": { "kill on sight": true }
     },
     "description": "Ragtag branch of the military that survived the initial cataclysm.   Allied to the command center, they seek leadership in this new world."
@@ -130,7 +130,7 @@
       },
       "super_soldiers": { "watch your back": true, "guard your stuff": true, "defends your space": true, "knows your voice": true },
       "old_guard": { "watch your back": true, "guard your stuff": true, "defends your space": true, "knows your voice": true },
-      "your_followers": { "watch your back": true, "guard your stuff": true, "knows your voice": true },
+      "your_followers": { "knows your voice": true },
       "hells_raiders": { "kill on sight": true }
     },
     "description": "Creations of an unknown project with links to the cataclysm.  Allied to the command center since they are their creation."
@@ -155,7 +155,7 @@
         "defends your space": true,
         "knows your voice": true
       },
-      "your_followers": { "watch your back": true, "guard your stuff": true, "knows your voice": true },
+      "your_followers": { "knows your voice": true },
       "slave_fighter": { "kill on sight": true }
     },
     "description": "People who all their lives have seen nothing but fighting in a ring for the amusement of the rich.  Most of the saner captives and new meat end up in Blue Team, pitted against hardened and \"broken in\" combatants."


### PR DESCRIPTION
Some assorted updates to fix some stuff, mainly in DDA version but also a few matching BN version updates.

* Testing so far indicates that NPCs in DDA no longer break when trying to reload a gun that uses batteries (see issue: https://github.com/Noctifer-de-Mortem/nocts_cata_mod/issues/402), so I was able to remove the UPS spawns from super soldier NPCs, as they no longer had to use the UPS versions of the Omnitech guns. This fixed an issue where loading Cata++ with Aftershock would cause load errors because for some reason Aftershock overrides the UPS to have internal charges.
* Removed some unneeded faction relationship stuff for Cata++ factions so they won't sit there and take it if you attack them. Thisseems to be a DDA-specific bug but did the same for the BN version just in case.
* Minor: made sure a relevant itemgroup was flagged as spawning with ammo in relevant items, and set MRE spawns in the DDA version to use the itemgroups used for that sort of thing.

Fixes https://github.com/Noctifer-de-Mortem/nocts_cata_mod/issues/425
Fixes https://github.com/Noctifer-de-Mortem/nocts_cata_mod/issues/424

Does not fix: whatever DDA's code is doing on latest build when you spawn in.
![342](https://user-images.githubusercontent.com/11582235/184510956-9b304710-b362-490e-9804-9fdb25a5cf11.jpg)

