### PR TITLE
Scenario and DDA fuel updates

### DIFF
--- a/nocts_cata_mod_BN/Char_creation/c_scenarios.json
+++ b/nocts_cata_mod_BN/Char_creation/c_scenarios.json
@@ -169,5 +169,18 @@
     "type": "scenario",
     "id": "overrun",
     "extend": { "professions": [ "bio_infantry", "bio_scout", "bio_knight", "bio_tool" ] }
+  },
+  {
+    "copy-from": "surrounded",
+    "type": "scenario",
+    "add_professions": true,
+    "extend": { "allowed_locs": [ "sloc_mansion" ] },
+    "id": "surrounded"
+  },
+  {
+    "copy-from": "migo_prisoner",
+    "type": "scenario",
+    "id": "migo_prisoner",
+    "extend": { "professions": [ "failed_weapon" ] }
   }
 ]

--- a/nocts_cata_mod_DDA/Char_creation/c_scenarios.json
+++ b/nocts_cata_mod_DDA/Char_creation/c_scenarios.json
@@ -184,5 +184,18 @@
     "type": "scenario",
     "id": "overrun",
     "extend": { "professions": [ "bio_infantry", "bio_scout", "bio_knight", "bio_tool" ] }
+  },
+  {
+    "copy-from": "surrounded",
+    "type": "scenario",
+    "add_professions": true,
+    "extend": { "allowed_locs": [ "sloc_mansion" ] },
+    "id": "surrounded"
+  },
+  {
+    "copy-from": "migo_prisoner",
+    "type": "scenario",
+    "id": "migo_prisoner",
+    "extend": { "professions": [ "failed_weapon" ] }
   }
 ]

--- a/nocts_cata_mod_DDA/Char_creation/c_start_locations.json
+++ b/nocts_cata_mod_DDA/Char_creation/c_start_locations.json
@@ -52,5 +52,12 @@
     "name": "Hazardous Waste Sarcophagus",
     "terrain": [ "haz_sar_1_2" ],
     "flags": [ "ALLOW_OUTSIDE" ]
+  },
+  {
+    "type": "start_location",
+    "id": "sloc_mansion",
+    "name": "Mansion",
+    "terrain": [ "mansion_+2", "mansion_+1", "mansion_+4", "mansion_+3" ],
+    "flags": [ "ALLOW_OUTSIDE" ]
   }
 ]

--- a/nocts_cata_mod_DDA/Surv_help/c_armor.json
+++ b/nocts_cata_mod_DDA/Surv_help/c_armor.json
@@ -1135,13 +1135,13 @@
     "weight": "50 kg",
     "volume": "40 L",
     "to_hit": -3,
-    "ammo": [ "diesel", "lamp_oil", "motor_oil", "jp8" ],
+    "ammo": [ "diesel", "lamp_oil", "crude_lamp_oil", "motor_oil", "jp8" ],
     "pocket_data": [
       {
         "pocket_type": "MAGAZINE",
         "rigid": true,
         "watertight": true,
-        "ammo_restriction": { "diesel": 2000, "lamp_oil": 2000, "motor_oil": 2000, "jp8": 2000 }
+        "ammo_restriction": { "diesel": 2000, "lamp_oil": 2000, "crude_lamp_oil": 2000, "motor_oil": 2000, "jp8": 2000 }
       }
     ],
     "relic_data": {

--- a/nocts_cata_mod_DDA/Weapons/c_mods.json
+++ b/nocts_cata_mod_DDA/Weapons/c_mods.json
@@ -15,7 +15,7 @@
     "location": "underbarrel",
     "mod_targets": [ "rifle", "shotgun", "smg", "crossbow", "launcher" ],
     "gun_data": {
-      "ammo": [ "diesel", "gasoline", "flammable", "lamp_oil", "motor_oil", "jp8", "avgas" ],
+      "ammo": [ "diesel", "gasoline", "flammable", "lamp_oil", "crude_lamp_oil", "motor_oil", "jp8", "avgas" ],
       "skill": "launcher",
       "ranged_damage": { "damage_type": "heat", "amount": -1 },
       "dispersion": 600,
@@ -30,7 +30,16 @@
         "pocket_type": "MAGAZINE",
         "rigid": true,
         "watertight": true,
-        "ammo_restriction": { "diesel": 250, "gasoline": 250, "flammable": 250, "lamp_oil": 250, "motor_oil": 250, "jp8": 250, "avgas": 250 }
+        "ammo_restriction": {
+          "diesel": 250,
+          "gasoline": 250,
+          "flammable": 250,
+          "lamp_oil": 250,
+          "crude_lamp_oil": 250,
+          "motor_oil": 250,
+          "jp8": 250,
+          "avgas": 250
+        }
       }
     ],
     "min_skills": [ [ "weapon", 2 ], [ "launcher", 1 ] ],

