### PR TITLE
Bundle of assorted ideas

### DIFF
--- a/nocts_cata_mod_BN/Mutations/c_bio_mutation.json
+++ b/nocts_cata_mod_BN/Mutations/c_bio_mutation.json
@@ -323,15 +323,17 @@
   {
     "type": "mutation",
     "id": "TOUGH_BIOWEAPON",
-    "name": { "str": "Unyielding" },
+    "name": { "str": "Unyielding Frame" },
     "points": 0,
-    "description": "Your durability and resilience are overall far beyond normal humans.  You gain a flat +50 to all hit points, plus your maximum stamina and stamina regeneration is 30% higher than normal.",
+    "description": "Your durability and resilience are overall far beyond normal humans, and your form is larger than a normal human.  You gain a flat +50 to all hit points, plus your maximum stamina and stamina regeneration is 30% higher than normal.",
     "valid": false,
     "purifiable": false,
     "profession": true,
     "cancels": [ "TOUGH", "FLIMSY", "FLIMSY2", "FLIMSY3", "GLASSJAW", "GOODCARDIO", "BADCARDIO" ],
     "hp_adjustment": 50,
-    "max_stamina_modifier": 1.3
+    "max_stamina_modifier": 1.3,
+    "types": [ "SIZE" ],
+    "body_size": "LARGE"
   },
   {
     "type": "mutation",

--- a/nocts_cata_mod_BN/Surv_help/c_armor.json
+++ b/nocts_cata_mod_BN/Surv_help/c_armor.json
@@ -52,6 +52,7 @@
     "warmth": 25,
     "material_thickness": 4,
     "environmental_protection": 15,
+    "valid_mods": [ "steel_padded", "alloy_padded" ],
     "use_action": {
       "type": "holster",
       "holster_prompt": "Sheath knife/sword",
@@ -101,6 +102,7 @@
     "warmth": 25,
     "material_thickness": 5,
     "environmental_protection": 15,
+    "valid_mods": [ "steel_padded", "alloy_padded" ],
     "use_action": {
       "type": "holster",
       "holster_prompt": "Sheath knife/sword",
@@ -568,6 +570,7 @@
     "material": [ "cotton" ],
     "symbol": "[",
     "looks_like": "house_coat",
+    "repairs_like": "house_coat",
     "color": "blue",
     "covers": [ "torso", "arms", "legs" ],
     "coverage": 85,
@@ -590,6 +593,7 @@
     "material": [ "cotton" ],
     "symbol": "[",
     "looks_like": "bra",
+    "repairs_like": "bra",
     "color": "white",
     "covers": [ "torso" ],
     "coverage": 15,
@@ -609,6 +613,7 @@
     "material": [ "cotton" ],
     "symbol": "[",
     "looks_like": "panties",
+    "repairs_like": "panties",
     "color": "white",
     "covers": [ "legs" ],
     "coverage": 15,
@@ -628,6 +633,7 @@
     "material": [ "cotton" ],
     "symbol": "[",
     "looks_like": "briefs",
+    "repairs_like": "briefs",
     "color": "white",
     "covers": [ "legs" ],
     "coverage": 15,
@@ -647,6 +653,7 @@
     "material": [ "cotton" ],
     "symbol": "[",
     "looks_like": "boxer_shorts",
+    "repairs_like": "boxer_shorts",
     "color": "light_gray",
     "covers": [ "legs" ],
     "coverage": 25,
@@ -666,6 +673,7 @@
     "material": [ "cotton" ],
     "symbol": "[",
     "looks_like": "boxer_briefs",
+    "repairs_like": "boxer_briefs",
     "color": "light_gray",
     "covers": [ "legs" ],
     "coverage": 20,
@@ -723,6 +731,7 @@
     "material": [ "cotton" ],
     "symbol": "[",
     "looks_like": "bikini_bottom",
+    "repairs_like": "bikini_bottom",
     "color": "white",
     "covers": [ "legs" ],
     "coverage": 12,
@@ -769,14 +778,24 @@
     "flags": [ "VARSIZE", "FANCY" ]
   },
   {
+    "type": "mutation",
+    "id": "C_MIGO_HEAT_BONUS",
+    "name": { "str": "Carapace Armor Cooling" },
+    "points": 99,
+    "valid": false,
+    "description": "This is used to make salvaged carapace armor provide further cooling if overheating.",
+    "player_display": false,
+    "bodytemp_modifiers": [ -1000, 0 ]
+  },
+  {
     "id": "c_mi_go_carapace_salvaged",
     "looks_like": "rm13_armor",
     "type": "TOOL_ARMOR",
     "symbol": "[",
     "color": "green",
     "name": { "str": "salvaged carapace armor" },
-    "description": "A vaguely human-shaped shell of alien sinew and steel support, covered in armor plates made of resin.  Salvaged using pre-cataclysm research into other living weaponry, it's been practically mutilated to fit a human (or mutant) wearer.  Activating it will reduce the suit's encumbrance, enhance strength and dexterity, protect the wearer from toxic gas, serve as a rebreather, enhance stamina and carry capacity, and provide some protection from outside temperature.  It seems to recharge from sunlight, and being active will also gradually fatigue the user and affect healthiness, plus render them more vulnerable to electric shocks.",
-    "flags": [ "OVERSIZE", "STURDY", "OUTER", "HELMET_COMPAT", "SWIM_GOGGLES", "SUN_GLASSES" ],
+    "description": "A vaguely human-shaped second skin of alien sinew and steel support, covered in armor plates made of resin.  Salvaged using pre-cataclysm research into other living weaponry, it's been practically mutilated to fit a human (or mutant) wearer.  Activating it will reduce the suit's encumbrance, enhance strength and dexterity, protect the wearer from toxic gas, serve as a rebreather, enhance stamina and carry capacity, and provide some protection from outside temperature.  It seems to recharge from sunlight, and being active will also gradually fatigue the user and affect healthiness, plus render them more vulnerable to electric shocks.",
+    "flags": [ "OVERSIZE", "STURDY", "SKINTIGHT", "HELMET_COMPAT", "SWIM_GOGGLES", "SUN_GLASSES", "ONLY_ONE" ],
     "price_postapoc": "80 USD",
     "material": [ "alien_resin", "flesh", "steel" ],
     "weight": "20 kg",
@@ -799,7 +818,8 @@
           "has": "WORN",
           "condition": "ACTIVE",
           "values": [ { "value": "STRENGTH", "add": 2 }, { "value": "DEXTERITY", "add": 1 }, { "value": "ARMOR_ELEC", "multiply": 0.5 } ],
-          "ench_effects": [ { "effect": "c_mi_go_carapace_stamina", "intensity": 1 } ]
+          "ench_effects": [ { "effect": "c_mi_go_carapace_stamina", "intensity": 1 } ],
+          "mutations": [ "C_MIGO_HEAT_BONUS" ]
         }
       ]
     },
