### PR TITLE
Fishing string obsolete flags

### DIFF
--- a/nocts_cata_mod_DDA/Surv_help/c_tools.json
+++ b/nocts_cata_mod_DDA/Surv_help/c_tools.json
@@ -595,8 +595,7 @@
     "pocket_data": [ { "pocket_type": "MAGAZINE", "ammo_restriction": { "fish_bait": 1 } } ],
     "charges_per_use": 1,
     "ammo": [ "fish_bait" ],
-    "flags": [ "FISH_POOR" ],
-    "use_action": "FISH_ROD",
+	  "qualities": [ [ "FISHING_ROD", 1 ] ],
     "to_hit": -1
   },
   {

--- a/nocts_cata_mod_DDA/Surv_help/c_tools.json
+++ b/nocts_cata_mod_DDA/Surv_help/c_tools.json
@@ -595,7 +595,7 @@
     "pocket_data": [ { "pocket_type": "MAGAZINE", "ammo_restriction": { "fish_bait": 1 } } ],
     "charges_per_use": 1,
     "ammo": [ "fish_bait" ],
-	  "qualities": [ [ "FISHING_ROD", 1 ] ],
+    "qualities": [ [ "FISHING_ROD", 1 ] ],
     "to_hit": -1
   },
   {


### PR DESCRIPTION
Due to merge commit 4d5e209 to the main experimental branch flag fish_poor&fish_good was eliminated. Usage is nested to qualities of "fishing_rod".