### PR TITLE
Assorted updates involving prepper/lab map items

### DIFF
--- a/nocts_cata_mod_BN/Npc/NC_BIO_WEAPONS.json
+++ b/nocts_cata_mod_BN/Npc/NC_BIO_WEAPONS.json
@@ -51,8 +51,6 @@
         ]
       },
       { "item": "mre_veggy_box" },
-      { "item": "biomap" },
-      { "item": "militarymap" },
       { "group": "everyday_gear" },
       { "group": "drugs_soldier", "prob": 50 },
       { "group": "supplies_electronics", "prob": 50, "count": [ 1, 3 ] }

--- a/nocts_cata_mod_BN/Npc/NC_SUPER_SOLDIERS.json
+++ b/nocts_cata_mod_BN/Npc/NC_SUPER_SOLDIERS.json
@@ -30,7 +30,6 @@
     "ammo": 100,
     "entries": [
       { "item": "protein_bar_evac", "count": [ 4, 8 ] },
-      { "item": "militarymap" },
       { "item": "id_military" },
       {
         "distribution": [
@@ -91,7 +90,6 @@
     "entries": [
       { "item": "badge_bio_weapon_evy" },
       { "item": "mre_veggy_box" },
-      { "item": "biomap" },
       { "item": "militarymap" },
       { "group": "NC_BIO_HUNTER_E_battery", "count": [ 5, 10 ] },
       { "group": "everyday_gear" },

--- a/nocts_cata_mod_BN/Recipe/c_recipes.json
+++ b/nocts_cata_mod_BN/Recipe/c_recipes.json
@@ -2802,5 +2802,47 @@
       [ [ "cable", 10 ], [ "wire", 1 ], [ "string_floss", 1 ] ],
       [ [ "material_sand", 10 ], [ "salt", 20 ] ]
     ]
+  },
+  {
+    "result": "note_apophis",
+    "type": "uncraft",
+    "time": "6 s",
+    "components": [ [ [ "paper", 1 ] ] ],
+    "flags": [ "BLIND_EASY" ]
+  },
+  {
+    "result": "note_sketchy_cabin",
+    "type": "uncraft",
+    "time": "6 s",
+    "components": [ [ [ "paper", 1 ] ] ],
+    "flags": [ "BLIND_EASY" ]
+  },
+  {
+    "result": "semap",
+    "type": "uncraft",
+    "time": "30 s",
+    "components": [ [ [ "paper", 10 ] ] ],
+    "flags": [ "BLIND_EASY" ]
+  },
+  {
+    "result": "ulmap",
+    "type": "uncraft",
+    "time": "30 s",
+    "components": [ [ [ "paper", 10 ] ] ],
+    "flags": [ "BLIND_EASY" ]
+  },
+  {
+    "result": "mccmap",
+    "type": "uncraft",
+    "time": "30 s",
+    "components": [ [ [ "paper", 10 ] ] ],
+    "flags": [ "BLIND_EASY" ]
+  },
+  {
+    "result": "biomap",
+    "type": "uncraft",
+    "time": "30 s",
+    "components": [ [ [ "paper", 10 ] ] ],
+    "flags": [ "BLIND_EASY" ]
   }
 ]

--- a/nocts_cata_mod_BN/Surv_help/c_tools.json
+++ b/nocts_cata_mod_BN/Surv_help/c_tools.json
@@ -559,26 +559,6 @@
     "to_hit": -1
   },
   {
-    "id": "shmap",
-    "category": "maps",
-    "type": "GENERIC",
-    "symbol": ";",
-    "color": "blue",
-    "looks_like": "survivormap",
-    "name": { "str_sp": "Bugout Location Directions" },
-    "description": "A map and set of directions, leading to somebody's rendezvous point.  The name scribbled in one corner seems faintly familiar.",
-    "material": [ "paper" ],
-    "weight": "30 g",
-    "volume": "250 ml",
-    "to_hit": -1,
-    "use_action": {
-      "type": "reveal_map",
-      "radius": 180,
-      "terrain": [ "Survivor_Holdout_1" ],
-      "message": "Throughly poring over the map, you memorize the location."
-    }
-  },
-  {
     "id": "auto_case",
     "category": "spare_parts",
     "type": "TOOL",
@@ -623,7 +603,13 @@
     "use_action": {
       "type": "reveal_map",
       "radius": 180,
-      "terrain": [ "surv_emcampn", "surv_emcampb", "surv_emcampz" ],
+      "terrain": [
+        "Survivor_Encampment",
+        "Survivor_Encampment_robotics",
+        "Survivor_Encampment_bandits",
+        "Survivor_Encampment_overrun",
+        "Survivor_Encampment_2"
+      ],
       "message": "You read the back of the note and plan your next move."
     }
   },