@@ -823,9 +843,10 @@
       "msg": "The suit's sinews go slack, releasing you from its grasp.",
       "type": "transform"
     },
+    "warmth": 0,
     "environmental_protection": 15,
     "encumbrance": 10,
-    "weight_capacity_modifier": 2,
+    "weight_capacity_modifier": 1.5,
     "extend": { "flags": [ "WATERPROOF", "RAINPROOF", "CLIMATE_CONTROL", "GAS_PROOF", "REBREATHER", "NO_TAKEOFF" ] }
   },
   {
@@ -834,8 +855,8 @@
     "symbol": "[",
     "color": "green",
     "name": { "str": "set of salvaged exo-wings", "str_pl": "sets of salvaged exo-wings" },
-    "description": "A set of thin, green iridescent wings, steel wires and joints meshed with thick alien nervous cords.  Salvaged using pre-cataclysm research into other living weaponry, it's been heavily altered to fit a human (or mutant) wearer.  Activating it will grant immunity to falling damage and vastly speed up movement.  It seems to recharge from sunlight, and being active will also gradually fatigue the user.",
-    "flags": [ "OVERSIZE", "STURDY", "BELTED" ],
+    "description": "A harness from which jut thin, green iridescent wings, steel wires and joints meshed with thick alien nervous cords.  Salvaged using pre-cataclysm research into other living weaponry, it's been heavily altered to fit a human (or mutant) wearer.  Activating it will grant immunity to falling damage and vastly speed up movement.  It seems to recharge from sunlight, and being active will also gradually fatigue the user.",
+    "flags": [ "OVERSIZE", "STURDY", "WAIST", "ONLY_ONE" ],
     "price_postapoc": "40 USD",
     "material": [ "alien_resin", "flesh", "steel" ],
     "weight": "2 kg",
@@ -892,6 +913,7 @@
     "encumbrance": 20,
     "warmth": 10,
     "material_thickness": 4,
+    "valid_mods": [ "steel_padded", "alloy_padded" ],
     "use_action": {
       "type": "bandolier",
       "capacity": 12,
@@ -998,7 +1020,7 @@
     "color": "dark_gray",
     "looks_like": "rm13_armor",
     "name": { "str": "makeshift power armor" },
-    "description": "An incredibly heavy suit of steel plates covering a network of hydraulics, driven by pieces of a stripped-down diesel engine jury-rigged to assist the wearer's movements.  It's cumbersome but provides considerable protection aside from gaps in the joints and vision slits, and the servos offer quite a bit of power when active.",
+    "description": "An incredibly heavy suit of steel plates covering a network of hydraulics, driven by pieces of a stripped-down diesel engine jury-rigged to assist the wearer's movements.  When running it will increase your strength and make it less encumbering to wear, but the motors make things warm and make stealth harder.",
     "flags": [ "OVERSIZE", "STURDY", "OUTER", "ALLOWS_NATURAL_ATTACKS" ],
     "price": "500 USD",
     "price_postapoc": "50 USD",
@@ -1054,6 +1076,6 @@
     },
     "warmth": 45,
     "encumbrance": 15,
-    "weight_capacity_modifier": 1.5
+    "weight_capacity_modifier": 2
   }
 ]

