### PR TITLE
Add cutting skill to bionic silencer

### DIFF
--- a/nocts_cata_mod_BN/Char_creation/c_classes_r.json
+++ b/nocts_cata_mod_BN/Char_creation/c_classes_r.json
@@ -172,6 +172,7 @@
       { "level": 4, "name": "dodge" },
       { "level": 3, "name": "mechanics" },
       { "level": 3, "name": "melee" },
+      { "level": 2, "name": "cutting" },
       { "level": 2, "name": "survival" }
     ],
     "items": {

--- a/nocts_cata_mod_DDA/Char_creation/c_classes_r.json
+++ b/nocts_cata_mod_DDA/Char_creation/c_classes_r.json
@@ -194,6 +194,7 @@
       { "level": 4, "name": "dodge" },
       { "level": 3, "name": "mechanics" },
       { "level": 3, "name": "melee" },
+      { "level": 2, "name": "cutting" },
       { "level": 2, "name": "survival" }
     ],
     "proficiencies": [ "prof_lockpicking" ],


### PR DESCRIPTION
Simple tweak now that I've remembered that bionic sword is meant to be cutting rather than unarmed, plus the profession starts with melee skills and not the CQB bionic so that's needed to complete the set.