--- a/nocts_cata_mod_BN/legacy.json
+++ b/nocts_cata_mod_BN/legacy.json
@@ -816,5 +816,25 @@
     "type": "BIONIC_ITEM",
     "name": { "str": "Obsolete CBM" },
     "description": "This is a now-unneeded holdover from back when Atomic Battery had to work around code bugs and would only generate power when turned off instead of when turned on."
+  },
+  {
+    "id": "shmap",
+    "category": "maps",
+    "type": "GENERIC",
+    "symbol": ";",
+    "color": "blue",
+    "looks_like": "survivormap",
+    "name": { "str_sp": "Bugout Location Directions" },
+    "description": "A map and set of directions, leading to somebody's rendezvous point.  The name scribbled in one corner seems faintly familiar.",
+    "material": [ "paper" ],
+    "weight": "30 g",
+    "volume": "250 ml",
+    "to_hit": -1,
+    "use_action": {
+      "type": "reveal_map",
+      "radius": 180,
+      "terrain": [ "Survivor_Holdout_1" ],
+      "message": "Thoroughly poring over the map, you memorize the location."
+    }
   }
 ]

--- a/nocts_cata_mod_DDA/Npc/NC_BIO_WEAPONS.json
+++ b/nocts_cata_mod_DDA/Npc/NC_BIO_WEAPONS.json
@@ -51,8 +51,6 @@
         ]
       },
       { "group": "mre_full_pack" },
-      { "item": "biomap" },
-      { "item": "militarymap" },
       { "group": "everyday_gear" },
       { "group": "drugs_soldier", "prob": 50 },
       { "group": "supplies_electronics", "prob": 50, "count": [ 1, 3 ] }

