### PR TITLE
DDA recipe update, split up encampments more

### DIFF
--- a/nocts_cata_mod_BN/Terrain/Survivor_Encampments.json
+++ b/nocts_cata_mod_BN/Terrain/Survivor_Encampments.json
@@ -122,7 +122,43 @@
   {
     "type": "mapgen",
     "method": "json",
-    "om_terrain": [ "Survivor_Encampment" ],
+    "om_terrain": [ "Survivor_Encampment_roof" ],
+    "weight": 1000,
+    "object": {
+      "rows": [
+        "                        ",
+        "                        ",
+        "                        ",
+        "                        ",
+        "  .....                 ",
+        "  .....                 ",
+        "  .....                 ",
+        "  ......         ,,,,,  ",
+        "  ......         ,,,,,  ",
+        "  .=....         ,,,,,  ",
+        "  ......         ,,,,,  ",
+        "  ......         ,,,,,  ",
+        "                        ",
+        "  ....................  ",
+        "  ....................  ",
+        "  ....................  ",
+        "  ....................  ",
+        "  ....................  ",
+        "  ....................  ",
+        "  ....................  ",
+        "  ....................  ",
+        "                        ",
+        "                        ",
+        "                        "
+      ],
+      "palettes": [ "roof_palette" ],
+      "terrain": { ",": "t_thatch_roof" }
+    }
+  },
+  {
+    "type": "mapgen",
+    "method": "json",
+    "om_terrain": [ "Survivor_Encampment_robotics" ],
     "//": "Variant two, house and equipment sheds.  These are infested with renegade robots.",
     "weight": 1000,
     "object": {
@@ -221,8 +257,7 @@
         "n": "f_cupboard",
         "o": "f_oven",
         "s": "f_sink",
-        "t": "f_toilet",
-        "v": "f_woodstove"
+        "t": "f_toilet"
       },
       "set": [ { "point": "trap", "id": "tr_rollmat", "x": 12, "y": 13 }, { "point": "trap", "id": "tr_rollmat", "x": 12, "y": 17 } ],
       "place_toilets": [ { "x": 6, "y": 20 } ],
@@ -283,7 +318,43 @@
   {
     "type": "mapgen",
     "method": "json",
-    "om_terrain": [ "Survivor_Encampment" ],
+    "om_terrain": [ "Survivor_Encampment_robotics_roof" ],
+    "weight": 1000,
+    "object": {
+      "rows": [
+        "                        ",
+        "                        ",
+        "                        ",
+        "  ........    ,,,,,,,,  ",
+        "  ........    ,,,,,,,,  ",
+        "  ........    ,,,,,,,,  ",
+        "  ........    ,,,,,,,,  ",
+        "  ........    ,,,,,,,,  ",
+        "  ........    ,,,,,,,,  ",
+        "  ........              ",
+        "  ........       ,,,,   ",
+        "  ........      ,,,,,,  ",
+        "  ........      ,,,,,,  ",
+        "  ........      ,,,,,,  ",
+        "  ........      ,,,,,,  ",
+        "  ........       ,,,,   ",
+        "  ........              ",
+        "  ........     ,,,,,,,  ",
+        "  ........     ,,,,,,,  ",
+        "  ........     ,,,,,,,  ",
+        "  ........     ,,,,,,,  ",
+        "  ........     ,,,,,,,  ",
+        "                        ",
+        "                        "
+      ],
+      "palettes": [ "roof_palette" ],
+      "terrain": { ",": "t_metal_flat_roof" }
+    }
+  },
+  {
+    "type": "mapgen",
+    "method": "json",
+    "om_terrain": [ "Survivor_Encampment_bandits" ],
     "//": "Variant three, hostile NPCs.  Slightly closer to the traditional encampment layout.",
     "weight": 1000,
     "object": {
@@ -413,7 +484,42 @@
   {
     "type": "mapgen",
     "method": "json",
-    "om_terrain": [ "Survivor_Encampment" ],
+    "om_terrain": [ "Survivor_Encampment_bandits_roof" ],
+    "weight": 1000,
+    "object": {
+      "rows": [
+        "                        ",
+        "                        ",
+        "                        ",
+        "                        ",
+        "                        ",
+        "                        ",
+        "  .......               ",
+        "  .......      .......  ",
+        "  .......      ...=...  ",
+        "  .......      .......  ",
+        "  .......      .......  ",
+        "  .......      .......  ",
+        "  .......               ",
+        "  .......      .......  ",
+        "  .......      .......  ",
+        "  .......      .....=.  ",
+        "  .......      .......  ",
+        "  .......      .......  ",
+        "  .......               ",
+        "               .......  ",
+        "               .......  ",
+        "               .......  ",
+        "                        ",
+        "                        "
+      ],
+      "palettes": [ "roof_palette" ]
+    }
+  },
+  {
+    "type": "mapgen",
+    "method": "json",
+    "om_terrain": [ "Survivor_Encampment_overrun" ],
     "//": "Variant four, zombie takeover.  Incomplete version based off the original design, implies they were struggling with an outbreak while still under construction.",
     "weight": 1000,
     "object": {
@@ -539,8 +645,43 @@
   {
     "type": "mapgen",
     "method": "json",
+    "om_terrain": [ "Survivor_Encampment_overrun_roof" ],
+    "weight": 1000,
+    "object": {
+      "rows": [
+        "                        ",
+        "                        ",
+        "                        ",
+        "  .......      .......  ",
+        "  .......      ...=...  ",
+        "  .......      .......  ",
+        "  .......      .......  ",
+        "  .......      .......  ",
+        "                        ",
+        "  .......      .......  ",
+        "  .......      .......  ",
+        "  .......      .....=.  ",
+        "  .......      .......  ",
+        "  .......      .......  ",
+        "                        ",
+        "                        ",
+        "                        ",
+        "                        ",
+        "                        ",
+        "                        ",
+        "                        ",
+        "                        ",
+        "                        ",
+        "                        "
+      ],
+      "palettes": [ "roof_palette" ]
+    }
+  },
+  {
+    "type": "mapgen",
+    "method": "json",
     "om_terrain": [ "Survivor_Encampment_2" ],
-    "//": "Prepper NPCs variant.  This version will remain rooted in a separate overmap special, to keep their spawns unique.",
+    "//": "Prepper NPCs variant.",
     "weight": 1000,
     "object": {
       "faction_owner": [ { "id": "preppers", "x": [ 2, 22 ], "y": [ 3, 22 ] } ],

--- a/nocts_cata_mod_BN/Terrain/overmap_special.json
+++ b/nocts_cata_mod_BN/Terrain/overmap_special.json
@@ -69,7 +69,7 @@
     "locations": [ "wilderness" ],
     "city_distance": [ 10, -1 ],
     "city_sizes": [ 0, 20 ],
-    "occurrences": [ 25, 100 ],
+    "occurrences": [ 50, 100 ],
     "flags": [ "CLASSIC", "UNIQUE" ]
   },
   {

--- a/nocts_cata_mod_BN/Terrain/overmap_special.json
+++ b/nocts_cata_mod_BN/Terrain/overmap_special.json
@@ -23,12 +23,54 @@
   {
     "type": "overmap_special",
     "id": "Survivor_Encampment",
-    "overmaps": [ { "point": [ 0, 0, 0 ], "overmap": "Survivor_Encampment_north" } ],
+    "overmaps": [
+      { "point": [ 0, 0, 0 ], "overmap": "Survivor_Encampment_north" },
+      { "point": [ 0, 0, 1 ], "overmap": "Survivor_Encampment_roof_north" }
+    ],
     "locations": [ "wilderness" ],
     "city_distance": [ 10, -1 ],
     "city_sizes": [ 0, 20 ],
-    "occurrences": [ 0, 5 ],
-    "flags": [ "CLASSIC" ]
+    "occurrences": [ 25, 100 ],
+    "flags": [ "CLASSIC", "UNIQUE" ]
+  },
+  {
+    "type": "overmap_special",
+    "id": "Survivor_Encampment_robotics",
+    "overmaps": [
+      { "point": [ 0, 0, 0 ], "overmap": "Survivor_Encampment_robotics_north" },
+      { "point": [ 0, 0, 1 ], "overmap": "Survivor_Encampment_robotics_roof_north" }
+    ],
+    "locations": [ "wilderness" ],
+    "city_distance": [ 10, -1 ],
+    "city_sizes": [ 0, 20 ],
+    "occurrences": [ 25, 100 ],
+    "flags": [ "CLASSIC", "UNIQUE" ]
+  },
+  {
+    "type": "overmap_special",
+    "id": "Survivor_Encampment_overrun",
+    "overmaps": [
+      { "point": [ 0, 0, 0 ], "overmap": "Survivor_Encampment_overrun_north" },
+      { "point": [ 0, 0, 1 ], "overmap": "Survivor_Encampment_overrun_roof_north" }
+    ],
+    "locations": [ "wilderness" ],
+    "city_distance": [ 10, -1 ],
+    "city_sizes": [ 0, 20 ],
+    "occurrences": [ 25, 100 ],
+    "flags": [ "CLASSIC", "UNIQUE" ]
+  },
+  {
+    "type": "overmap_special",
+    "id": "Survivor_Encampment_bandits",
+    "overmaps": [
+      { "point": [ 0, 0, 0 ], "overmap": "Survivor_Encampment_bandits_north" },
+      { "point": [ 0, 0, 1 ], "overmap": "Survivor_Encampment_bandits_roof_north" }
+    ],
+    "locations": [ "wilderness" ],
+    "city_distance": [ 10, -1 ],
+    "city_sizes": [ 0, 20 ],
+    "occurrences": [ 25, 100 ],
+    "flags": [ "CLASSIC", "UNIQUE" ]
   },
   {
     "type": "overmap_special",

--- a/nocts_cata_mod_BN/Terrain/overmap_terrain.json
+++ b/nocts_cata_mod_BN/Terrain/overmap_terrain.json
@@ -30,6 +30,16 @@
     "extras": "surv_encamp"
   },
   {
+    "id": "Survivor_Encampment_robotics",
+    "copy-from": "Survivor_Encampment",
+    "type": "overmap_terrain"
+  },
+  {
+    "id": "Survivor_Encampment_overrun",
+    "copy-from": "Survivor_Encampment",
+    "type": "overmap_terrain"
+  },
+  {
     "id": "Survivor_Encampment_2",
     "type": "overmap_terrain",
     "name": "Survivor Encampment",
@@ -38,10 +48,35 @@
     "see_cost": 5
   },
   {
-    "id": "Survivor_Encampment_2_roof",
+    "id": "Survivor_Encampment_bandits",
+    "copy-from": "Survivor_Encampment_2",
+    "type": "overmap_terrain"
+  },
+  {
+    "id": "Survivor_Encampment_roof",
     "copy-from": "Survivor_Encampment_2",
     "type": "overmap_terrain",
     "name": "Survivor Encampment roof"
+  },
+  {
+    "id": "Survivor_Encampment_robotics_roof",
+    "copy-from": "Survivor_Encampment_roof",
+    "type": "overmap_terrain"
+  },
+  {
+    "id": "Survivor_Encampment_bandits_roof",
+    "copy-from": "Survivor_Encampment_roof",
+    "type": "overmap_terrain"
+  },
+  {
+    "id": "Survivor_Encampment_overrun_roof",
+    "copy-from": "Survivor_Encampment_roof",
+    "type": "overmap_terrain"
+  },
+  {
+    "id": "Survivor_Encampment_2_roof",
+    "copy-from": "Survivor_Encampment_roof",
+    "type": "overmap_terrain"
   },
   {
     "id": "Bio_Weapon_Lab_1",

--- a/nocts_cata_mod_DDA/Recipe/c_recipes.json
+++ b/nocts_cata_mod_DDA/Recipe/c_recipes.json
@@ -1425,7 +1425,7 @@
       { "proficiency": "prof_blacksmithing" },
       { "proficiency": "prof_gunsmithing_basic" },
       { "proficiency": "prof_gunsmithing_antique" },
-      { "proficiency": "prof_carving", "time_multiplier": 1.5, "fail_multiplier": 1.15 }
+      { "proficiency": "prof_carving" }
     ],
     "tools": [ [ [ "tongs", -1 ] ], [ [ "swage", -1 ] ], [ [ "small_repairkit", 120 ], [ "large_repairkit", 120 ] ] ],
     "components": [ [ [ "2x4", 2 ] ], [ [ "pipe", 2 ] ], [ [ "spring", 2 ] ], [ [ "pilot_light", 1 ] ] ]

--- a/nocts_cata_mod_DDA/Terrain/Survivor_Encampments.json
+++ b/nocts_cata_mod_DDA/Terrain/Survivor_Encampments.json
@@ -122,7 +122,43 @@
   {
     "type": "mapgen",
     "method": "json",
-    "om_terrain": [ "Survivor_Encampment" ],
+    "om_terrain": [ "Survivor_Encampment_roof" ],
+    "weight": 1000,
+    "object": {
+      "rows": [
+        "                        ",
+        "                        ",
+        "                        ",
+        "                        ",
+        "  .....                 ",
+        "  .....                 ",
+        "  .....                 ",
+        "  ......         ,,,,,  ",
+        "  ......         ,,,,,  ",
+        "  .=....         ,,,,,  ",
+        "  ......         ,,,,,  ",
+        "  ......         ,,,,,  ",
+        "                        ",
+        "  ....................  ",
+        "  ....................  ",
+        "  ....................  ",
+        "  ....................  ",
+        "  ....................  ",
+        "  ....................  ",
+        "  ....................  ",
+        "  ....................  ",
+        "                        ",
+        "                        ",
+        "                        "
+      ],
+      "palettes": [ "roof_palette" ],
+      "terrain": { ",": "t_thatch_roof" }
+    }
+  },
+  {
+    "type": "mapgen",
+    "method": "json",
+    "om_terrain": [ "Survivor_Encampment_robotics" ],
     "//": "Variant two, house and equipment sheds.  These are infested with renegade robots.",
     "weight": 1000,
     "object": {
@@ -222,8 +258,7 @@
         "n": "f_cupboard",
         "o": "f_oven",
         "s": "f_sink",
-        "t": "f_toilet",
-        "v": "f_woodstove"
+        "t": "f_toilet"
       },
       "set": [ { "point": "trap", "id": "tr_rollmat", "x": 12, "y": 13 }, { "point": "trap", "id": "tr_rollmat", "x": 12, "y": 17 } ],
       "place_toilets": [ { "x": 6, "y": 20 } ],
@@ -285,7 +320,43 @@
   {
     "type": "mapgen",
     "method": "json",
-    "om_terrain": [ "Survivor_Encampment" ],
+    "om_terrain": [ "Survivor_Encampment_robotics_roof" ],
+    "weight": 1000,
+    "object": {
+      "rows": [
+        "                        ",
+        "                        ",
+        "                        ",
+        "  ........    ,,,,,,,,  ",
+        "  ........    ,,,,,,,,  ",
+        "  ........    ,,,,,,,,  ",
+        "  ........    ,,,,,,,,  ",
+        "  ........    ,,,,,,,,  ",
+        "  ........    ,,,,,,,,  ",
+        "  ........              ",
+        "  ........       ,,,,   ",
+        "  ........      ,,,,,,  ",
+        "  ........      ,,,,,,  ",
+        "  ........      ,,,,,,  ",
+        "  ........      ,,,,,,  ",
+        "  ........       ,,,,   ",
+        "  ........              ",
+        "  ........     ,,,,,,,  ",
+        "  ........     ,,,,,,,  ",
+        "  ........     ,,,,,,,  ",
+        "  ........     ,,,,,,,  ",
+        "  ........     ,,,,,,,  ",
+        "                        ",
+        "                        "
+      ],
+      "palettes": [ "roof_palette" ],
+      "terrain": { ",": "t_metal_flat_roof" }
+    }
+  },
+  {
+    "type": "mapgen",
+    "method": "json",
+    "om_terrain": [ "Survivor_Encampment_bandits" ],
     "//": "Variant three, hostile NPCs.  Slightly closer to the traditional encampment layout.",
     "weight": 1000,
     "object": {
@@ -415,7 +486,42 @@
   {
     "type": "mapgen",
     "method": "json",
-    "om_terrain": [ "Survivor_Encampment" ],
+    "om_terrain": [ "Survivor_Encampment_bandits_roof" ],
+    "weight": 1000,
+    "object": {
+      "rows": [
+        "                        ",
+        "                        ",
+        "                        ",
+        "                        ",
+        "                        ",
+        "                        ",
+        "  .......               ",
+        "  .......      .......  ",
+        "  .......      ...=...  ",
+        "  .......      .......  ",
+        "  .......      .......  ",
+        "  .......      .......  ",
+        "  .......               ",
+        "  .......      .......  ",
+        "  .......      .......  ",
+        "  .......      .....=.  ",
+        "  .......      .......  ",
+        "  .......      .......  ",
+        "  .......               ",
+        "               .......  ",
+        "               .......  ",
+        "               .......  ",
+        "                        ",
+        "                        "
+      ],
+      "palettes": [ "roof_palette" ]
+    }
+  },
+  {
+    "type": "mapgen",
+    "method": "json",
+    "om_terrain": [ "Survivor_Encampment_overrun" ],
     "//": "Variant four, zombie takeover.  Incomplete version based off the original design, implies they were struggling with an outbreak while still under construction.",
     "weight": 1000,
     "object": {
@@ -541,8 +647,43 @@
   {
     "type": "mapgen",
     "method": "json",
+    "om_terrain": [ "Survivor_Encampment_overrun_roof" ],
+    "weight": 1000,
+    "object": {
+      "rows": [
+        "                        ",
+        "                        ",
+        "                        ",
+        "  .......      .......  ",
+        "  .......      ...=...  ",
+        "  .......      .......  ",
+        "  .......      .......  ",
+        "  .......      .......  ",
+        "                        ",
+        "  .......      .......  ",
+        "  .......      .......  ",
+        "  .......      .....=.  ",
+        "  .......      .......  ",
+        "  .......      .......  ",
+        "                        ",
+        "                        ",
+        "                        ",
+        "                        ",
+        "                        ",
+        "                        ",
+        "                        ",
+        "                        ",
+        "                        ",
+        "                        "
+      ],
+      "palettes": [ "roof_palette" ]
+    }
+  },
+  {
+    "type": "mapgen",
+    "method": "json",
     "om_terrain": [ "Survivor_Encampment_2" ],
-    "//": "Prepper NPCs variant.  This version will remain rooted in a separate overmap special, to keep their spawns unique.",
+    "//": "Prepper NPCs variant.",
     "weight": 1000,
     "object": {
       "faction_owner": [ { "id": "preppers", "x": [ 2, 22 ], "y": [ 3, 22 ] } ],

--- a/nocts_cata_mod_DDA/Terrain/overmap_special.json
+++ b/nocts_cata_mod_DDA/Terrain/overmap_special.json
@@ -69,7 +69,7 @@
     "locations": [ "wilderness" ],
     "city_distance": [ 10, -1 ],
     "city_sizes": [ 0, 20 ],
-    "occurrences": [ 25, 100 ],
+    "occurrences": [ 50, 100 ],
     "flags": [ "CLASSIC", "UNIQUE" ]
   },
   {

--- a/nocts_cata_mod_DDA/Terrain/overmap_special.json
+++ b/nocts_cata_mod_DDA/Terrain/overmap_special.json
@@ -23,12 +23,54 @@
   {
     "type": "overmap_special",
     "id": "Survivor_Encampment",
-    "overmaps": [ { "point": [ 0, 0, 0 ], "overmap": "Survivor_Encampment_north" } ],
+    "overmaps": [
+      { "point": [ 0, 0, 0 ], "overmap": "Survivor_Encampment_north" },
+      { "point": [ 0, 0, 1 ], "overmap": "Survivor_Encampment_roof_north" }
+    ],
     "locations": [ "wilderness" ],
     "city_distance": [ 10, -1 ],
     "city_sizes": [ 0, 20 ],
-    "occurrences": [ 0, 5 ],
-    "flags": [ "CLASSIC" ]
+    "occurrences": [ 25, 100 ],
+    "flags": [ "CLASSIC", "UNIQUE" ]
+  },
+  {
+    "type": "overmap_special",
+    "id": "Survivor_Encampment_robotics",
+    "overmaps": [
+      { "point": [ 0, 0, 0 ], "overmap": "Survivor_Encampment_robotics_north" },
+      { "point": [ 0, 0, 1 ], "overmap": "Survivor_Encampment_robotics_roof_north" }
+    ],
+    "locations": [ "wilderness" ],
+    "city_distance": [ 10, -1 ],
+    "city_sizes": [ 0, 20 ],
+    "occurrences": [ 25, 100 ],
+    "flags": [ "CLASSIC", "UNIQUE" ]
+  },
+  {
+    "type": "overmap_special",
+    "id": "Survivor_Encampment_overrun",
+    "overmaps": [
+      { "point": [ 0, 0, 0 ], "overmap": "Survivor_Encampment_overrun_north" },
+      { "point": [ 0, 0, 1 ], "overmap": "Survivor_Encampment_overrun_roof_north" }
+    ],
+    "locations": [ "wilderness" ],
+    "city_distance": [ 10, -1 ],
+    "city_sizes": [ 0, 20 ],
+    "occurrences": [ 25, 100 ],
+    "flags": [ "CLASSIC", "UNIQUE" ]
+  },
+  {
+    "type": "overmap_special",
+    "id": "Survivor_Encampment_bandits",
+    "overmaps": [
+      { "point": [ 0, 0, 0 ], "overmap": "Survivor_Encampment_bandits_north" },
+      { "point": [ 0, 0, 1 ], "overmap": "Survivor_Encampment_bandits_roof_north" }
+    ],
+    "locations": [ "wilderness" ],
+    "city_distance": [ 10, -1 ],
+    "city_sizes": [ 0, 20 ],
+    "occurrences": [ 25, 100 ],
+    "flags": [ "CLASSIC", "UNIQUE" ]
   },
   {
     "type": "overmap_special",

--- a/nocts_cata_mod_DDA/Terrain/overmap_terrain.json
+++ b/nocts_cata_mod_DDA/Terrain/overmap_terrain.json
@@ -30,6 +30,16 @@
     "extras": "surv_encamp"
   },
   {
+    "id": "Survivor_Encampment_robotics",
+    "copy-from": "Survivor_Encampment",
+    "type": "overmap_terrain"
+  },
+  {
+    "id": "Survivor_Encampment_overrun",
+    "copy-from": "Survivor_Encampment",
+    "type": "overmap_terrain"
+  },
+  {
     "id": "Survivor_Encampment_2",
     "type": "overmap_terrain",
     "name": "Survivor Encampment",
@@ -38,10 +48,35 @@
     "see_cost": 5
   },
   {
-    "id": "Survivor_Encampment_2_roof",
+    "id": "Survivor_Encampment_bandits",
+    "copy-from": "Survivor_Encampment_2",
+    "type": "overmap_terrain"
+  },
+  {
+    "id": "Survivor_Encampment_roof",
     "copy-from": "Survivor_Encampment_2",
     "type": "overmap_terrain",
     "name": "Survivor Encampment roof"
+  },
+  {
+    "id": "Survivor_Encampment_robotics_roof",
+    "copy-from": "Survivor_Encampment_roof",
+    "type": "overmap_terrain"
+  },
+  {
+    "id": "Survivor_Encampment_bandits_roof",
+    "copy-from": "Survivor_Encampment_roof",
+    "type": "overmap_terrain"
+  },
+  {
+    "id": "Survivor_Encampment_overrun_roof",
+    "copy-from": "Survivor_Encampment_roof",
+    "type": "overmap_terrain"
+  },
+  {
+    "id": "Survivor_Encampment_2_roof",
+    "copy-from": "Survivor_Encampment_roof",
+    "type": "overmap_terrain"
   },
   {
     "id": "Bio_Weapon_Lab_1",


### PR DESCRIPTION
1. Fixed proficiency stuff in DDA version, due to https://github.com/CleverRaven/Cataclysm-DDA/pull/64079 together with copy-pasting fail multipliers and the like no longer needed since proficiencies can define defaults for that.
2. Finished the split of survivor encampments and adding roof levels to them. Now each variation has a different unique overmap special, standardizing around 25% chance for uninhabited versions and 50% for ones with NPCs. This also accordingly fixes the issue where weird map extras could spawn on the NPC-inhabited version.

I also plan to at some point add arcanist variations to some of the encampments to the Arcana/Cata++ patchmod, to go with this.