### PR TITLE
Fix survivor's cookbook reads too fast

### DIFF
--- a/nocts_cata_mod_DDA/Surv_help/c_tools.json
+++ b/nocts_cata_mod_DDA/Surv_help/c_tools.json
@@ -720,7 +720,7 @@
     "looks_like": "recipe_melee",
     "material": [ "paper" ],
     "to_hit": -2,
-    "time": 40,
+    "time": 40 m,
     "fun": -1
   },
   {

--- a/nocts_cata_mod_DDA/Surv_help/c_tools.json
+++ b/nocts_cata_mod_DDA/Surv_help/c_tools.json
@@ -720,7 +720,7 @@
     "looks_like": "recipe_melee",
     "material": [ "paper" ],
     "to_hit": -2,
-    "time": 40 m,
+    "time": "40 m",
     "fun": -1
   },
   {


### PR DESCRIPTION
Currently reading `survivor's cookbook` for one time takes 40 seconds. This is irrational and imbalanced, since this can level up crafting skill insanely quickly. I make it take 40 minutes to read once.