--- a/nocts_cata_mod_BN/Terrain/makeshift_command_center.json
+++ b/nocts_cata_mod_BN/Terrain/makeshift_command_center.json
@@ -31,7 +31,7 @@
         "|,,.,,,,.,,,,,,,,,,,,,,|"
       ],
       "terrain": { "|": "t_chainfence_v", "-": "t_chainfence_h", "&": "t_chaingate_c", ",": "t_grass", ".": "t_dirt" },
-      "place_vehicles": [ { "vehicle": "lux_rv", "x": 11, "y": 12, "chance": 99, "fuel": 85, "status": -1, "rotation": 90 } ]
+      "place_vehicles": [ { "vehicle": "command_center_rvs", "x": 11, "y": 12, "chance": 99, "fuel": 85, "status": -1, "rotation": 90 } ]
     }
   },
   {

--- a/nocts_cata_mod_BN/Vehicles/c_carts.json
+++ b/nocts_cata_mod_BN/Vehicles/c_carts.json
@@ -30,7 +30,7 @@
     "blueprint": [ "&" ],
     "parts": [
       { "x": 0, "y": 0, "parts": [ "xlframe_horizontal", "wheel_caster", "medium_storage_battery", "autoclave" ] },
-      { "x": 1, "y": 0, "parts": [ "xlframe_horizontal", "wheel_caster", "box" ] },
+      { "x": 1, "y": 0, "parts": [ "xlframe_horizontal", "wheel_caster", "box", "water_faucet" ] },
       { "x": 1, "y": 0, "part": "tank_little", "fuel": "water" }
     ],
     "items": [ { "x": 0, "y": 0, "chance": 90, "items": [ "pouch_autoclave" ] } ]

--- a/nocts_cata_mod_BN/Vehicles/c_vehicle_groups.json
+++ b/nocts_cata_mod_BN/Vehicles/c_vehicle_groups.json
@@ -24,5 +24,10 @@
     "id": "highway",
     "type": "vehicle_group",
     "vehicles": [ [ "surv_tachanka", 5 ] ]
+  },
+  {
+    "id": "command_center_rvs",
+    "type": "vehicle_group",
+    "vehicles": [ [ "rv", 50 ], [ "lux_rv", 25 ], [ "surv_rv", 15 ], [ "c_surv_rv_military", 10 ] ]
   }
 ]

