### PR TITLE
Grid survivor stations for BN version

### DIFF
--- a/nocts_cata_mod_BN/Terrain/c_construction.json
+++ b/nocts_cata_mod_BN/Terrain/c_construction.json
@@ -1,0 +1,21 @@
+[
+  {
+    "type": "construction_group",
+    "id": "place_survstation",
+    "name": "Place survivor's station"
+  },
+  {
+    "type": "construction",
+    "id": "c_constr_gridsurvstation",
+    "group": "place_survstation",
+    "category": "WORKSHOP",
+    "required_skills": [ [ "electronics", 1 ] ],
+    "time": "30 m",
+    "qualities": [ [ { "id": "SCREW", "level": 1 } ] ],
+    "using": [ [ "soldering_standard", 20 ] ],
+    "components": [ [ [ "surv_station", 1 ] ], [ [ "cable", 5 ] ], [ [ "solder_wire", 10 ] ] ],
+    "pre_note": "Will only work if constructed in/on a building that has an electric grid with a mounted battery.",
+    "pre_special": "check_empty",
+    "post_furniture": "f_surv_station"
+  }
+]

--- a/nocts_cata_mod_BN/Terrain/c_furniture.json
+++ b/nocts_cata_mod_BN/Terrain/c_furniture.json
@@ -1,0 +1,44 @@
+[
+  {
+    "type": "furniture",
+    "id": "f_surv_station",
+    "looks_like": "surv_station",
+    "name": "grid survivor's station",
+    "symbol": "&",
+    "description": "A makeshift vehicle mountable station comprised of many utilities, all compressed into a single unit.  Draws power from the electrical grid, combining the functions of a kitchen unit, forge, welding rig, FOODCO kitchen buddy, and a chemistry lab.  Has no cargo space due to all the components it is made out of.",
+    "color": "blue",
+    "move_cost_mod": -1,
+    "coverage": 80,
+    "required_str": 10,
+    "crafting_pseudo_item": [
+      "fake_oven",
+      "fake_gridforge",
+      "fake_gridwelder",
+      "fake_gridsolderingiron",
+      "fake_gridfood_processor",
+      "fake_griddehydrator",
+      "fake_gridvac_sealer",
+      "fake_gridwater_purifier",
+      "press",
+      "fake_chemistry_set",
+      "fake_gridelectrolysis_kit"
+    ],
+    "examine_action": "use_furn_fake_item",
+    "flags": [ "NOITEM", "BLOCKSDOOR", "MINEABLE", "EASY_DECONSTRUCT" ],
+    "deconstruct": { "items": [ { "item": "surv_station", "count": 1 }, { "item": "cable", "charges": 5 } ] },
+    "bash": {
+      "str_min": 18,
+      "str_max": 50,
+      "sound": "metal screeching!",
+      "sound_fail": "clang!",
+      "items": [
+        { "item": "steel_lump", "count": [ 30, 40 ] },
+        { "item": "steel_chunk", "count": [ 30, 40 ] },
+        { "item": "scrap", "count": [ 30, 40 ] },
+        { "item": "circuit", "count": [ 30, 40 ] },
+        { "item": "e_scrap", "count": [ 30, 40 ] },
+        { "item": "amplifier", "count": [ 30, 40 ] }
+      ]
+    }
+  }
+]

--- a/nocts_cata_mod_BN/Vehicles/c_vehicle_parts.json
+++ b/nocts_cata_mod_BN/Vehicles/c_vehicle_parts.json
@@ -39,15 +39,15 @@
     "//": "Actual item",
     "name": "survivor's station",
     "description": "A makeshift vehicle mountable station comprised of many utilities, all compressed into a single unit.  Has no cargo space due to all the components it is made out of.",
-    "weight": 123134,
+    "weight": "123134 g",
     "to_hit": -2,
     "color": "light_red",
     "symbol": "&",
     "looks_like": "craftrig",
     "material": [ "steel" ],
-    "volume": 120,
+    "volume": "30 L",
     "category": "veh_parts",
-    "price": 80000
+    "price": "800 USD"
   },
   {
     "type": "vehicle_part",

--- a/nocts_cata_mod_DDA/Vehicles/c_vehicle_parts.json
+++ b/nocts_cata_mod_DDA/Vehicles/c_vehicle_parts.json
@@ -37,15 +37,15 @@
     "//": "Actual item",
     "name": "survivor's station",
     "description": "A makeshift vehicle mountable station comprised of many utilities, all compressed into a single unit.  Has no cargo space due to all the components it is made out of.",
-    "weight": 123134,
+    "weight": "123134 g",
     "to_hit": -2,
     "color": "light_red",
     "symbol": "&",
     "looks_like": "craftrig",
     "material": [ "steel" ],
-    "volume": 120,
+    "volume": "30 L",
     "category": "veh_parts",
-    "price": 80000
+    "price": "800 USD"
   },
   {
     "type": "vehicle_part",


### PR DESCRIPTION
Added grid-usable survivor's stations to BN version. Can't be merged yet as it depends on https://github.com/cataclysmbnteam/Cataclysm-BN/pull/2172 and https://github.com/cataclysmbnteam/Cataclysm-BN/pull/2187 which will need to be merged first, and its construction category is also consistent with https://github.com/cataclysmbnteam/Cataclysm-BN/pull/2155.

Also belatedly updated the survivor's station item to use string weight, volume, and price; along with updating description to remind player what crafting stations are combined into it.