### PR TITLE
Update c_monsters.json

### DIFF
--- a/nocts_cata_mod_DDA/Monsters/c_monster_harvest.json
+++ b/nocts_cata_mod_DDA/Monsters/c_monster_harvest.json
@@ -3,24 +3,6 @@
     "id": "CBM_FAILED_BIO",
     "type": "harvest",
     "entries": [
-      {
-        "drop": "bionic_power_storage_mil",
-        "type": "bionic_group",
-        "flags": [ "NO_STERILE", "NO_PACKED" ],
-        "faults": [ "fault_bionic_salvaged" ]
-      },
-      {
-        "drop": "bionic_power_storage_mil",
-        "type": "bionic_group",
-        "flags": [ "NO_STERILE", "NO_PACKED" ],
-        "faults": [ "fault_bionic_salvaged" ]
-      },
-      {
-        "drop": "bionics_failed_bio",
-        "type": "bionic_group",
-        "flags": [ "NO_STERILE", "NO_PACKED" ],
-        "faults": [ "fault_bionic_salvaged" ]
-      },
       { "drop": "mutant_human_flesh", "type": "flesh", "mass_ratio": 0.2 },
       { "drop": "hstomach_large", "scale_num": [ 1, 1 ], "max": 1, "type": "offal" },
       { "drop": "mutant_human_fat", "type": "flesh", "mass_ratio": 0.1 },
@@ -34,24 +16,6 @@
     "id": "CBM_FAILED_BIO_ZOMBIE",
     "type": "harvest",
     "entries": [
-      {
-        "drop": "bionic_power_storage_mil",
-        "type": "bionic_group",
-        "flags": [ "FILTHY", "NO_STERILE", "NO_PACKED" ],
-        "faults": [ "fault_bionic_salvaged" ]
-      },
-      {
-        "drop": "bionic_power_storage_mil",
-        "type": "bionic_group",
-        "flags": [ "FILTHY", "NO_STERILE", "NO_PACKED" ],
-        "faults": [ "fault_bionic_salvaged" ]
-      },
-      {
-        "drop": "bionic_power_storage_mil",
-        "type": "bionic_group",
-        "flags": [ "FILTHY", "NO_STERILE", "NO_PACKED" ],
-        "faults": [ "fault_bionic_salvaged" ]
-      },
       { "drop": "meat_tainted", "type": "flesh", "mass_ratio": 0.25 },
       { "drop": "fat_tainted", "type": "flesh", "mass_ratio": 0.08 },
       { "drop": "bone_tainted", "type": "bone", "mass_ratio": 0.1 },
@@ -63,42 +27,6 @@
     "id": "CBM_APOPHIS",
     "type": "harvest",
     "entries": [
-      {
-        "drop": "bionic_power_storage_mil",
-        "type": "bionic_group",
-        "flags": [ "NO_STERILE", "NO_PACKED" ],
-        "faults": [ "fault_bionic_salvaged" ]
-      },
-      {
-        "drop": "bionic_power_storage_mil",
-        "type": "bionic_group",
-        "flags": [ "NO_STERILE", "NO_PACKED" ],
-        "faults": [ "fault_bionic_salvaged" ]
-      },
-      {
-        "drop": "bionic_power_storage_mil",
-        "type": "bionic_group",
-        "flags": [ "NO_STERILE", "NO_PACKED" ],
-        "faults": [ "fault_bionic_salvaged" ]
-      },
-      {
-        "drop": "bionics_apophis_off",
-        "type": "bionic_group",
-        "flags": [ "NO_STERILE", "NO_PACKED" ],
-        "faults": [ "fault_bionic_salvaged" ]
-      },
-      {
-        "drop": "bionics_apophis_def",
-        "type": "bionic_group",
-        "flags": [ "NO_STERILE", "NO_PACKED" ],
-        "faults": [ "fault_bionic_salvaged" ]
-      },
-      {
-        "drop": "bionics_apophis_util",
-        "type": "bionic_group",
-        "flags": [ "NO_STERILE", "NO_PACKED" ],
-        "faults": [ "fault_bionic_salvaged" ]
-      },
       { "drop": "mutant_human_flesh", "type": "flesh", "mass_ratio": 0.2 },
       { "drop": "hstomach_large", "scale_num": [ 1, 1 ], "max": 1, "type": "offal" },
       { "drop": "mutant_human_fat", "type": "flesh", "mass_ratio": 0.1 },
@@ -112,18 +40,6 @@
     "id": "CBM_SOLDAT_ZOMBIE_GENERIC",
     "type": "harvest",
     "entries": [
-      {
-        "drop": "bio_power_storage_sentinel",
-        "type": "bionic",
-        "flags": [ "FILTHY", "NO_STERILE", "NO_PACKED" ],
-        "faults": [ "fault_bionic_salvaged" ]
-      },
-      {
-        "drop": "bionics_soldat_zombie_generic",
-        "type": "bionic_group",
-        "flags": [ "FILTHY", "NO_STERILE", "NO_PACKED" ],
-        "faults": [ "fault_bionic_salvaged" ]
-      },
       { "drop": "meat_tainted", "type": "flesh", "mass_ratio": 0.25 },
       { "drop": "fat_tainted", "type": "flesh", "mass_ratio": 0.08 },
       { "drop": "bone_tainted", "type": "bone", "mass_ratio": 0.1 }
@@ -133,18 +49,6 @@
     "id": "CBM_SOLDAT_ZOMBIE",
     "type": "harvest",
     "entries": [
-      {
-        "drop": "bio_power_storage_sentinel",
-        "type": "bionic",
-        "flags": [ "FILTHY", "NO_STERILE", "NO_PACKED" ],
-        "faults": [ "fault_bionic_salvaged" ]
-      },
-      {
-        "drop": "bionics_soldat_zombie",
-        "type": "bionic_group",
-        "flags": [ "FILTHY", "NO_STERILE", "NO_PACKED" ],
-        "faults": [ "fault_bionic_salvaged" ]
-      },
       { "drop": "meat_tainted", "type": "flesh", "mass_ratio": 0.25 },
       { "drop": "fat_tainted", "type": "flesh", "mass_ratio": 0.08 },
       { "drop": "bone_tainted", "type": "bone", "mass_ratio": 0.1 }
@@ -154,18 +58,6 @@
     "id": "CBM_SOLDAT_KNIGHT_ZOMBIE",
     "type": "harvest",
     "entries": [
-      {
-        "drop": "bio_power_storage_sentinel",
-        "type": "bionic",
-        "flags": [ "FILTHY", "NO_STERILE", "NO_PACKED" ],
-        "faults": [ "fault_bionic_salvaged" ]
-      },
-      {
-        "drop": "bionics_soldat_knight_zombie",
-        "type": "bionic_group",
-        "flags": [ "FILTHY", "NO_STERILE", "NO_PACKED" ],
-        "faults": [ "fault_bionic_salvaged" ]
-      },
       { "drop": "meat_tainted", "type": "flesh", "mass_ratio": 0.25 },
       { "drop": "fat_tainted", "type": "flesh", "mass_ratio": 0.08 },
       { "drop": "bone_tainted", "type": "bone", "mass_ratio": 0.1 }
@@ -175,18 +67,6 @@
     "id": "CBM_SOLDAT_SNIPER_ZOMBIE",
     "type": "harvest",
     "entries": [
-      {
-        "drop": "bio_power_storage_sentinel",
-        "type": "bionic",
-        "flags": [ "FILTHY", "NO_STERILE", "NO_PACKED" ],
-        "faults": [ "fault_bionic_salvaged" ]
-      },
-      {
-        "drop": "bionics_soldat_sniper_zombie",
-        "type": "bionic_group",
-        "flags": [ "FILTHY", "NO_STERILE", "NO_PACKED" ],
-        "faults": [ "fault_bionic_salvaged" ]
-      },
       { "drop": "meat_tainted", "type": "flesh", "mass_ratio": 0.25 },
       { "drop": "fat_tainted", "type": "flesh", "mass_ratio": 0.08 },
       { "drop": "bone_tainted", "type": "bone", "mass_ratio": 0.1 }
@@ -196,18 +76,6 @@
     "id": "CBM_SOLDAT_TOOL_ZOMBIE",
     "type": "harvest",
     "entries": [
-      {
-        "drop": "bio_power_storage_sentinel",
-        "type": "bionic",
-        "flags": [ "FILTHY", "NO_STERILE", "NO_PACKED" ],
-        "faults": [ "fault_bionic_salvaged" ]
-      },
-      {
-        "drop": "bionics_soldat_tool_zombie",
-        "type": "bionic_group",
-        "flags": [ "FILTHY", "NO_STERILE", "NO_PACKED" ],
-        "faults": [ "fault_bionic_salvaged" ]
-      },
       { "drop": "meat_tainted", "type": "flesh", "mass_ratio": 0.25 },
       { "drop": "fat_tainted", "type": "flesh", "mass_ratio": 0.08 },
       { "drop": "bone_tainted", "type": "bone", "mass_ratio": 0.1 }
@@ -219,8 +87,7 @@
     "entries": [
       { "drop": "meat_tainted", "type": "flesh", "mass_ratio": 0.4 },
       { "drop": "fat_tainted", "type": "flesh", "mass_ratio": 0.1 },
-      { "drop": "fat_tainted", "type": "offal", "mass_ratio": 0.1 },
-      { "drop": "c_mi_go_advanced_dissection_worker", "type": "bionic_group", "max": 1 }
+      { "drop": "fat_tainted", "type": "offal", "mass_ratio": 0.1 }
     ]
   },
   {
@@ -229,8 +96,7 @@
     "entries": [
       { "drop": "meat_tainted", "type": "flesh", "mass_ratio": 0.4 },
       { "drop": "fat_tainted", "type": "flesh", "mass_ratio": 0.1 },
-      { "drop": "fat_tainted", "type": "offal", "mass_ratio": 0.1 },
-      { "drop": "c_mi_go_advanced_dissection_slaver", "type": "bionic_group", "max": 1 }
+      { "drop": "fat_tainted", "type": "offal", "mass_ratio": 0.1 }
     ]
   },
   {
@@ -239,8 +105,7 @@
     "entries": [
       { "drop": "meat_tainted", "type": "flesh", "mass_ratio": 0.4 },
       { "drop": "fat_tainted", "type": "flesh", "mass_ratio": 0.1 },
-      { "drop": "fat_tainted", "type": "offal", "mass_ratio": 0.1 },
-      { "drop": "c_mi_go_advanced_dissection_surgeon", "type": "bionic_group", "max": 1 }
+      { "drop": "fat_tainted", "type": "offal", "mass_ratio": 0.1 }
     ]
   },
   {
@@ -249,8 +114,7 @@
     "entries": [
       { "drop": "meat_tainted", "type": "flesh", "mass_ratio": 0.4 },
       { "drop": "fat_tainted", "type": "flesh", "mass_ratio": 0.1 },
-      { "drop": "fat_tainted", "type": "offal", "mass_ratio": 0.1 },
-      { "drop": "c_mi_go_advanced_dissection_guard", "type": "bionic_group", "max": 1 }
+      { "drop": "fat_tainted", "type": "offal", "mass_ratio": 0.1 }
     ]
   },
   {
@@ -259,8 +123,7 @@
     "entries": [
       { "drop": "meat_tainted", "type": "flesh", "mass_ratio": 0.4 },
       { "drop": "fat_tainted", "type": "flesh", "mass_ratio": 0.1 },
-      { "drop": "fat_tainted", "type": "offal", "mass_ratio": 0.1 },
-      { "drop": "c_mi_go_advanced_dissection_myrmidon", "type": "bionic_group", "max": 1 }
+      { "drop": "fat_tainted", "type": "offal", "mass_ratio": 0.1 }
     ]
   },
   {
@@ -269,8 +132,7 @@
     "entries": [
       { "drop": "meat_tainted", "type": "flesh", "mass_ratio": 0.4 },
       { "drop": "fat_tainted", "type": "flesh", "mass_ratio": 0.1 },
-      { "drop": "fat_tainted", "type": "offal", "mass_ratio": 0.1 },
-      { "drop": "c_mi_go_advanced_dissection_scout", "type": "bionic_group", "max": 1 }
+      { "drop": "fat_tainted", "type": "offal", "mass_ratio": 0.1 }
     ]
   }
 ]

--- a/nocts_cata_mod_DDA/Monsters/c_monster_harvest_dissect.json
+++ b/nocts_cata_mod_DDA/Monsters/c_monster_harvest_dissect.json
@@ -1,0 +1,248 @@
+[
+  {
+    "id": "dissect_CBM_FAILED_BIO",
+    "type": "harvest",
+    "entries": [
+      {
+        "drop": "bionic_power_storage_mil",
+        "type": "bionic_group",
+        "flags": [ "NO_STERILE", "NO_PACKED" ],
+        "faults": [ "fault_bionic_salvaged" ]
+      },
+      {
+        "drop": "bionic_power_storage_mil",
+        "type": "bionic_group",
+        "flags": [ "NO_STERILE", "NO_PACKED" ],
+        "faults": [ "fault_bionic_salvaged" ]
+      },
+      {
+        "drop": "bionics_failed_bio",
+        "type": "bionic_group",
+        "flags": [ "NO_STERILE", "NO_PACKED" ],
+        "faults": [ "fault_bionic_salvaged" ]
+      }
+    ]
+  },
+  {
+    "id": "dissect_CBM_FAILED_BIO_ZOMBIE",
+    "type": "harvest",
+    "entries": [
+      {
+        "drop": "bionic_power_storage_mil",
+        "type": "bionic_group",
+        "flags": [ "FILTHY", "NO_STERILE", "NO_PACKED" ],
+        "faults": [ "fault_bionic_salvaged" ]
+      },
+      {
+        "drop": "bionic_power_storage_mil",
+        "type": "bionic_group",
+        "flags": [ "FILTHY", "NO_STERILE", "NO_PACKED" ],
+        "faults": [ "fault_bionic_salvaged" ]
+      },
+      {
+        "drop": "bionic_power_storage_mil",
+        "type": "bionic_group",
+        "flags": [ "FILTHY", "NO_STERILE", "NO_PACKED" ],
+        "faults": [ "fault_bionic_salvaged" ]
+      }
+    ]
+  },
+  {
+    "id": "dissect_CBM_APOPHIS",
+    "type": "harvest",
+    "entries": [
+      {
+        "drop": "bionic_power_storage_mil",
+        "type": "bionic_group",
+        "flags": [ "NO_STERILE", "NO_PACKED" ],
+        "faults": [ "fault_bionic_salvaged" ]
+      },
+      {
+        "drop": "bionic_power_storage_mil",
+        "type": "bionic_group",
+        "flags": [ "NO_STERILE", "NO_PACKED" ],
+        "faults": [ "fault_bionic_salvaged" ]
+      },
+      {
+        "drop": "bionic_power_storage_mil",
+        "type": "bionic_group",
+        "flags": [ "NO_STERILE", "NO_PACKED" ],
+        "faults": [ "fault_bionic_salvaged" ]
+      },
+      {
+        "drop": "bionics_apophis_off",
+        "type": "bionic_group",
+        "flags": [ "NO_STERILE", "NO_PACKED" ],
+        "faults": [ "fault_bionic_salvaged" ]
+      },
+      {
+        "drop": "bionics_apophis_def",
+        "type": "bionic_group",
+        "flags": [ "NO_STERILE", "NO_PACKED" ],
+        "faults": [ "fault_bionic_salvaged" ]
+      },
+      {
+        "drop": "bionics_apophis_util",
+        "type": "bionic_group",
+        "flags": [ "NO_STERILE", "NO_PACKED" ],
+        "faults": [ "fault_bionic_salvaged" ]
+      }
+    ]
+  },
+  {
+    "id": "dissect_CBM_SOLDAT_ZOMBIE_GENERIC",
+    "type": "harvest",
+    "entries": [
+      {
+        "drop": "bio_power_storage_sentinel",
+        "type": "bionic",
+        "flags": [ "FILTHY", "NO_STERILE", "NO_PACKED" ],
+        "faults": [ "fault_bionic_salvaged" ]
+      },
+      {
+        "drop": "bionics_soldat_zombie_generic",
+        "type": "bionic_group",
+        "flags": [ "FILTHY", "NO_STERILE", "NO_PACKED" ],
+        "faults": [ "fault_bionic_salvaged" ]
+      }
+    ]
+  },
+  {
+    "id": "dissect_CBM_SOLDAT_ZOMBIE",
+    "type": "harvest",
+    "entries": [
+      {
+        "drop": "bio_power_storage_sentinel",
+        "type": "bionic",
+        "flags": [ "FILTHY", "NO_STERILE", "NO_PACKED" ],
+        "faults": [ "fault_bionic_salvaged" ]
+      },
+      {
+        "drop": "bionics_soldat_zombie",
+        "type": "bionic_group",
+        "flags": [ "FILTHY", "NO_STERILE", "NO_PACKED" ],
+        "faults": [ "fault_bionic_salvaged" ]
+      }
+    ]
+  },
+  {
+    "id": "dissect_CBM_SOLDAT_KNIGHT_ZOMBIE",
+    "type": "harvest",
+    "entries": [
+      {
+        "drop": "bio_power_storage_sentinel",
+        "type": "bionic",
+        "flags": [ "FILTHY", "NO_STERILE", "NO_PACKED" ],
+        "faults": [ "fault_bionic_salvaged" ]
+      },
+      {
+        "drop": "bionics_soldat_knight_zombie",
+        "type": "bionic_group",
+        "flags": [ "FILTHY", "NO_STERILE", "NO_PACKED" ],
+        "faults": [ "fault_bionic_salvaged" ]
+      }
+    ]
+  },
+  {
+    "id": "dissect_CBM_SOLDAT_SNIPER_ZOMBIE",
+    "type": "harvest",
+    "entries": [
+      {
+        "drop": "bio_power_storage_sentinel",
+        "type": "bionic",
+        "flags": [ "FILTHY", "NO_STERILE", "NO_PACKED" ],
+        "faults": [ "fault_bionic_salvaged" ]
+      },
+      {
+        "drop": "bionics_soldat_sniper_zombie",
+        "type": "bionic_group",
+        "flags": [ "FILTHY", "NO_STERILE", "NO_PACKED" ],
+        "faults": [ "fault_bionic_salvaged" ]
+      }
+    ]
+  },
+  {
+    "id": "dissect_CBM_SOLDAT_TOOL_ZOMBIE",
+    "type": "harvest",
+    "entries": [
+      {
+        "drop": "bio_power_storage_sentinel",
+        "type": "bionic",
+        "flags": [ "FILTHY", "NO_STERILE", "NO_PACKED" ],
+        "faults": [ "fault_bionic_salvaged" ]
+      },
+      {
+        "drop": "bionics_soldat_tool_zombie",
+        "type": "bionic_group",
+        "flags": [ "FILTHY", "NO_STERILE", "NO_PACKED" ],
+        "faults": [ "fault_bionic_salvaged" ]
+      }
+    ]
+  },
+  {
+    "id": "dissect_c_mi_go_multi_worker",
+    "type": "harvest",
+    "entries": [
+      {
+        "drop": "c_mi_go_advanced_dissection_worker",
+        "type": "bionic_group",
+        "max": 1
+      }
+    ]
+  },
+  {
+    "id": "dissect_c_mi_go_multi_slaver",
+    "type": "harvest",
+    "entries": [
+      {
+        "drop": "c_mi_go_advanced_dissection_slaver",
+        "type": "bionic_group",
+        "max": 1
+      }
+    ]
+  },
+  {
+    "id": "dissect_c_mi_go_multi_surgeon",
+    "type": "harvest",
+    "entries": [
+      {
+        "drop": "c_mi_go_advanced_dissection_surgeon",
+        "type": "bionic_group",
+        "max": 1
+      }
+    ]
+  },
+  {
+    "id": "dissect_c_mi_go_multi_guard",
+    "type": "harvest",
+    "entries": [
+      {
+        "drop": "c_mi_go_advanced_dissection_guard",
+        "type": "bionic_group",
+        "max": 1
+      }
+    ]
+  },
+  {
+    "id": "dissect_c_mi_go_multi_myrmidon",
+    "type": "harvest",
+    "entries": [
+      {
+        "drop": "c_mi_go_advanced_dissection_myrmidon",
+        "type": "bionic_group",
+        "max": 1
+      }
+    ]
+  },
+  {
+    "id": "dissect_c_mi_go_multi_scout",
+    "type": "harvest",
+    "entries": [
+      {
+        "drop": "c_mi_go_advanced_dissection_scout",
+        "type": "bionic_group",
+        "max": 1
+      }
+    ]
+  }
+]

--- a/nocts_cata_mod_DDA/Monsters/c_monster_override.json
+++ b/nocts_cata_mod_DDA/Monsters/c_monster_override.json
@@ -91,42 +91,42 @@
     "id": "mon_mi_go",
     "copy-from": "mon_mi_go",
     "type": "MONSTER",
-    "harvest": "c_mi_go_multi_worker"
-    "dissect": "dissect_c_mi_go_multi_worker",
+    "harvest": "c_mi_go_multi_worker",
+    "dissect": "dissect_c_mi_go_multi_worker"
   },
   {
     "id": "mon_mi_go_slaver",
     "copy-from": "mon_mi_go_slaver",
     "type": "MONSTER",
-    "harvest": "c_mi_go_multi_slaver"
-    "dissect": "dissect_c_mi_go_multi_slaver",
+    "harvest": "c_mi_go_multi_slaver",
+    "dissect": "dissect_c_mi_go_multi_slaver"
   },
   {
     "id": "mon_mi_go_surgeon",
     "copy-from": "mon_mi_go_surgeon",
     "type": "MONSTER",
-    "harvest": "c_mi_go_multi_surgeon"
-    "dissect": "dissect_c_mi_go_multi_surgeon",
+    "harvest": "c_mi_go_multi_surgeon",
+    "dissect": "dissect_c_mi_go_multi_surgeon"
   },
   {
     "id": "mon_mi_go_guard",
     "copy-from": "mon_mi_go_guard",
     "type": "MONSTER",
-    "harvest": "c_mi_go_multi_guard"
-    "dissect": "dissect_c_mi_go_multi_guard",
+    "harvest": "c_mi_go_multi_guard",
+    "dissect": "dissect_c_mi_go_multi_guard"
   },
   {
     "id": "mon_mi_go_myrmidon",
     "copy-from": "mon_mi_go_myrmidon",
     "type": "MONSTER",
-    "harvest": "c_mi_go_multi_myrmidon"
-    "dissect": "dissect_c_mi_go_multi_myrmidon",
+    "harvest": "c_mi_go_multi_myrmidon",
+    "dissect": "dissect_c_mi_go_multi_myrmidon"
   },
   {
     "id": "mon_mi_go_scout",
     "copy-from": "mon_mi_go_scout",
     "type": "MONSTER",
-    "harvest": "c_mi_go_multi_scout"
-    "dissect": "dissect_c_mi_go_multi_scout",
+    "harvest": "c_mi_go_multi_scout",
+    "dissect": "dissect_c_mi_go_multi_scout"
   }
 ]

--- a/nocts_cata_mod_DDA/Monsters/c_monster_override.json
+++ b/nocts_cata_mod_DDA/Monsters/c_monster_override.json
@@ -92,35 +92,41 @@
     "copy-from": "mon_mi_go",
     "type": "MONSTER",
     "harvest": "c_mi_go_multi_worker"
+    "dissect": "dissect_c_mi_go_multi_worker",
   },
   {
     "id": "mon_mi_go_slaver",
     "copy-from": "mon_mi_go_slaver",
     "type": "MONSTER",
     "harvest": "c_mi_go_multi_slaver"
+    "dissect": "dissect_c_mi_go_multi_slaver",
   },
   {
     "id": "mon_mi_go_surgeon",
     "copy-from": "mon_mi_go_surgeon",
     "type": "MONSTER",
     "harvest": "c_mi_go_multi_surgeon"
+    "dissect": "dissect_c_mi_go_multi_surgeon",
   },
   {
     "id": "mon_mi_go_guard",
     "copy-from": "mon_mi_go_guard",
     "type": "MONSTER",
     "harvest": "c_mi_go_multi_guard"
+    "dissect": "dissect_c_mi_go_multi_guard",
   },
   {
     "id": "mon_mi_go_myrmidon",
     "copy-from": "mon_mi_go_myrmidon",
     "type": "MONSTER",
     "harvest": "c_mi_go_multi_myrmidon"
+    "dissect": "dissect_c_mi_go_multi_myrmidon",
   },
   {
     "id": "mon_mi_go_scout",
     "copy-from": "mon_mi_go_scout",
     "type": "MONSTER",
     "harvest": "c_mi_go_multi_scout"
+    "dissect": "dissect_c_mi_go_multi_scout",
   }
 ]

--- a/nocts_cata_mod_DDA/Monsters/c_monsters.json
+++ b/nocts_cata_mod_DDA/Monsters/c_monsters.json
@@ -33,6 +33,7 @@
     "regeneration_modifiers": [ [ "onfire", -2 ] ],
     "regen_morale": true,
     "harvest": "CBM_FAILED_BIO_ZOMBIE",
+    "dissect": "CBM_FAILED_BIO_ZOMBIE",
     "special_attacks": [ [ "SHOCKSTORM", 10 ], [ "PARROT", 50 ], { "type": "bite", "cooldown": 5 } ],
     "special_when_hit": [ "ZAPBACK", 60 ],
     "anger_triggers": [ "FRIEND_DIED", "FRIEND_ATTACKED", "HURT", "STALK", "PLAYER_CLOSE" ],
@@ -91,6 +92,7 @@
     "regeneration_modifiers": [ [ "onfire", -3 ] ],
     "regen_morale": true,
     "harvest": "CBM_FAILED_BIO",
+    "dissect": "CBM_FAILED_BIO",
     "special_attacks": [ [ "SHOCKSTORM", 15 ], [ "PARROT", 80 ] ],
     "special_when_hit": [ "ZAPBACK", 75 ],
     "anger_triggers": [ "FRIEND_DIED", "FRIEND_ATTACKED", "HURT", "STALK", "PLAYER_CLOSE" ],
@@ -135,6 +137,7 @@
     "regeneration_modifiers": [ [ "onfire", -5 ] ],
     "starting_ammo": { "generic_no_ammo": 1000 },
     "harvest": "CBM_APOPHIS",
+    "dissect": "CBM_APOPHIS",
     "special_attacks": [
       [ "SHOCKSTORM", 15 ],
       [ "TAZER", 15 ],
@@ -211,6 +214,7 @@
     "vision_night": 3,
     "luminance": 5,
     "harvest": "CBM_FAILED_BIO",
+    "dissect": "CBM_FAILED_BIO",
     "regenerates": 4,
     "regeneration_modifiers": [ [ "onfire", -2 ] ],
     "regen_morale": true,
@@ -269,6 +273,7 @@
     "regeneration_modifiers": [ [ "onfire", -1 ], [ "corroding", -1 ] ],
     "regen_morale": true,
     "harvest": "CBM_SOLDAT_ZOMBIE_GENERIC",
+    "dissect": "CBM_SOLDAT_ZOMBIE_GENERIC",
     "special_attacks": [ [ "GRAB", 10 ] ],
     "special_when_hit": [ "ZAPBACK", 60 ],
     "anger_triggers": [ "FRIEND_DIED", "FRIEND_ATTACKED", "HURT", "STALK", "PLAYER_CLOSE" ],
@@ -313,6 +318,7 @@
     "regeneration_modifiers": [ [ "onfire", -1 ], [ "corroding", -1 ] ],
     "regen_morale": true,
     "harvest": "CBM_SOLDAT_ZOMBIE_GENERIC",
+    "dissect": "CBM_SOLDAT_ZOMBIE_GENERIC",
     "special_attacks": [ [ "GRAB", 10 ] ],
     "special_when_hit": [ "ZAPBACK", 60 ],
     "anger_triggers": [ "FRIEND_DIED", "FRIEND_ATTACKED", "HURT", "STALK", "PLAYER_CLOSE" ],
@@ -380,6 +386,7 @@
     "regen_morale": true,
     "starting_ammo": { "battery": 100 },
     "harvest": "CBM_SOLDAT_ZOMBIE",
+    "dissect": "CBM_SOLDAT_ZOMBIE",
     "special_attacks": [
       {
         "type": "gun",
@@ -450,6 +457,7 @@
     "regen_morale": true,
     "starting_ammo": { "battery": 100 },
     "harvest": "CBM_SOLDAT_ZOMBIE",
+    "dissect": "CBM_SOLDAT_ZOMBIE",
     "special_attacks": [
       {
         "type": "gun",
@@ -519,6 +527,7 @@
     "regen_morale": true,
     "starting_ammo": { "battery": 200 },
     "harvest": "CBM_SOLDAT_KNIGHT_ZOMBIE",
+    "dissect": "CBM_SOLDAT_KNIGHT_ZOMBIE",
     "special_attacks": [
       {
         "type": "gun",
@@ -587,6 +596,7 @@
     "regen_morale": true,
     "starting_ammo": { "battery": 5 },
     "harvest": "CBM_SOLDAT_KNIGHT_ZOMBIE",
+    "dissect": "CBM_SOLDAT_KNIGHT_ZOMBIE",
     "special_attacks": [
       {
         "type": "gun",
@@ -657,6 +667,7 @@
     "regen_morale": true,
     "starting_ammo": { "battery": 50 },
     "harvest": "CBM_SOLDAT_SNIPER_ZOMBIE",
+    "dissect": "CBM_SOLDAT_SNIPER_ZOMBIE",
     "special_attacks": [
       {
         "type": "gun",
@@ -728,6 +739,7 @@
     "regen_morale": true,
     "starting_ammo": { "battery": 25 },
     "harvest": "CBM_SOLDAT_TOOL_ZOMBIE",
+    "dissect": "CBM_SOLDAT_TOOL_ZOMBIE",
     "special_attacks": [
       {
         "type": "gun",
@@ -797,6 +809,7 @@
     "regen_morale": true,
     "starting_ammo": { "battery": 50 },
     "harvest": "CBM_SOLDAT_TOOL_ZOMBIE",
+    "dissect": "CBM_SOLDAT_TOOL_ZOMBIE",
     "special_attacks": [
       {
         "type": "gun",
@@ -865,6 +878,7 @@
     "regeneration_modifiers": [ [ "onfire", -1 ], [ "corroding", -1 ] ],
     "regen_morale": true,
     "harvest": "CBM_SOLDAT_ZOMBIE_GENERIC",
+    "dissect": "CBM_SOLDAT_ZOMBIE_GENERIC",
     "special_attacks": [
       { "type": "leap", "cooldown": 10, "max_range": 5 },
       [ "GRAB", 5 ],

--- a/nocts_cata_mod_DDA/Monsters/c_monsters.json
+++ b/nocts_cata_mod_DDA/Monsters/c_monsters.json
@@ -33,7 +33,7 @@
     "regeneration_modifiers": [ [ "onfire", -2 ] ],
     "regen_morale": true,
     "harvest": "CBM_FAILED_BIO_ZOMBIE",
-    "dissect": "CBM_FAILED_BIO_ZOMBIE",
+    "dissect": "dissect_CBM_FAILED_BIO_ZOMBIE",
     "special_attacks": [ [ "SHOCKSTORM", 10 ], [ "PARROT", 50 ], { "type": "bite", "cooldown": 5 } ],
     "special_when_hit": [ "ZAPBACK", 60 ],
     "anger_triggers": [ "FRIEND_DIED", "FRIEND_ATTACKED", "HURT", "STALK", "PLAYER_CLOSE" ],
@@ -92,7 +92,7 @@
     "regeneration_modifiers": [ [ "onfire", -3 ] ],
     "regen_morale": true,
     "harvest": "CBM_FAILED_BIO",
-    "dissect": "CBM_FAILED_BIO",
+    "dissect": "dissect_CBM_FAILED_BIO",
     "special_attacks": [ [ "SHOCKSTORM", 15 ], [ "PARROT", 80 ] ],
     "special_when_hit": [ "ZAPBACK", 75 ],
     "anger_triggers": [ "FRIEND_DIED", "FRIEND_ATTACKED", "HURT", "STALK", "PLAYER_CLOSE" ],
@@ -137,7 +137,7 @@
     "regeneration_modifiers": [ [ "onfire", -5 ] ],
     "starting_ammo": { "generic_no_ammo": 1000 },
     "harvest": "CBM_APOPHIS",
-    "dissect": "CBM_APOPHIS",
+    "dissect": "dissect_CBM_APOPHIS",
     "special_attacks": [
       [ "SHOCKSTORM", 15 ],
       [ "TAZER", 15 ],
@@ -214,7 +214,7 @@
     "vision_night": 3,
     "luminance": 5,
     "harvest": "CBM_FAILED_BIO",
-    "dissect": "CBM_FAILED_BIO",
+    "dissect": "dissect_CBM_FAILED_BIO",
     "regenerates": 4,
     "regeneration_modifiers": [ [ "onfire", -2 ] ],
     "regen_morale": true,
@@ -273,7 +273,7 @@
     "regeneration_modifiers": [ [ "onfire", -1 ], [ "corroding", -1 ] ],
     "regen_morale": true,
     "harvest": "CBM_SOLDAT_ZOMBIE_GENERIC",
-    "dissect": "CBM_SOLDAT_ZOMBIE_GENERIC",
+    "dissect": "dissect_CBM_SOLDAT_ZOMBIE_GENERIC",
     "special_attacks": [ [ "GRAB", 10 ] ],
     "special_when_hit": [ "ZAPBACK", 60 ],
     "anger_triggers": [ "FRIEND_DIED", "FRIEND_ATTACKED", "HURT", "STALK", "PLAYER_CLOSE" ],
@@ -318,7 +318,7 @@
     "regeneration_modifiers": [ [ "onfire", -1 ], [ "corroding", -1 ] ],
     "regen_morale": true,
     "harvest": "CBM_SOLDAT_ZOMBIE_GENERIC",
-    "dissect": "CBM_SOLDAT_ZOMBIE_GENERIC",
+    "dissect": "dissect_CBM_SOLDAT_ZOMBIE_GENERIC",
     "special_attacks": [ [ "GRAB", 10 ] ],
     "special_when_hit": [ "ZAPBACK", 60 ],
     "anger_triggers": [ "FRIEND_DIED", "FRIEND_ATTACKED", "HURT", "STALK", "PLAYER_CLOSE" ],
@@ -386,7 +386,7 @@
     "regen_morale": true,
     "starting_ammo": { "battery": 100 },
     "harvest": "CBM_SOLDAT_ZOMBIE",
-    "dissect": "CBM_SOLDAT_ZOMBIE",
+    "dissect": "dissect_CBM_SOLDAT_ZOMBIE",
     "special_attacks": [
       {
         "type": "gun",
@@ -457,7 +457,7 @@
     "regen_morale": true,
     "starting_ammo": { "battery": 100 },
     "harvest": "CBM_SOLDAT_ZOMBIE",
-    "dissect": "CBM_SOLDAT_ZOMBIE",
+    "dissect": "dissect_CBM_SOLDAT_ZOMBIE",
     "special_attacks": [
       {
         "type": "gun",
@@ -527,7 +527,7 @@
     "regen_morale": true,
     "starting_ammo": { "battery": 200 },
     "harvest": "CBM_SOLDAT_KNIGHT_ZOMBIE",
-    "dissect": "CBM_SOLDAT_KNIGHT_ZOMBIE",
+    "dissect": "dissect_CBM_SOLDAT_KNIGHT_ZOMBIE",
     "special_attacks": [
       {
         "type": "gun",
@@ -596,7 +596,7 @@
     "regen_morale": true,
     "starting_ammo": { "battery": 5 },
     "harvest": "CBM_SOLDAT_KNIGHT_ZOMBIE",
-    "dissect": "CBM_SOLDAT_KNIGHT_ZOMBIE",
+    "dissect": "dissect_CBM_SOLDAT_KNIGHT_ZOMBIE",
     "special_attacks": [
       {
         "type": "gun",
@@ -667,7 +667,7 @@
     "regen_morale": true,
     "starting_ammo": { "battery": 50 },
     "harvest": "CBM_SOLDAT_SNIPER_ZOMBIE",
-    "dissect": "CBM_SOLDAT_SNIPER_ZOMBIE",
+    "dissect": "dissect_CBM_SOLDAT_SNIPER_ZOMBIE",
     "special_attacks": [
       {
         "type": "gun",
@@ -739,7 +739,7 @@
     "regen_morale": true,
     "starting_ammo": { "battery": 25 },
     "harvest": "CBM_SOLDAT_TOOL_ZOMBIE",
-    "dissect": "CBM_SOLDAT_TOOL_ZOMBIE",
+    "dissect": "dissect_CBM_SOLDAT_TOOL_ZOMBIE",
     "special_attacks": [
       {
         "type": "gun",
@@ -809,7 +809,7 @@
     "regen_morale": true,
     "starting_ammo": { "battery": 50 },
     "harvest": "CBM_SOLDAT_TOOL_ZOMBIE",
-    "dissect": "CBM_SOLDAT_TOOL_ZOMBIE",
+    "dissect": "dissect_CBM_SOLDAT_TOOL_ZOMBIE",
     "special_attacks": [
       {
         "type": "gun",
@@ -878,7 +878,7 @@
     "regeneration_modifiers": [ [ "onfire", -1 ], [ "corroding", -1 ] ],
     "regen_morale": true,
     "harvest": "CBM_SOLDAT_ZOMBIE_GENERIC",
-    "dissect": "CBM_SOLDAT_ZOMBIE_GENERIC",
+    "dissect": "dissect_CBM_SOLDAT_ZOMBIE_GENERIC",
     "special_attacks": [
       { "type": "leap", "cooldown": 10, "max_range": 5 },
       [ "GRAB", 5 ],


### PR DESCRIPTION
Fix for #486 
Used https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/json/monsters/cyborgs.json as template and found that monsters now have separate "harvest" and "dissect" sections. Added "dissect" to all monsters that had "harvest".