### PR TITLE
Fix survivor encampment NPCs

### DIFF
--- a/nocts_cata_mod_BN/Npc/c_npc.json
+++ b/nocts_cata_mod_BN/Npc/c_npc.json
@@ -18,7 +18,7 @@
     "name_suffix": "Prepper",
     "class": "NC_PREPPER",
     "attitude": 0,
-    "mission": 7,
+    "mission": 3,
     "chat": "TALK_STRANGER_NEUTRAL",
     "faction": "preppers"
   },

--- a/nocts_cata_mod_DDA/Npc/c_npc.json
+++ b/nocts_cata_mod_DDA/Npc/c_npc.json
@@ -18,7 +18,7 @@
     "name_suffix": "Prepper",
     "class": "NC_PREPPER",
     "attitude": 0,
-    "mission": 7,
+    "mission": 3,
     "chat": "TALK_STRANGER_NEUTRAL",
     "faction": "preppers"
   },


### PR DESCRIPTION
Simply just sets it so they can sell the stuff that spawns near them, easy fix.