### PR TITLE
Hammer multitool and wire saw updates

### DIFF
--- a/nocts_cata_mod_BN/Recipe/c_recipes.json
+++ b/nocts_cata_mod_BN/Recipe/c_recipes.json
@@ -2831,7 +2831,8 @@
     "components": [
       [ [ "plastic_chunk", 1 ], [ "2x4", 1 ], [ "stick", 1 ] ],
       [ [ "cable", 10 ], [ "wire", 1 ], [ "string_floss", 1 ] ],
-      [ [ "material_sand", 10 ], [ "salt", 20 ] ]
+      [ [ "material_sand", 10 ], [ "salt", 20 ] ],
+      [ [ "superglue", 1 ], [ "bone_glue", 1 ] ]
     ]
   },
   {

--- a/nocts_cata_mod_BN/Surv_help/c_tools.json
+++ b/nocts_cata_mod_BN/Surv_help/c_tools.json
@@ -621,7 +621,7 @@
     "color": "brown",
     "weapon_category": [ "1H_HAMMERS" ],
     "name": { "str": "hammer multi-tool" },
-    "description": "A multi-tool combing a small hammer and pair of pliers.  Small and practical, the survivor's mini-tool-kit.",
+    "description": "A multi-tool combining a small hammer and pliers with a number of other small tools.  Small and practical, the survivor's mini-tool-kit.",
     "price": "50 USD",
     "price_postapoc": "5 USD",
     "material": [ "steel", "wood" ],
@@ -636,11 +636,13 @@
       [ "SAW_W", 1 ],
       [ "SAW_M", 1 ],
       [ "WRENCH", 1 ],
+      [ "PULL", 1 ],
       [ "SCREW", 1 ],
       [ "SCREW_FINE", 1 ],
       [ "BUTCHER", 8 ],
       [ "HAMMER", 2 ],
-      [ "HAMMER_FINE", 1 ]
+      [ "HAMMER_FINE", 1 ],
+      [ "PRY", 1 ]
     ]
   },
   {
@@ -1168,6 +1170,7 @@
     "symbol": ";",
     "color": "light_gray",
     "looks_like": "chain",
-    "qualities": [ [ "SAW_M", 1 ], [ "SAW_W", 1 ] ]
+    "qualities": [ [ "SAW_M", 1 ], [ "SAW_W", 1 ] ],
+    "use_action": "HACKSAW"
   }
 ]

--- a/nocts_cata_mod_DDA/Recipe/c_recipes.json
+++ b/nocts_cata_mod_DDA/Recipe/c_recipes.json
@@ -2993,7 +2993,8 @@
     "components": [
       [ [ "plastic_chunk", 1 ], [ "2x4", 1 ], [ "stick", 1 ] ],
       [ [ "cable", 10 ], [ "wire", 1 ], [ "string_floss", 1 ], [ "thread_kevlar", 25 ] ],
-      [ [ "material_sand", 10 ], [ "salt", 20 ] ]
+      [ [ "material_sand", 10 ], [ "salt", 20 ] ],
+      [ [ "superglue", 1 ], [ "bone_glue", 1 ] ]
     ]
   },
   {

--- a/nocts_cata_mod_DDA/Surv_help/c_tools.json
+++ b/nocts_cata_mod_DDA/Surv_help/c_tools.json
@@ -669,7 +669,7 @@
     "color": "brown",
     "weapon_category": [ "MACES" ],
     "name": { "str": "hammer multi-tool" },
-    "description": "A multi-tool combing a small hammer and pair of pliers.  Small and practical, the survivor's mini-tool-kit.",
+    "description": "A multi-tool combining a small hammer and pliers with a number of other small tools.  Small and practical, the survivor's mini-tool-kit.",
     "price": "50 USD",
     "price_postapoc": "5 USD",
     "material": [ "steel", "wood" ],
@@ -687,7 +687,8 @@
       [ "SCREW_FINE", 1 ],
       [ "BUTCHER", 8 ],
       [ "HAMMER", 2 ],
-      [ "HAMMER_FINE", 1 ]
+      [ "HAMMER_FINE", 1 ],
+      [ "PRY", 1 ]
     ]
   },
   {


### PR DESCRIPTION
Updated the hammer multitool's tool qualities. Gains level 1 prying since claw hammers have that, the BN version gets level 1 bullet pulling since pliers have that (and it's probably more robust than the vanilla multi-tool which doesn't gain it).

Also added the `HACKSAW` use action to the makeshift wire saw, and updated the recipe to require superglue or bone glue due to the required abrasive.