### PR TITLE
Updates for BN version

### DIFF
--- a/nocts_cata_mod_BN/Terrain/c_furniture.json
+++ b/nocts_cata_mod_BN/Terrain/c_furniture.json
@@ -9,7 +9,7 @@
     "color": "blue",
     "move_cost_mod": -1,
     "coverage": 80,
-    "required_str": 10,
+    "required_str": -1,
     "crafting_pseudo_item": [
       "fake_oven",
       "fake_gridforge",

--- a/nocts_cata_mod_BN/Terrain/makeshift_command_center.json
+++ b/nocts_cata_mod_BN/Terrain/makeshift_command_center.json
@@ -208,7 +208,6 @@
         "w": "f_wreckage",
         "{": "f_dresser"
       },
-      "mapping": { "w": { "item": { "item": "scrap", "repeat": [ 1, 3 ] } } },
       "place_toilets": [ { "x": 5, "y": 19 } ],
       "place_items": [
         { "item": "stash_food", "x": 8, "y": 2, "chance": 85, "repeat": 12 },


### PR DESCRIPTION
1. Removed a spawn of items under rubble now that rubble in BN version gets shovel yield automatically.
2. Prevent dragging grid survivor station since dragging grid furniture can potentially cause problems it turns out.