--- a/nocts_cata_mod_DDA/Mutations/c_bio_mutation.json
+++ b/nocts_cata_mod_DDA/Mutations/c_bio_mutation.json
@@ -323,15 +323,17 @@
   {
     "type": "mutation",
     "id": "TOUGH_BIOWEAPON",
-    "name": { "str": "Unyielding" },
+    "name": { "str": "Unyielding Frame" },
     "points": 0,
-    "description": "Your durability and resilience are overall far beyond normal humans.  You gain a flat +50 to all hit points, plus your maximum stamina and stamina regeneration is 30% higher than normal.",
+    "description": "Your durability and resilience are overall far beyond normal humans, and your form is larger than a normal human.  You gain a flat +50 to all hit points, plus your maximum stamina and stamina regeneration is 30% higher than normal.",
     "valid": false,
     "purifiable": false,
     "profession": true,
     "cancels": [ "TOUGH", "FLIMSY", "FLIMSY2", "FLIMSY3", "GLASSJAW", "GOODCARDIO", "BADCARDIO" ],
     "hp_adjustment": 50,
-    "cardio_multiplier": 1.3
+    "cardio_multiplier": 1.3,
+    "types": [ "SIZE" ],
+    "flags": [ "LARGE" ]
   },
   {
     "type": "mutation",

--- a/nocts_cata_mod_DDA/Surv_help/c_armor.json
+++ b/nocts_cata_mod_DDA/Surv_help/c_armor.json
@@ -70,6 +70,7 @@
     "warmth": 25,
     "material_thickness": 4,
     "environmental_protection": 15,
+    "valid_mods": [ "steel_padded" ],
     "use_action": { "type": "holster", "holster_prompt": "Sheath knife/sword", "holster_msg": "You sheath your %s" },
     "flags": [
       "VARSIZE",
@@ -136,6 +137,7 @@
     "warmth": 25,
     "material_thickness": 5,
     "environmental_protection": 15,
+    "valid_mods": [ "steel_padded" ],
     "use_action": { "type": "holster", "holster_prompt": "Sheath knife/sword", "holster_msg": "You sheath your %s" },
     "flags": [
       "VARSIZE",
@@ -639,6 +641,7 @@
     "material": [ "cotton" ],
     "symbol": "[",
     "looks_like": "house_coat",
+    "repairs_like": "house_coat",
     "color": "blue",
     "warmth": 20,
     "material_thickness": 2,
@@ -678,6 +681,7 @@
     "material": [ "cotton" ],
     "symbol": "[",
     "looks_like": "bra",
+    "repairs_like": "bra",
     "color": "white",
     "warmth": 5,
     "material_thickness": 2,
@@ -696,6 +700,7 @@
     "material": [ "cotton" ],
     "symbol": "[",
     "looks_like": "panties",
+    "repairs_like": "panties",
     "color": "white",
     "warmth": 5,
     "material_thickness": 1,
@@ -714,6 +719,7 @@
     "material": [ "cotton" ],
     "symbol": "[",
     "looks_like": "briefs",
+    "repairs_like": "briefs",
     "color": "white",
     "warmth": 5,
     "material_thickness": 1,
@@ -732,6 +738,7 @@
     "material": [ "cotton" ],
     "symbol": "[",
     "looks_like": "boxer_shorts",
+    "repairs_like": "boxer_shorts",
     "color": "light_gray",
     "warmth": 5,
     "material_thickness": 1,
@@ -750,6 +757,7 @@
     "material": [ "cotton" ],
     "symbol": "[",
     "looks_like": "boxer_briefs",
+    "repairs_like": "boxer_briefs",
     "color": "light_gray",
     "warmth": 5,
     "material_thickness": 1,
@@ -804,6 +812,7 @@
     "material": [ "cotton" ],
     "symbol": "[",
     "looks_like": "bikini_bottom",
+    "repairs_like": "bikini_bottom",
     "color": "white",
     "warmth": 5,
     "material_thickness": 1,
@@ -846,6 +855,16 @@
     "armor": [ { "encumbrance": 0, "coverage": 7, "covers": [ "leg_l", "leg_r" ] } ]
   },
   {
+    "type": "mutation",
+    "id": "C_MIGO_HEAT_BONUS",
+    "name": { "str": "Carapace Armor Cooling" },
+    "points": 99,
+    "valid": false,
+    "description": "This is used to make salvaged carapace armor provide further cooling if overheating.",
+    "player_display": false,
+    "bodytemp_modifiers": [ -1000, 0 ]
+  },
+  {
     "id": "c_mi_go_carapace_salvaged",
     "looks_like": "rm13_armor",
     "type": "TOOL_ARMOR",
@@ -853,8 +872,8 @@
     "symbol": "[",
     "color": "green",
     "name": { "str": "salvaged carapace armor" },
-    "description": "A vaguely human-shaped shell of alien sinew and steel support, covered in armor plates made of resin.  Effectively mutilated to fit a human (or mutant) wearer, somehow it's still functional, almost alive in fact.  Activating it will reduce the suit's encumbrance, enhance strength and dexterity, protect the wearer from toxic gas, serve as a rebreather, enhance stamina and carry capacity, and provide some protection from outside temperature.  It seems to recharge from sunlight, and being active will also gradually fatigue the user and affect healthiness, plus render them more vulnerable to electric shocks.",
-    "flags": [ "OVERSIZE", "STURDY", "OUTER", "PADDED", "SWIM_GOGGLES", "SUN_GLASSES" ],
+    "description": "A vaguely human-shaped second skin of alien sinew and steel support, covered in armor plates made of resin.  Effectively mutilated to fit a human (or mutant) wearer, somehow it's still functional, almost alive in fact.  Activating it will reduce the suit's encumbrance, enhance strength and dexterity, protect the wearer from toxic gas, serve as a rebreather, enhance stamina and carry capacity, and provide some protection from outside temperature.  It seems to recharge from sunlight, and being active will also gradually fatigue the user and affect healthiness, plus render them more vulnerable to electric shocks.",
+    "flags": [ "OVERSIZE", "STURDY", "SKINTIGHT", "PADDED", "SWIM_GOGGLES", "SUN_GLASSES", "ONLY_ONE" ],
     "price_postapoc": "80 USD",
     "material": [ "alien_resin", "flesh", "steel" ],
     "weight": "20 kg",
@@ -881,11 +900,12 @@
             { "value": "STRENGTH", "add": 2 },
             { "value": "DEXTERITY", "add": 1 },
             { "value": "ARMOR_ELEC", "multiply": 0.5 },
-            { "value": "CARRY_WEIGHT", "multiply": 1.0 },
+            { "value": "CARRY_WEIGHT", "multiply": 1.5 },
             { "value": "CLIMATE_CONTROL_HEAT", "add": 50 },
             { "value": "CLIMATE_CONTROL_CHILL", "add": 50 }
           ],
-          "ench_effects": [ { "effect": "c_mi_go_carapace_stamina", "intensity": 1 } ]
+          "ench_effects": [ { "effect": "c_mi_go_carapace_stamina", "intensity": 1 } ],
+          "mutations": [ "C_MIGO_HEAT_BONUS" ]
         }
       ]
     },