--- a/nocts_cata_mod_DDA/Weapons/c_ranged.json
+++ b/nocts_cata_mod_DDA/Weapons/c_ranged.json
@@ -1214,7 +1214,15 @@
     "price": "880 USD",
     "price_postapoc": "88 USD",
     "material": [ "wood", "steel" ],
-    "flags": [ "WATERPROOF_GUN", "NEVER_JAMS", "FIRE_TWOHAND", "STR_DRAW", "RELOAD_AND_SHOOT", "PRIMITIVE_RANGED_WEAPON", "DURABLE_MELEE" ],
+    "flags": [
+      "WATERPROOF_GUN",
+      "NEVER_JAMS",
+      "FIRE_TWOHAND",
+      "STR_DRAW",
+      "RELOAD_AND_SHOOT",
+      "PRIMITIVE_RANGED_WEAPON",
+      "DURABLE_MELEE"
+    ],
     "techniques": [ "RAPID", "WBLOCK_2", "PRECISE" ],
     "ammo_effects": [ "NEVER_MISFIRES" ],
     "skill": "archery",
@@ -1880,7 +1888,7 @@
     "name": { "str": "survivor's flamethrower" },
     "//": "Most stats are in between regular flamethrower and obsoleted simple flamethrower.  Integral mag because multiple ammo types.  No burst fire, less range and a damage penalty, but it uses half as much fuel as normal.",
     "description": "A makeshift flamethrower, charged from a integral fuel tank using a hand-cranked pump.  While homemade, it is higher-quality than most makeshift weapons, and can run on just about any fuel of suitable viscosity.  It uses considerably less fuel per gout of flame, at the expense of power and range.",
-    "ammo": [ "diesel", "gasoline", "flammable", "lamp_oil", "motor_oil", "jp8", "avgas" ],
+    "ammo": [ "diesel", "gasoline", "flammable", "lamp_oil", "crude_lamp_oil", "motor_oil", "jp8", "avgas" ],
     "weight": "1587 g",
     "volume": "5 L",
     "price": "200 USD",
@@ -1898,7 +1906,16 @@
         "pocket_type": "MAGAZINE",
         "rigid": true,
         "watertight": true,
-        "ammo_restriction": { "diesel": 1500, "gasoline": 1500, "flammable": 1500, "lamp_oil": 1500, "motor_oil": 1500, "jp8": 1500, "avgas": 1500 }
+        "ammo_restriction": {
+          "diesel": 1500,
+          "gasoline": 1500,
+          "flammable": 1500,
+          "lamp_oil": 1500,
+          "crude_lamp_oil": 1500,
+          "motor_oil": 1500,
+          "jp8": 1500,
+          "avgas": 1500
+        }
       }
     ],
     "reload": 4,


### PR DESCRIPTION
* Added mansion center as a valid place to start in the Surrounded scenario, combine with Medieval Mod Reborn for basically Hector start. :3
* Added a copy of BN's mansion center start location JSON to DDA version, since DDA favors starting in mansion basement instead.
* Allow starting as a failed bio-weapon in the mi-go captive scenario.
* Added crude lamp oil as an option to items in the DDA version that use assorted related fuels.
* Linted affected files.