### PR TITLE
Adjustment to makeshift power armor

### DIFF
--- a/nocts_cata_mod_BN/Surv_help/c_armor.json
+++ b/nocts_cata_mod_BN/Surv_help/c_armor.json
@@ -952,7 +952,7 @@
     "description": "An incredibly heavy suit of steel plates covering a network of hydraulics, driven by pieces of a stripped-down diesel engine jury-rigged to assist the wearer's movements.  It's currently active, strengthening the wearer and making the armor less encumbering, but also being warmer and making stealth more difficult.",
     "extend": { "effects": [ "TRADER_AVOID" ] },
     "//": "power_draw does not actually work sanely for non-battery items, so value fits for roughly how many turns one unit of the weakest allowed fuel would last at twice the power draw of vanilla power armor, rounded down.",
-    "turns_per_charge": 3,
+    "turns_per_charge": 6,
     "revert_to": "c_power_armor_surv",
     "revert_msg": "Your makeshift power armor sputters and dies!",
     "use_action": {

--- a/nocts_cata_mod_DDA/Surv_help/c_armor.json
+++ b/nocts_cata_mod_DDA/Surv_help/c_armor.json
@@ -1087,7 +1087,7 @@
     "description": "An incredibly heavy suit of steel plates covering a network of hydraulics, driven by pieces of a stripped-down diesel engine jury-rigged to assist the wearer's movements.  It's currently active, strengthening the wearer and making the armor less encumbering, but also being warmer and making stealth more difficult.",
     "extend": { "effects": [ "TRADER_AVOID" ] },
     "//": "power_draw does not actually work sanely for non-battery items, so value fits for roughly how many turns one unit of the weakest allowed fuel would last at twice the power draw of vanilla power armor, rounded down.",
-    "turns_per_charge": 3,
+    "turns_per_charge": 6,
     "revert_to": "c_power_armor_surv",
     "revert_msg": "Your makeshift power armor sputters and dies!",
     "use_action": {


### PR DESCRIPTION
Lil tweak to energy efficiency of makeshift power armor. Stated turns per charge is meant to fit a rate of power draw double that of regular power armor, relative to the fuel value of the least-efficient fuel usable.

Per that, lamp oil and motor have 26 kJ per unit, power armor draws a total of 2 kW, so makeshift power armor would have 4 kW power draw, making each unit of fuel last 6.5 turns (reasonable to round down to an even 6).