### PR TITLE
A few martial arts updates

### DIFF
--- a/nocts_cata_mod_BN/Surv_help/c_martialarts.json
+++ b/nocts_cata_mod_BN/Surv_help/c_martialarts.json
@@ -12,11 +12,22 @@
     "arm_block_with_bio_armor_arms": true,
     "leg_block_with_bio_armor_legs": true,
     "allow_melee": true,
+    "static_buffs": [
+      {
+        "id": "buff_surv_com_static",
+        "name": "Fluid Motion",
+        "description": "You've learned to move with a purposeful efficiency.  Movement speed increased by 25% of Intelligence.",
+        "skill_requirements": [ { "name": "melee", "level": 7 } ],
+        "unarmed_allowed": true,
+        "melee_allowed": true,
+        "flat_bonuses": [ { "stat": "speed", "scaling-stat": "int", "scale": 0.25 } ]
+      }
+    ],
     "onmove_buffs": [
       {
         "id": "buff_surv_com_onmove",
         "name": "Elusiveness",
-        "description": "Quick and fluid movements make you harder to catch.\n\n+1 Dodge attempts, Dodge skill increased by 25% of Intelligence, immunity to knockdown.\nLasts 3 turns, stacks 2 times.",
+        "description": "Quick and fluid movements make you harder to catch, and better able to roll with the punches.\n\n+1 Dodge attempts, Dodge skill increased by 25% of Intelligence, bash damage taken reduced by 25% of Intelligence, immunity to knockdown.\nLasts 3 turns, stacks 2 times.",
         "skill_requirements": [ { "name": "melee", "level": 4 } ],
         "unarmed_allowed": true,
         "melee_allowed": true,
@@ -24,7 +35,10 @@
         "buff_duration": 3,
         "max_stacks": 2,
         "bonus_dodges": 1,
-        "flat_bonuses": [ { "stat": "dodge", "scaling-stat": "int", "scale": 0.25 } ]
+        "flat_bonuses": [
+          { "stat": "dodge", "scaling-stat": "int", "scale": 0.25 },
+          { "stat": "armor", "type": "bash", "scaling-stat": "str", "scale": 0.25 }
+        ]
       }
     ],
     "onhit_buffs": [
@@ -88,12 +102,24 @@
       {
         "id": "buff_mut_com_onpause",
         "name": "Stored Potential",
-        "description": "Conserving your energy and focusing your mind will permit explosive bursts of action.\n\n-10% move cost.\nLasts 3 turns, stacks 3 times.",
+        "description": "Conserving your energy and focusing your mind will permit explosive bursts of action.\n\n-10% move cost.\nLasts 3 turns.",
         "skill_requirements": [ { "name": "melee", "level": 5 } ],
         "unarmed_allowed": true,
         "melee_allowed": true,
         "buff_duration": 3,
-        "max_stacks": 3,
+        "mult_bonuses": [ { "stat": "movecost", "scale": 0.9 } ]
+      }
+    ],
+    "onattack_buffs": [
+      {
+        "id": "buff_mut_com_onattack",
+        "name": "Tension",
+        "description": "All you need to survive is to commit to the offensive.\n\n-10% move cost.\nLasts 3 turns, stacks 2 times.",
+        "skill_requirements": [ { "name": "melee", "level": 5 } ],
+        "unarmed_allowed": true,
+        "melee_allowed": true,
+        "buff_duration": 3,
+        "max_stacks": 2,
         "mult_bonuses": [ { "stat": "movecost", "scale": 0.9 } ]
       }
     ],
@@ -143,6 +169,7 @@
       "ecs_lajatang_off",
       "ecs_lajatang_on",
       "glaive",
+      "sword_metal",
       "greatsword_makeshift",
       "halberd",
       "halberd_fake",

--- a/nocts_cata_mod_DDA/Surv_help/c_martialarts.json
+++ b/nocts_cata_mod_DDA/Surv_help/c_martialarts.json
@@ -12,11 +12,22 @@
     "arm_block_with_bio_armor_arms": true,
     "leg_block_with_bio_armor_legs": true,
     "allow_all_weapons": true,
