### PR TITLE
Super soldier gear updates

### DIFF
--- a/nocts_cata_mod_BN/Char_creation/c_classes_bw.json
+++ b/nocts_cata_mod_BN/Char_creation/c_classes_bw.json
@@ -466,7 +466,13 @@
         "entries": [
           { "item": "mil_armor", "contents-group": "c_plut_medium" },
           { "item": "two_way_radio", "contents-item": [ "battery_ups" ] },
-          { "item": "arc_laser_rifle", "ammo-item": "battery", "charges": 5000, "contents-item": "shoulder_strap" },
+          {
+            "item": "arc_laser_rifle",
+            "ammo-item": "battery",
+            "charges": 5000,
+            "contents-item": "shoulder_strap",
+            "custom-flags": [ "auto_wield" ]
+          },
           { "item": "knife_combat", "container-item": "sheath" },
           { "item": "neo_laser_pistol_ups", "container-item": "XL_holster" }
         ]
@@ -531,7 +537,13 @@
           { "item": "lmil_armor", "contents-group": "c_plut_medium" },
           { "item": "two_way_radio", "contents-item": [ "battery_ups" ] },
           { "item": "mil_mess_kit", "contents-item": [ "battery_ups" ] },
-          { "item": "mx_laser_sniper", "ammo-item": "battery", "charges": 5000, "contents-item": "shoulder_strap" },
+          {
+            "item": "mx_laser_sniper",
+            "ammo-item": "battery",
+            "charges": 5000,
+            "contents-item": "shoulder_strap",
+            "custom-flags": [ "auto_wield" ]
+          },
           { "item": "neo_laser_pistol_ups", "container-item": "XL_holster" },
           { "item": "knife_combat", "container-item": "sheath" }
         ]
@@ -589,7 +601,13 @@
           { "item": "lmil_armor", "contents-group": "c_plut_light" },
           { "item": "chemistry_set", "contents-item": [ "battery_ups" ] },
           { "item": "two_way_radio", "contents-item": [ "battery_ups" ] },
-          { "item": "akro_laser_smg", "ammo-item": "battery", "charges": 1000, "contents-item": "shoulder_strap" },
+          {
+            "item": "akro_laser_smg",
+            "ammo-item": "battery",
+            "charges": 1000,
+            "contents-item": "shoulder_strap",
+            "custom-flags": [ "auto_wield" ]
+          },
           { "item": "knife_combat", "container-item": "sheath" },
           { "item": "neo_laser_pistol_ups", "container-item": "XL_holster" }
         ]
