### PR TITLE
Wasteland drifter updates

### DIFF
--- a/nocts_cata_mod_BN/Char_creation/c_classes_r.json
+++ b/nocts_cata_mod_BN/Char_creation/c_classes_r.json
@@ -3,7 +3,7 @@
     "type": "item_group",
     "subtype": "collection",
     "id": "flintlock_pouch_surv_drifter",
-    "entries": [ { "item": "36navy_makeshift_magnum", "charges": 14 } ]
+    "entries": [ { "item": "36navy_makeshift_magnum", "charges": 20 } ]
   },
   {
     "type": "item_group",
@@ -66,7 +66,7 @@
       { "level": 4, "name": "gun" },
       { "level": 3, "name": "pistol" },
       { "level": 3, "name": "melee" },
-      { "level": 2, "name": "stabbing" },
+      { "level": 2, "name": "cutting" },
       { "level": 2, "name": "dodge" },
       { "level": 4, "name": "tailor" },
       { "level": 3, "name": "cooking" },
@@ -102,7 +102,7 @@
           { "item": "ear_plugs", "custom-flags": [ "no_auto_equip" ] },
           { "item": "vinegar", "container-item": "bottle_plastic_small" },
           { "item": "lamp_oil", "container-item": "bottle_plastic_small" },
-          { "item": "36navy_makeshift_magnum", "charges": 8 }
+          { "item": "36navy_makeshift_magnum", "charges": 2 }
         ]
       },
       "male": [ "boxer_shorts" ],

--- a/nocts_cata_mod_DDA/Char_creation/c_classes_r.json
+++ b/nocts_cata_mod_DDA/Char_creation/c_classes_r.json
@@ -75,7 +75,7 @@
       { "level": 4, "name": "gun" },
       { "level": 3, "name": "pistol" },
       { "level": 3, "name": "melee" },
-      { "level": 2, "name": "stabbing" },
+      { "level": 2, "name": "cutting" },
       { "level": 2, "name": "dodge" },
       { "level": 4, "name": "tailor" },
       { "level": 3, "name": "cooking" },


### PR DESCRIPTION
* Belatedly updated the wasteland drifter's starting inventory in the BN version, since bandoliers in BN can hold more ammo than in DDA.
* Also in both versions, fixed them starting with stabbing skill when their knife uses cutting skill.