### PR TITLE
Fix stealth cloak in DDA version again

### DIFF
--- a/nocts_cata_mod_DDA/Surv_help/c_armor.json
+++ b/nocts_cata_mod_DDA/Surv_help/c_armor.json
@@ -318,15 +318,6 @@
     "flags": [ "TRADER_AVOID", "NO_SALVAGE" ]
   },
   {
-    "id": "c_stealth_cloak",
-    "//": "Reinstated for use because it turns out ench_effects called directly from relics is broken in DDA.",
-    "type": "enchantment",
-    "has": "WORN",
-    "condition": "ALWAYS",
-    "values": [ { "value": "SPEED", "add": -20 }, { "value": "STRENGTH", "add": -4 }, { "value": "DEXTERITY", "add": -4 } ],
-    "ench_effects": [ { "effect": "invisibility", "intensity": 1 } ]
-  },
-  {
     "id": "acs_74_stealth_cloak_on",
     "type": "TOOL_ARMOR",
     "name": { "str": "ACS-74 stealth cloak" },
@@ -344,7 +335,16 @@
     "warmth": 15,
     "material_thickness": 1,
     "environmental_protection": 4,
-    "relic_data": { "passive_effects": [ { "id": "c_stealth_cloak" } ] },
+    "relic_data": {
+      "passive_effects": [
+        {
+          "has": "WORN",
+          "condition": "ALWAYS",
+          "values": [ { "value": "SPEED", "add": -20 }, { "value": "STRENGTH", "add": -4 }, { "value": "DEXTERITY", "add": -4 } ],
+          "ench_effects": [ { "effect": "invisibility", "intensity": 1 } ]
+        }
+      ]
+    },
     "flags": [ "OVERSIZE", "HOOD", "WATERPROOF", "OUTER", "VARSIZE", "PADDED" ],
     "armor": [ { "encumbrance": 15, "coverage": 75, "covers": [ "leg_l", "leg_r", "torso", "arm_l", "arm_r", "head" ] } ]
   },

--- a/nocts_cata_mod_DDA/legacy.json
+++ b/nocts_cata_mod_DDA/legacy.json
@@ -112,19 +112,19 @@
     "id": "stealth_cloak_f",
     "copy-from": "acs_74_stealth_cloak_on",
     "type": "ARMOR",
-    "name": "stealth cloak"
+    "name": "obsolete stealth cloak"
   },
   {
     "id": "stealth_cloak",
     "copy-from": "acs_74_stealth_cloak_on",
     "type": "ARMOR",
-    "name": "stealth cloak (on)"
+    "name": "obsolete stealth cloak (on)"
   },
   {
     "id": "flesh_blade_on",
     "copy-from": "flesh_blade",
     "type": "ARMOR",
-    "name": "biological sword"
+    "name": "obsolete biological sword"
   },
   {
     "id": "mold_metal",
@@ -1006,5 +1006,13 @@
     "pocket_data": [ { "pocket_type": "MAGAZINE", "rigid": true, "ammo_restriction": { "battery": 20 } } ],
     "reload_time": 100,
     "flags": [ "MAG_COMPACT", "MAG_DESTROY", "NO_UNLOAD" ]
+  },
+  {
+    "id": "c_stealth_cloak",
+    "type": "enchantment",
+    "has": "WORN",
+    "condition": "ALWAYS",
+    "values": [ { "value": "SPEED", "add": -20 }, { "value": "STRENGTH", "add": -4 }, { "value": "DEXTERITY", "add": -4 } ],
+    "ench_effects": [ { "effect": "invisibility", "intensity": 1 } ]
   }
 ]


### PR DESCRIPTION
Converted stealth cloak in DDA version to call its relic data directly instead of using an enchantment. Code comment in the enchantment ID indicates we did that because effects from relic data didn't work at one point, but it works now when enchantments called directly likely that still don't work and I'm not sure if they've EVER worked.

Also marked some obsolete items in the legacy file as such in their item name to reduce confusion for people debugging.

Fixes https://github.com/Noctifer-de-Mortem/nocts_cata_mod/issues/461