@@ -916,6 +936,7 @@
     },
     "extend": { "flags": [ "WATERPROOF", "RAINPROOF", "GAS_PROOF", "REBREATHER", "NO_TAKEOFF" ] },
     "material": [ "alien_resin", "flesh", "steel" ],
+    "warmth": 0,
     "material_thickness": 4,
     "environmental_protection": 15,
     "armor": [
@@ -932,8 +953,8 @@
     "symbol": "[",
     "color": "green",
     "name": { "str": "set of salvaged exo-wings", "str_pl": "sets of salvaged exo-wings" },
-    "description": "A set of thin, green iridescent wings, steel wires and joints meshed with thick alien nervous cords.  Salvaged using pre-cataclysm research into other living weaponry, it's been heavily altered to fit a human (or mutant) wearer.  Activating it will grant immunity to falling damage and vastly speed up movement.  It seems to recharge from sunlight, and being active will also gradually fatigue the user.",
-    "flags": [ "OVERSIZE", "STURDY", "BELTED", "PADDED" ],
+    "description": "A harness from which jut thin, green iridescent wings, steel wires and joints meshed with thick alien nervous cords.  Salvaged using pre-cataclysm research into other living weaponry, it's been heavily altered to fit a human (or mutant) wearer.  Activating it will grant immunity to falling damage and vastly speed up movement.  It seems to recharge from sunlight, and being active will also gradually fatigue the user.",
+    "flags": [ "OVERSIZE", "STURDY", "BELTED", "PADDED", "ONLY_ONE" ],
     "price_postapoc": "40 USD",
     "material": [ "alien_resin", "flesh", "steel" ],
     "weight": "2 kg",
@@ -962,7 +983,7 @@
       ]
     },
     "material_thickness": 2,