+    "static_buffs": [
+      {
+        "id": "buff_surv_com_static",
+        "name": "Fluid Motion",
+        "description": "You've learned to move with a purposeful efficiency.  Movement speed increased by 25% of Intelligence.",
+        "skill_requirements": [ { "name": "melee", "level": 7 } ],
+        "unarmed_allowed": true,
+        "melee_allowed": true,
+        "flat_bonuses": [ { "stat": "speed", "scaling-stat": "int", "scale": 0.25 } ]
+      }
+    ],
     "onmove_buffs": [
       {
         "id": "buff_surv_com_onmove",
         "name": "Elusiveness",
-        "description": "Quick and fluid movements make you harder to catch.\n\n+1 Dodge attempts, Dodge skill increased by 25% of Intelligence, immunity to knockdown.\nLasts 3 turns, stacks 2 times.",
+        "description": "Quick and fluid movements make you harder to catch, and better able to roll with the punches.\n\n+1 Dodge attempts, Dodge skill increased by 25% of Intelligence, bash damage taken reduced by 25% of Intelligence, immunity to knockdown.\nLasts 3 turns, stacks 2 times.",
         "skill_requirements": [ { "name": "melee", "level": 4 } ],
         "unarmed_allowed": true,
         "melee_allowed": true,
@@ -24,7 +35,10 @@
         "buff_duration": 3,
         "max_stacks": 3,
         "bonus_dodges": 1,
-        "flat_bonuses": [ { "stat": "dodge", "scaling-stat": "int", "scale": 0.25 } ]
+        "flat_bonuses": [
+          { "stat": "dodge", "scaling-stat": "int", "scale": 0.25 },
+          { "stat": "armor", "type": "bash", "scaling-stat": "str", "scale": 0.25 }
+        ]
       }
     ],
     "onhit_buffs": [
@@ -88,12 +102,24 @@
       {
         "id": "buff_mut_com_onpause",
         "name": "Stored Potential",
-        "description": "Conserving your energy and focusing your mind will permit explosive bursts of action.\n\n-10% move cost.\nLasts 3 turns, stacks 3 times.",
+        "description": "Conserving your energy and focusing your mind will permit explosive bursts of action.\n\n-10% move cost.\nLasts 3 turns.",
         "skill_requirements": [ { "name": "melee", "level": 5 } ],
         "unarmed_allowed": true,
         "melee_allowed": true,
         "buff_duration": 3,
-        "max_stacks": 3,
+        "mult_bonuses": [ { "stat": "movecost", "scale": 0.9 } ]
+      }
+    ],
+    "onattack_buffs": [
+      {
+        "id": "buff_mut_com_onattack",
+        "name": "Tension",
+        "description": "All you need to survive is to commit to the offensive.\n\n-10% move cost.\nLasts 3 turns, stacks 2 times.",
+        "skill_requirements": [ { "name": "melee", "level": 5 } ],
+        "unarmed_allowed": true,
+        "melee_allowed": true,
+        "buff_duration": 3,
+        "max_stacks": 2,
         "mult_bonuses": [ { "stat": "movecost", "scale": 0.9 } ]
       }
     ],


### PR DESCRIPTION
These are a couple of updates geared towards giving Survivor Combatives a bit more defensive benefits that help give it parity with Post-Human Combaitves. In addition, it also adjusts one of the buffs of Post-Human Combatives to be a bit less counterintuitive to make proper use of.

* Added a static buff to Survivor Combatives at a high enough level, that adds a bonus bit of int-scaling speed boost.
* Added bash damage reduction, scaling off int, to Survivor Combative's on-hit buff.
* Shifted two layers of Post-Human Combatives' movecost bonuses from the onpause buff to a new onattack buff. This makes it easier to get the full use of the movecost bonuses, while still allowing the onpause buff to work as a setup buff.
* Belatedly added the hand-forged sword to Post Human Combatives' weapon list in the BN version, as while its DDA counterpart is in the "wannabe macuahuitl" weapon family with the nail sword and friends, the BN version is closer to a bulkier longsword in general stats, and has a slow moves-per-attack rate that fits the style.