### PR TITLE
Fix uncraft time

### DIFF
--- a/nocts_cata_mod_BN/Recipe/c_recipes.json
+++ b/nocts_cata_mod_BN/Recipe/c_recipes.json
@@ -1059,7 +1059,7 @@
     "category": "CC_WEAPON",
     "subcategory": "CSC_WEAPON_CUTTING",
     "skill_used": "fabrication",
-    "time": "0 m",
+    "time": "1 s",
     "reversible": true,
     "decomp_learn": 1,
     "autolearn": true,

--- a/nocts_cata_mod_DDA/Recipe/c_recipes.json
+++ b/nocts_cata_mod_DDA/Recipe/c_recipes.json
@@ -1105,7 +1105,7 @@
     "category": "CC_WEAPON",
     "subcategory": "CSC_WEAPON_CUTTING",
     "skill_used": "fabrication",
-    "time": "0 m",
+    "time": "1 s",
     "reversible": true,
     "decomp_learn": 1,
     "autolearn": true,


### PR DESCRIPTION
Easy enough fix to something I forgot about, fixes a case of a zero-time reversible recipe, something no longer allowed in BN. Also updated DDA version for consistency just in case.