### PR TITLE
Fix mono-sword in DDA version

### DIFF
--- a/nocts_cata_mod_DDA/Surv_help/c_bionics.json
+++ b/nocts_cata_mod_DDA/Surv_help/c_bionics.json
@@ -53,8 +53,8 @@
     "techniques": [ "RAPID", "WBLOCK_2" ],
     "volume": "2250 ml",
     "cutting": 48,
-    "flags": [ "NO_UNWIELD", "NO_DROP", "UNBREAKABLE_MELEE", "TRADER_AVOID" ],
-    "qualities": [ [ "CUT", 1 ], [ "BUTCHER", 20 ] ]
+    "flags": [ "BIONIC_WEAPON", "UNBREAKABLE_MELEE", "TRADER_AVOID" ],
+    "qualities": [ [ "CUT", 2 ], [ "BUTCHER", 20 ] ]
   },
   {
     "type": "bionic",

--- a/nocts_cata_mod_DDA/Weapons/c_melee.json
+++ b/nocts_cata_mod_DDA/Weapons/c_melee.json
@@ -18,7 +18,7 @@
     "cutting": 32,
     "to_hit": 2,
     "flags": [ "UNBREAKABLE_MELEE", "SHEATH_KNIFE" ],
-    "qualities": [ [ "CUT", 1 ], [ "BUTCHER", 22 ] ],
+    "qualities": [ [ "CUT", 2 ], [ "BUTCHER", 22 ] ],
     "gunmod_data": {
       "location": "underbarrel",
       "mod_targets": [ "shotgun", "rifle", "smg", "crossbow" ],
@@ -45,7 +45,7 @@
     "cutting": 44,
     "to_hit": 2,
     "flags": [ "UNBREAKABLE_MELEE", "SHEATH_SWORD" ],
-    "qualities": [ [ "CUT", 1 ], [ "BUTCHER", 20 ] ],
+    "qualities": [ [ "CUT", 2 ], [ "BUTCHER", 20 ] ],
     "gunmod_data": {
       "location": "underbarrel",
       "mod_targets": [ "shotgun", "rifle", "smg", "crossbow" ],
@@ -70,7 +70,7 @@
     "bashing": 12,
     "cutting": 14,
     "flags": [ "STAB", "UNARMED_WEAPON", "UNBREAKABLE_MELEE" ],
-    "qualities": [ [ "CUT", 1 ], [ "BUTCHER", 12 ] ]
+    "qualities": [ [ "CUT", 2 ], [ "BUTCHER", 12 ] ]
   },
   {
     "type": "TOOL",
@@ -180,7 +180,7 @@
     "bashing": 2,
     "cutting": 20,
     "flags": [ "UNARMED_WEAPON", "DURABLE_MELEE", "SHEATH_KNIFE" ],
-    "qualities": [ [ "CUT", 1 ], [ "CUT_FINE", 4 ], [ "BUTCHER", 25 ] ]
+    "qualities": [ [ "CUT", 2 ], [ "CUT_FINE", 4 ], [ "BUTCHER", 25 ] ]
   },
   {
     "id": "greatsword_makeshift",


### PR DESCRIPTION
* Updated flags for the bionic sword weapon so it should work right in DDA again. Fixes https://github.com/Noctifer-de-Mortem/nocts_cata_mod/issues/456
* Also belatedly implemented use of level-2 cutting quality for a few weapons that fit for it in DDA version, since that's a thing over there.