@@ -637,11 +655,17 @@
     ],
     "items": {
       "both": {
-        "items": [ "helmet_liner", "thermal_shirt", "gloves_liner", "under_armor_shorts", "socks", "hmil_helm" ],
+        "items": [ "helmet_liner", "thermal_shirt", "gloves_liner", "under_armor_shorts", "socks", "hmil_helm", "legrig" ],
         "entries": [
           { "item": "hmil_armor", "contents-group": "c_plut_heavy" },
           { "item": "two_way_radio", "contents-item": "battery_ups" },
-          { "item": "krx_laser_lmg", "ammo-item": "battery", "charges": 10000, "contents-item": "shoulder_strap" },
+          {
+            "item": "krx_laser_lmg",
+            "ammo-item": "battery",
+            "charges": 10000,
+            "contents-item": "shoulder_strap",
+            "custom-flags": [ "auto_wield" ]
+          },
           { "item": "xarm_laser_shotgun_ups", "contents-item": "shoulder_strap" },
           { "item": "knife_combat", "container-item": "sheath" }
         ]

--- a/nocts_cata_mod_BN/Monsters/c_monster_drops.json
+++ b/nocts_cata_mod_BN/Monsters/c_monster_drops.json
@@ -108,7 +108,10 @@
       { "item": "mil_armor", "damage": [ 1, 4 ], "prob": 75 },
       { "item": "mil_helm", "damage": [ 1, 4 ], "prob": 75 },
       { "item": "shield_ballistic", "prob": 10, "damage": [ 1, 4 ] },
-      { "item": "vest", "damage": [ 1, 4 ], "prob": 50 },
+      {
+        "distribution": [ { "item": "molle_pack", "damage": [ 1, 4 ], "prob": 50 }, { "item": "rucksack", "damage": [ 1, 4 ], "prob": 50 } ],
+        "prob": 50
+      },
       {
         "distribution": [
           { "item": "sheath", "contents-item": "knife_combat", "damage": [ 0, 3 ], "prob": 75 },
@@ -159,7 +162,10 @@
       { "item": "mil_armor", "damage": [ 1, 4 ], "prob": 75 },
       { "item": "mil_helm", "damage": [ 1, 4 ], "prob": 75 },
       { "item": "shield_ballistic", "prob": 10, "damage": [ 1, 4 ] },
-      { "item": "vest", "damage": [ 1, 4 ], "prob": 50 },
+      {
+        "distribution": [ { "item": "molle_pack", "damage": [ 1, 4 ], "prob": 50 }, { "item": "rucksack", "damage": [ 1, 4 ], "prob": 50 } ],
+        "prob": 50
+      },
       {
         "distribution": [
           { "item": "sheath", "contents-item": "knife_combat", "damage": [ 0, 3 ], "prob": 75 },
@@ -209,8 +215,14 @@
       { "group": "mon_zombie_bio_common" },
       { "item": "lmil_armor", "damage": [ 1, 4 ], "prob": 75 },
       { "item": "lmil_helm", "damage": [ 1, 4 ], "prob": 75 },
-      { "item": "rucksack", "damage": [ 1, 4 ], "prob": 50 },
-      { "item": "dump_pouch", "damage": [ 1, 4 ], "prob": 50 },
+      {
+        "distribution": [ { "item": "molle_pack", "damage": [ 1, 4 ], "prob": 50 }, { "item": "rucksack", "damage": [ 1, 4 ], "prob": 50 } ],
+        "prob": 50
+      },
+      {
+        "distribution": [ { "item": "legrig", "damage": [ 1, 4 ], "prob": 50 }, { "item": "dump_pouch", "damage": [ 1, 4 ], "prob": 50 } ],
+        "prob": 50
+      },
       {
         "distribution": [
           { "item": "sheath", "contents-item": "knife_combat", "damage": [ 0, 3 ], "prob": 75 },
@@ -265,8 +277,10 @@
       { "item": "hmil_armor", "damage": [ 1, 4 ], "prob": 75 },
       { "item": "hmil_helm", "damage": [ 1, 4 ], "prob": 75 },
       { "item": "shield_ballistic", "prob": 10, "damage": [ 1, 4 ] },
-      { "item": "vest", "damage": [ 1, 4 ], "prob": 50 },
-      { "item": "dump_pouch", "damage": [ 1, 4 ], "prob": 50 },
+      {
+        "distribution": [ { "item": "legrig", "damage": [ 1, 4 ], "prob": 50 }, { "item": "dump_pouch", "damage": [ 1, 4 ], "prob": 50 } ],
+        "prob": 50
+      },
       {
         "distribution": [
           { "item": "sheath", "contents-item": "knife_combat", "damage": [ 0, 3 ], "prob": 75 },
@@ -316,8 +330,10 @@
       { "group": "mon_zombie_bio_common" },
       { "item": "hmil_armor", "damage": [ 1, 4 ], "prob": 75 },
       { "item": "hmil_helm", "damage": [ 1, 4 ], "prob": 75 },
-      { "item": "vest", "damage": [ 1, 4 ], "prob": 50 },
-      { "item": "dump_pouch", "damage": [ 1, 4 ], "prob": 50 },
+      {
+        "distribution": [ { "item": "legrig", "damage": [ 1, 4 ], "prob": 50 }, { "item": "dump_pouch", "damage": [ 1, 4 ], "prob": 50 } ],
+        "prob": 50
+      },
       {
         "distribution": [
           { "item": "sheath", "contents-item": "knife_combat", "damage": [ 0, 3 ], "prob": 75 },
@@ -347,7 +363,10 @@
       { "item": "lmil_armor", "damage": [ 1, 4 ], "prob": 75 },
       { "item": "lmil_helm", "damage": [ 1, 4 ], "prob": 75 },
       { "item": "shield_ballistic", "prob": 10, "damage": [ 1, 4 ] },
-      { "item": "molle_pack", "damage": [ 1, 4 ], "prob": 50 },
+      {
+        "distribution": [ { "item": "molle_pack", "damage": [ 1, 4 ], "prob": 50 }, { "item": "rucksack", "damage": [ 1, 4 ], "prob": 50 } ],
+        "prob": 50
+      },
       {
         "distribution": [
           { "item": "sheath", "contents-item": "knife_combat", "damage": [ 0, 3 ], "prob": 75 },
@@ -404,7 +423,10 @@
       { "group": "mon_zombie_bio_common" },
       { "item": "lmil_armor", "damage": [ 1, 4 ], "prob": 75 },
       { "item": "lmil_helm", "damage": [ 1, 4 ], "prob": 75 },
-      { "item": "molle_pack", "damage": [ 1, 4 ], "prob": 50 },
+      {
+        "distribution": [ { "item": "molle_pack", "damage": [ 1, 4 ], "prob": 50 }, { "item": "rucksack", "damage": [ 1, 4 ], "prob": 50 } ],
+        "prob": 50
+      },
       {
         "distribution": [
           { "item": "sheath", "contents-item": "knife_combat", "damage": [ 0, 3 ], "prob": 75 },
@@ -506,7 +528,10 @@
               { "item": "mil_armor", "damage": [ 1, 4 ], "prob": 75 },
               { "item": "mil_helm", "damage": [ 1, 4 ], "prob": 75 },
               { "item": "shield_ballistic", "prob": 10, "damage": [ 1, 4 ] },
-              { "item": "vest", "damage": [ 1, 4 ], "prob": 50 },
+              {
+                "distribution": [ { "item": "molle_pack", "damage": [ 1, 4 ], "prob": 50 }, { "item": "rucksack", "damage": [ 1, 4 ], "prob": 50 } ],
+                "prob": 50
+              },
               {
                 "item": "medium_atomic_battery_cell_rechargeable",
                 "damage": [ 0, 1 ],
@@ -521,8 +546,10 @@
               { "item": "hmil_armor", "damage": [ 1, 4 ], "prob": 75 },
               { "item": "hmil_helm", "damage": [ 1, 4 ], "prob": 75 },
               { "item": "shield_ballistic", "prob": 10, "damage": [ 1, 4 ] },
-              { "item": "vest", "damage": [ 1, 4 ], "prob": 50 },
-              { "item": "dump_pouch", "damage": [ 1, 4 ], "prob": 50 },
+              {
+                "distribution": [ { "item": "legrig", "damage": [ 1, 4 ], "prob": 50 }, { "item": "dump_pouch", "damage": [ 1, 4 ], "prob": 50 } ],
+                "prob": 50
+              },
               {
                 "distribution": [
                   { "item": "heavy_atomic_battery_cell_rechargeable", "damage": [ 0, 1 ], "charges": [ 0, 10000 ], "prob": 15 },
@@ -537,8 +564,14 @@
             "collection": [
               { "item": "lmil_armor", "damage": [ 1, 4 ], "prob": 75 },
               { "item": "lmil_helm", "damage": [ 1, 4 ], "prob": 75 },
-              { "item": "rucksack", "damage": [ 1, 4 ], "prob": 50 },
-              { "item": "dump_pouch", "damage": [ 1, 4 ], "prob": 50 },
+              {
+                "distribution": [ { "item": "molle_pack", "damage": [ 1, 4 ], "prob": 50 }, { "item": "rucksack", "damage": [ 1, 4 ], "prob": 50 } ],
+                "prob": 50
+              },
+              {
+                "distribution": [ { "item": "legrig", "damage": [ 1, 4 ], "prob": 50 }, { "item": "dump_pouch", "damage": [ 1, 4 ], "prob": 50 } ],
+                "prob": 50
+              },
               {
                 "item": "medium_atomic_battery_cell_rechargeable",
                 "damage": [ 0, 1 ],
@@ -557,7 +590,10 @@
               { "item": "lmil_armor", "damage": [ 1, 4 ], "prob": 75 },
               { "item": "lmil_helm", "damage": [ 1, 4 ], "prob": 75 },
               { "item": "shield_ballistic", "prob": 5, "damage": [ 1, 4 ] },
-              { "item": "molle_pack", "damage": [ 1, 4 ], "prob": 50 },
+              {
+                "distribution": [ { "item": "molle_pack", "damage": [ 1, 4 ], "prob": 50 }, { "item": "rucksack", "damage": [ 1, 4 ], "prob": 50 } ],
+                "prob": 50
+              },
               {
                 "distribution": [
                   { "item": "light_atomic_battery_cell_rechargeable", "damage": [ 0, 1 ], "charges": [ 0, 500 ], "prob": 20 },

--- a/nocts_cata_mod_DDA/Char_creation/c_classes_bw.json
+++ b/nocts_cata_mod_DDA/Char_creation/c_classes_bw.json
@@ -465,7 +465,13 @@
         "entries": [
           { "item": "mil_armor", "contents-group": "c_plut_medium" },
           { "item": "two_way_radio", "contents-item": [ "battery_ups" ] },
-          { "item": "arc_laser_rifle", "ammo-item": "battery", "charges": 5000, "contents-item": "shoulder_strap" },
+          {
+            "item": "arc_laser_rifle",
+            "ammo-item": "battery",
+            "charges": 5000,
+            "contents-item": "shoulder_strap",
+            "custom-flags": [ "auto_wield" ]
+          },
           { "item": "knife_combat", "container-item": "sheath" },
           { "item": "neo_laser_pistol_ups", "container-item": "XL_holster" }
         ]
@@ -530,7 +536,13 @@
           { "item": "lmil_armor", "contents-group": "c_plut_medium" },
           { "item": "two_way_radio", "contents-item": [ "battery_ups" ] },
           { "item": "mil_mess_kit", "contents-item": [ "battery_ups" ] },
-          { "item": "mx_laser_sniper", "ammo-item": "battery", "charges": 5000, "contents-item": "shoulder_strap" },
+          {
+            "item": "mx_laser_sniper",
+            "ammo-item": "battery",
+            "charges": 5000,
+            "contents-item": "shoulder_strap",
+            "custom-flags": [ "auto_wield" ]
+          },
           { "item": "neo_laser_pistol_ups", "container-item": "XL_holster" },
           { "item": "knife_combat", "container-item": "sheath" }
         ]
@@ -589,7 +601,13 @@
           { "item": "lmil_armor", "contents-group": "c_plut_light" },
           { "item": "chemistry_set", "contents-item": [ "battery_ups" ] },
           { "item": "two_way_radio", "contents-item": [ "battery_ups" ] },
-          { "item": "akro_laser_smg", "ammo-item": "battery", "charges": 1000, "contents-item": "shoulder_strap" },
+          {
+            "item": "akro_laser_smg",
+            "ammo-item": "battery",
+            "charges": 1000,
+            "contents-item": "shoulder_strap",
+            "custom-flags": [ "auto_wield" ]
+          },
           { "item": "knife_combat", "container-item": "sheath" },
           { "item": "neo_laser_pistol_ups", "container-item": "XL_holster" }
         ]
@@ -636,11 +654,17 @@
     "proficiencies": [ "prof_gunsmithing_basic", "prof_traps", "prof_disarming", "prof_spotting" ],
     "items": {
       "both": {
-        "items": [ "helmet_liner", "thermal_shirt", "gloves_liner", "under_armor_shorts", "socks", "hmil_helm" ],
+        "items": [ "helmet_liner", "thermal_shirt", "gloves_liner", "under_armor_shorts", "socks", "hmil_helm", "legrig" ],
         "entries": [
           { "item": "hmil_armor", "contents-group": "c_plut_heavy" },
           { "item": "two_way_radio", "contents-item": "battery_ups" },
-          { "item": "krx_laser_lmg", "ammo-item": "battery", "charges": 10000, "contents-item": "shoulder_strap" },
+          {
+            "item": "krx_laser_lmg",
+            "ammo-item": "battery",
+            "charges": 10000,
+            "contents-item": "shoulder_strap",
+            "custom-flags": [ "auto_wield" ]
+          },
           { "item": "xarm_laser_shotgun_ups", "contents-item": "shoulder_strap" },
           { "item": "knife_combat", "container-item": "sheath" }
         ]

--- a/nocts_cata_mod_DDA/Monsters/c_monster_drops.json
+++ b/nocts_cata_mod_DDA/Monsters/c_monster_drops.json
@@ -107,7 +107,10 @@
       { "group": "mon_zombie_bio_common" },
       { "item": "mil_armor", "damage": [ 1, 4 ], "prob": 75 },
       { "item": "mil_helm", "damage": [ 1, 4 ], "prob": 75 },
-      { "item": "vest", "damage": [ 1, 4 ], "prob": 50 },
+      {
+        "distribution": [ { "item": "molle_pack", "damage": [ 1, 4 ], "prob": 50 }, { "item": "rucksack", "damage": [ 1, 4 ], "prob": 50 } ],
+        "prob": 50
+      },
       {
         "distribution": [
           { "item": "sheath", "contents-item": "knife_combat", "damage": [ 0, 3 ], "prob": 75 },
@@ -151,7 +154,10 @@
       { "group": "mon_zombie_bio_common" },
       { "item": "mil_armor", "damage": [ 1, 4 ], "prob": 75 },
       { "item": "mil_helm", "damage": [ 1, 4 ], "prob": 75 },
-      { "item": "vest", "damage": [ 1, 4 ], "prob": 50 },
+      {
+        "distribution": [ { "item": "molle_pack", "damage": [ 1, 4 ], "prob": 50 }, { "item": "rucksack", "damage": [ 1, 4 ], "prob": 50 } ],
+        "prob": 50
+      },
       {
         "distribution": [
           { "item": "sheath", "contents-item": "knife_combat", "damage": [ 0, 3 ], "prob": 75 },
@@ -195,8 +201,14 @@
       { "group": "mon_zombie_bio_common" },
       { "item": "lmil_armor", "damage": [ 1, 4 ], "prob": 75 },
       { "item": "lmil_helm", "damage": [ 1, 4 ], "prob": 75 },
-      { "item": "rucksack", "damage": [ 1, 4 ], "prob": 50 },
-      { "item": "dump_pouch", "damage": [ 1, 4 ], "prob": 50 },
+      {
+        "distribution": [ { "item": "molle_pack", "damage": [ 1, 4 ], "prob": 50 }, { "item": "rucksack", "damage": [ 1, 4 ], "prob": 50 } ],
+        "prob": 50
+      },
+      {
+        "distribution": [ { "item": "legrig", "damage": [ 1, 4 ], "prob": 50 }, { "item": "dump_pouch", "damage": [ 1, 4 ], "prob": 50 } ],
+        "prob": 50
+      },
       {
         "distribution": [
           { "item": "sheath", "contents-item": "knife_combat", "damage": [ 0, 3 ], "prob": 75 },
@@ -244,8 +256,10 @@
       { "group": "mon_zombie_bio_common" },
       { "item": "hmil_armor", "damage": [ 1, 4 ], "prob": 75 },
       { "item": "hmil_helm", "damage": [ 1, 4 ], "prob": 75 },
-      { "item": "vest", "damage": [ 1, 4 ], "prob": 50 },
-      { "item": "dump_pouch", "damage": [ 1, 4 ], "prob": 50 },
+      {
+        "distribution": [ { "item": "legrig", "damage": [ 1, 4 ], "prob": 50 }, { "item": "dump_pouch", "damage": [ 1, 4 ], "prob": 50 } ],
+        "prob": 50
+      },
       {
         "distribution": [
           { "item": "sheath", "contents-item": "knife_combat", "damage": [ 0, 3 ], "prob": 75 },
@@ -289,8 +303,10 @@
       { "group": "mon_zombie_bio_common" },
       { "item": "hmil_armor", "damage": [ 1, 4 ], "prob": 75 },
       { "item": "hmil_helm", "damage": [ 1, 4 ], "prob": 75 },
-      { "item": "vest", "damage": [ 1, 4 ], "prob": 50 },
-      { "item": "dump_pouch", "damage": [ 1, 4 ], "prob": 50 },
+      {
+        "distribution": [ { "item": "legrig", "damage": [ 1, 4 ], "prob": 50 }, { "item": "dump_pouch", "damage": [ 1, 4 ], "prob": 50 } ],
+        "prob": 50
+      },
       {
         "distribution": [
           { "item": "sheath", "contents-item": "knife_combat", "damage": [ 0, 3 ], "prob": 75 },
@@ -313,7 +329,10 @@
       { "group": "mon_zombie_bio_common" },
       { "item": "lmil_armor", "damage": [ 1, 4 ], "prob": 75 },
       { "item": "lmil_helm", "damage": [ 1, 4 ], "prob": 75 },
-      { "item": "molle_pack", "damage": [ 1, 4 ], "prob": 50 },
+      {
+        "distribution": [ { "item": "molle_pack", "damage": [ 1, 4 ], "prob": 50 }, { "item": "rucksack", "damage": [ 1, 4 ], "prob": 50 } ],
+        "prob": 50
+      },
       {
         "distribution": [
           { "item": "sheath", "contents-item": "knife_combat", "damage": [ 0, 3 ], "prob": 75 },
@@ -364,7 +383,10 @@
       { "group": "mon_zombie_bio_common" },
       { "item": "lmil_armor", "damage": [ 1, 4 ], "prob": 75 },
       { "item": "lmil_helm", "damage": [ 1, 4 ], "prob": 75 },
-      { "item": "molle_pack", "damage": [ 1, 4 ], "prob": 50 },
+      {
+        "distribution": [ { "item": "molle_pack", "damage": [ 1, 4 ], "prob": 50 }, { "item": "rucksack", "damage": [ 1, 4 ], "prob": 50 } ],
+        "prob": 50
+      },
       {
         "distribution": [
           { "item": "sheath", "contents-item": "knife_combat", "damage": [ 0, 3 ], "prob": 75 },
@@ -459,7 +481,10 @@
             "collection": [
               { "item": "mil_armor", "damage": [ 1, 4 ], "prob": 75 },
               { "item": "mil_helm", "damage": [ 1, 4 ], "prob": 75 },
-              { "item": "vest", "damage": [ 1, 4 ], "prob": 50 },
+              {
+                "distribution": [ { "item": "molle_pack", "damage": [ 1, 4 ], "prob": 50 }, { "item": "rucksack", "damage": [ 1, 4 ], "prob": 50 } ],
+                "prob": 50
+              },
               {
                 "item": "medium_atomic_battery_cell_rechargeable",
                 "damage": [ 0, 1 ],
@@ -473,8 +498,10 @@
             "collection": [
               { "item": "hmil_armor", "damage": [ 1, 4 ], "prob": 75 },
               { "item": "hmil_helm", "damage": [ 1, 4 ], "prob": 75 },
-              { "item": "vest", "damage": [ 1, 4 ], "prob": 50 },
-              { "item": "dump_pouch", "damage": [ 1, 4 ], "prob": 50 },
+              {
+                "distribution": [ { "item": "legrig", "damage": [ 1, 4 ], "prob": 50 }, { "item": "dump_pouch", "damage": [ 1, 4 ], "prob": 50 } ],
+                "prob": 50
+              },
               {
                 "distribution": [
                   { "item": "heavy_atomic_battery_cell_rechargeable", "damage": [ 0, 1 ], "charges": [ 0, 10000 ], "prob": 15 },
@@ -489,8 +516,14 @@
             "collection": [
               { "item": "lmil_armor", "damage": [ 1, 4 ], "prob": 75 },
               { "item": "lmil_helm", "damage": [ 1, 4 ], "prob": 75 },
-              { "item": "rucksack", "damage": [ 1, 4 ], "prob": 50 },
-              { "item": "dump_pouch", "damage": [ 1, 4 ], "prob": 50 },
+              {
+                "distribution": [ { "item": "molle_pack", "damage": [ 1, 4 ], "prob": 50 }, { "item": "rucksack", "damage": [ 1, 4 ], "prob": 50 } ],
+                "prob": 50
+              },
+              {
+                "distribution": [ { "item": "legrig", "damage": [ 1, 4 ], "prob": 50 }, { "item": "dump_pouch", "damage": [ 1, 4 ], "prob": 50 } ],
+                "prob": 50
+              },
               {
                 "item": "medium_atomic_battery_cell_rechargeable",
                 "damage": [ 0, 1 ],
@@ -508,7 +541,10 @@
             "collection": [
               { "item": "lmil_armor", "damage": [ 1, 4 ], "prob": 75 },
               { "item": "lmil_helm", "damage": [ 1, 4 ], "prob": 75 },
-              { "item": "molle_pack", "damage": [ 1, 4 ], "prob": 50 },
+              {
+                "distribution": [ { "item": "molle_pack", "damage": [ 1, 4 ], "prob": 50 }, { "item": "rucksack", "damage": [ 1, 4 ], "prob": 50 } ],
+                "prob": 50
+              },
               {
                 "distribution": [
                   { "item": "light_atomic_battery_cell_rechargeable", "damage": [ 0, 1 ], "charges": [ 0, 500 ], "prob": 20 },


### PR DESCRIPTION
* Set it so the super soldier professions all start off wielding their primary weapon instead of having it slung on their shoulder.
* Added a drop leg pouch to the super soldier juggernaut so they have at least some storage without beefing up their torso encumbrance even more than it's already at.
* Belatedly updated augmented undead juggernaut monsterdrops, has it pick between dump pouch and drop leg pouches at random, likewise set the others to randomly pick MOLLE pack or rucksack.