-    "armor": [ { "encumbrance": 10, "coverage": 40, "covers": [ "torso" ] } ]
+    "armor": [ { "encumbrance": 10, "coverage": 40, "covers": [ "torso" ], "specifically_covers": [ "torso_waist" ] } ]
   },
   {
     "id": "c_mi_go_wings_salvaged_on",
@@ -979,7 +1000,7 @@
       "ammo_scale": 0
     },
     "extend": { "flags": [ "NO_TAKEOFF" ] },
-    "armor": [ { "encumbrance": 0, "coverage": 40, "covers": [ "torso" ] } ]
+    "armor": [ { "encumbrance": 0, "coverage": 40, "covers": [ "torso" ], "specifically_covers": [ "torso_waist" ] } ]
   },
   {
     "id": "cowboy_hat_surv",
@@ -992,6 +1013,7 @@
     "material": [ "leather", "cotton", "kevlar" ],
     "warmth": 10,
     "material_thickness": 4,
+    "valid_mods": [ "steel_padded" ],
     "pocket_data": [
       {
         "ammo_restriction": {
@@ -1129,7 +1151,7 @@
     "color": "dark_gray",
     "looks_like": "rm13_armor",
     "name": { "str": "makeshift power armor" },
-    "description": "An incredibly heavy suit of steel plates covering a network of hydraulics, driven by pieces of a stripped-down diesel engine jury-rigged to assist the wearer's movements.  It's cumbersome but provides considerable protection aside from gaps in the joints and vision slits, and the servos offer quite a bit of power when active.",
+    "description": "An incredibly heavy suit of steel plates covering a network of hydraulics, driven by pieces of a stripped-down diesel engine jury-rigged to assist the wearer's movements.  When running it will increase your strength and make it less encumbering to wear, but the motors make things warm and make stealth harder.",
     "flags": [ "OVERSIZE", "STURDY", "OUTER", "ALLOWS_NATURAL_ATTACKS", "PADDED" ],
     "price": "500 USD",
     "price_postapoc": "50 USD",
@@ -1151,7 +1173,7 @@
         {
           "has": "WORN",
           "condition": "ACTIVE",
-          "values": [ { "value": "STRENGTH", "add": 4 }, { "value": "CARRY_WEIGHT", "multiply": 1.5 } ],
+          "values": [ { "value": "STRENGTH", "add": 4 }, { "value": "CARRY_WEIGHT", "multiply": 2.0 } ],
           "mutations": [ "C_MOVE_NOISE" ]
         }
       ]

--- a/nocts_cata_mod_DDA/Terrain/makeshift_command_center.json
+++ b/nocts_cata_mod_DDA/Terrain/makeshift_command_center.json
@@ -31,7 +31,7 @@
         "|,,.,,,,.,,,,,,,,,,,,,,|"
       ],
       "terrain": { "|": "t_chainfence_v", "-": "t_chainfence_h", "&": "t_chaingate_c", ",": "t_grass", ".": "t_dirt" },
-      "place_vehicles": [ { "vehicle": "lux_rv", "x": 11, "y": 12, "chance": 99, "fuel": 85, "status": -1, "rotation": 90 } ]
+      "place_vehicles": [ { "vehicle": "command_center_rvs", "x": 11, "y": 12, "chance": 99, "fuel": 85, "status": -1, "rotation": 90 } ]
     }
   },
   {

--- a/nocts_cata_mod_DDA/Vehicles/c_carts.json
+++ b/nocts_cata_mod_DDA/Vehicles/c_carts.json
@@ -30,7 +30,7 @@
     "blueprint": [ "&O" ],
     "parts": [
       { "x": 0, "y": 0, "parts": [ "xlframe_horizontal", "wheel_caster", "medium_storage_battery", "autoclave" ] },
-      { "x": 1, "y": 0, "parts": [ "xlframe_horizontal", "wheel_caster", "box" ] },
+      { "x": 1, "y": 0, "parts": [ "xlframe_horizontal", "wheel_caster", "box", "water_faucet" ] },
       { "x": 1, "y": 0, "part": "tank_little", "fuel": "water" }
     ],
     "items": [ { "x": 1, "y": 0, "chance": 90, "items": [ "pouch_autoclave" ] } ]

--- a/nocts_cata_mod_DDA/Vehicles/c_vehicle_groups.json
+++ b/nocts_cata_mod_DDA/Vehicles/c_vehicle_groups.json
@@ -24,5 +24,10 @@
     "id": "highway",
     "type": "vehicle_group",
     "vehicles": [ [ "surv_tachanka", 5 ] ]
+  },
+  {
+    "id": "command_center_rvs",
+    "type": "vehicle_group",
+    "vehicles": [ [ "rv", 50 ], [ "lux_rv", 25 ], [ "surv_rv", 15 ], [ "c_surv_rv_military", 10 ] ]
   }
 ]


### PR DESCRIPTION
* Made description of makeshift power armor clarify what it does when active a bit better.
* Added Large size to Bio-Weapon Beta via a tweak to the Unyielding mutation unique to them.
* Adjusted mi-go carapace armor to fit the inner layer instead of armor, fitting the idea of it being a second skin and making it more usable with other armor types.
* Added a mutation-from-enchantment to carapace armor that adds some extra cooling if the user is overheating, and set active version to have zero warmth.
* Likewise reflavored the exo-wings a bit to justify them going on the waist slot instead of strapped, so that they don't compete with precious backpacks.
* Gave both carapace armor and ex-wings the `ONLY_ONE` flag.
* Allowed padding the scout suits and survivor cowboy hat with steel and/or superalloy.
* Defined `repairs_like` for several fancy items, excluding stuff that's already craftable (thus not needing it) or where its vanilla counterpart is also hard to repair.
* Defined a vehicle group to allow any of the various RV types to spawn at the makeshift command center, instead of only ever luxury RVs.
* Added a facuet to the autoclave cart's water tank, fixing the water being inaccessible for sterilizing in BN.
* Swapped `weight_capacity_modifier` of active carapace armor and makeshift power armor.