--- a/nocts_cata_mod_DDA/Npc/NC_SUPER_SOLDIERS.json
+++ b/nocts_cata_mod_DDA/Npc/NC_SUPER_SOLDIERS.json
@@ -30,7 +30,6 @@
     "ammo": 100,
     "entries": [
       { "item": "protein_bar_evac", "count": [ 4, 8 ] },
-      { "item": "militarymap" },
       { "item": "id_military" },
       {
         "distribution": [
@@ -89,7 +88,6 @@
     "entries": [
       { "item": "badge_bio_weapon_evy" },
       { "group": "mre_full_pack" },
-      { "item": "biomap" },
       { "item": "militarymap" },
       { "group": "NC_BIO_HUNTER_E_battery", "count": [ 5, 10 ] },
       { "group": "everyday_gear" },

--- a/nocts_cata_mod_DDA/Recipe/c_recipes.json
+++ b/nocts_cata_mod_DDA/Recipe/c_recipes.json
@@ -1558,7 +1558,13 @@
     "book_learn": [ [ "recipe_surv", 5 ] ],
     "using": [ [ "welding_standard", 10 ] ],
     "qualities": [ { "id": "HAMMER", "level": 2 }, { "id": "SAW_M", "level": 1 }, { "id": "WRENCH", "level": 1 } ],
-    "components": [ [ [ "kitchen_unit", 1 ] ], [ [ "forgerig", 1 ] ], [ [ "weldrig", 1 ] ], [ [ "craftrig", 1 ] ], [ [ "veh_tools_kitchen", 1 ] ] ]
+    "components": [
+      [ [ "kitchen_unit", 1 ] ],
+      [ [ "forgerig", 1 ] ],
+      [ [ "weldrig", 1 ] ],
+      [ [ "craftrig", 1 ] ],
+      [ [ "veh_tools_kitchen", 1 ] ]
+    ]
   },
   {
     "result": "mil_surp_pack_1",
@@ -2955,5 +2961,53 @@
       [ [ "cable", 10 ], [ "wire", 1 ], [ "string_floss", 1 ], [ "thread_kevlar", 25 ] ],
       [ [ "material_sand", 10 ], [ "salt", 20 ] ]
     ]
+  },
+  {
+    "result": "note_apophis",
+    "type": "uncraft",
+    "time": "6 s",
+    "activity_level": "LIGHT_EXERCISE",
+    "components": [ [ [ "paper", 1 ] ] ],
+    "flags": [ "BLIND_EASY" ]
+  },
+  {
+    "result": "note_sketchy_cabin",
+    "type": "uncraft",
+    "time": "6 s",
+    "activity_level": "LIGHT_EXERCISE",
+    "components": [ [ [ "paper", 1 ] ] ],
+    "flags": [ "BLIND_EASY" ]
+  },
+  {
+    "result": "semap",
+    "type": "uncraft",
+    "time": "30 s",
+    "activity_level": "LIGHT_EXERCISE",
+    "components": [ [ [ "paper", 10 ] ] ],
+    "flags": [ "BLIND_EASY" ]
+  },
+  {
+    "result": "ulmap",
+    "type": "uncraft",
+    "time": "30 s",
+    "activity_level": "LIGHT_EXERCISE",
+    "components": [ [ [ "paper", 10 ] ] ],
+    "flags": [ "BLIND_EASY" ]
+  },
+  {
+    "result": "mccmap",
+    "type": "uncraft",
+    "time": "30 s",
+    "activity_level": "LIGHT_EXERCISE",
+    "components": [ [ [ "paper", 10 ] ] ],
+    "flags": [ "BLIND_EASY" ]
+  },
+  {
+    "result": "biomap",
+    "type": "uncraft",
+    "time": "30 s",
+    "activity_level": "LIGHT_EXERCISE",
+    "components": [ [ [ "paper", 10 ] ] ],
+    "flags": [ "BLIND_EASY" ]
   }
 ]

--- a/nocts_cata_mod_DDA/Surv_help/c_tools.json
+++ b/nocts_cata_mod_DDA/Surv_help/c_tools.json
@@ -602,26 +602,6 @@
     "to_hit": -1
   },
   {
-    "id": "shmap",
-    "category": "maps",
-    "type": "GENERIC",
-    "symbol": ";",
-    "color": "blue",
-    "looks_like": "survivormap",
-    "name": { "str_sp": "Bugout Location Directions" },
-    "description": "A map and set of directions, leading to somebody's rendezvous point.  The name scribbled in one corner seems faintly familiar.",
-    "material": [ "paper" ],
-    "weight": "30 g",
-    "volume": "250 ml",
-    "to_hit": -1,
-    "use_action": {
-      "type": "reveal_map",
-      "radius": 180,
-      "terrain": [ "Survivor_Holdout_1" ],
-      "message": "Throughly poring over the map, you memorize the location."
-    }
-  },
-  {
     "id": "auto_case",
     "category": "spare_parts",
     "type": "TOOL",
@@ -671,7 +651,13 @@
     "use_action": {
       "type": "reveal_map",
       "radius": 180,
-      "terrain": [ "surv_emcampn", "surv_emcampb", "surv_emcampz" ],
+      "terrain": [
+        "Survivor_Encampment",
+        "Survivor_Encampment_robotics",
+        "Survivor_Encampment_bandits",
+        "Survivor_Encampment_overrun",
+        "Survivor_Encampment_2"
+      ],
       "message": "You read the back of the note and plan your next move."
     }
   },

--- a/nocts_cata_mod_DDA/legacy.json
+++ b/nocts_cata_mod_DDA/legacy.json
@@ -1159,5 +1159,25 @@
     "type": "vehicle_part_migration",
     "from": "mk_ionic_cannon_t",
     "to": "turret_mk_ionic_cannon"
+  },
+  {
+    "id": "shmap",
+    "category": "maps",
+    "type": "GENERIC",
+    "symbol": ";",
+    "color": "blue",
+    "looks_like": "survivormap",
+    "name": { "str_sp": "Bugout Location Directions" },
+    "description": "A map and set of directions, leading to somebody's rendezvous point.  The name scribbled in one corner seems faintly familiar.",
+    "material": [ "paper" ],
+    "weight": "30 g",
+    "volume": "250 ml",
+    "to_hit": -1,
+    "use_action": {
+      "type": "reveal_map",
+      "radius": 180,
+      "terrain": [ "Survivor_Holdout_1" ],
+      "message": "Thoroughly poring over the map, you memorize the location."
+    }
   }
 ]


### PR DESCRIPTION
* Added uncrafts to note and map items.
* Fixed survivor encampment map to point to the new versions of them.
* Obsoleted the map that only points to the single-NPC prepper location, since it didn't spawn anywhere and the location it points to if I recall spawns on roads now.
* Removed map from Evy's inventory since it's while it might explain how she found the location (aside from just Evy being Evy), it's just redundant to the player since they're already there.
* Removed map items from the super soldier and bio-weapon NPCs at the command center, being largely redundant by the time you reach that location plus a map to the unknown lab already spawns in the command center if you somehow beef it and softlock Router's mission.