### PR TITLE
Barbaran Montante weapon injection for BN version

### DIFF
--- a/nocts_cata_mod_BN/Surv_help/c_martialarts.json
+++ b/nocts_cata_mod_BN/Surv_help/c_martialarts.json
@@ -247,6 +247,13 @@
     "extend": { "weapons": [ "unbio_sword_weapon", "flesh_blade" ] }
   },
   {
+    "id": "style_barbaran",
+    "copy-from": "style_barbaran",
+    "type": "martial_art",
+    "name": { "str": "Barbaran Montante" },
+    "extend": { "weapons": [ "greatsword_makeshift" ] }
+  },
+  {
     "id": "style_swordsmanship",
     "copy-from": "style_swordsmanship",
     "type": "martial_art",


### PR DESCRIPTION
A recent BN PR ported the Barbaran Montante martial art over from DDA, so now both the DDA and BN version inject makeshift greatsword into it.