### PR TITLE
Update Minie ball ammo in BN version

### DIFF
--- a/nocts_cata_mod_BN/Weapons/c_ammo.json
+++ b/nocts_cata_mod_BN/Weapons/c_ammo.json
@@ -9,8 +9,7 @@
     "weight": "55 g",
     "price": "25 USD",
     "price_postapoc": "15 USD",
-    "damage": { "damage_type": "bullet", "armor_penetration": 12 },
-    "proportional": { "range": 4.0, "dispersion": 0.89, "recoil": 2.0 },
+    "proportional": { "damage": { "damage_type": "bullet", "armor_penetration": 1.25 }, "range": 4.0, "dispersion": 0.89, "recoil": 2.0 },
     "extend": { "effects": [ "RECYCLED" ] }
   },
   {


### PR DESCRIPTION
Now that baseline paper cartridges in BN have some baseline armor penetration, shifted their stats a bit to not fully override.

DDA version untouched since no arpen on their version.