### PR TITLE
Pending BN updates: assassination scenario

### DIFF
--- a/nocts_cata_mod_BN/Char_creation/c_scenarios.json
+++ b/nocts_cata_mod_BN/Char_creation/c_scenarios.json
@@ -209,5 +209,11 @@
     "type": "scenario",
     "id": "migo_prisoner",
     "extend": { "professions": [ "failed_weapon" ] }
+  },
+  {
+    "copy-from": "assassination",
+    "type": "scenario",
+    "id": "assassination",
+    "extend": { "professions": [ "bio_weapon_d", "bio_scout", "bionic_silencer" ] }
   }
 ]


### PR DESCRIPTION
Simple lil thing set aside for when https://github.com/cataclysmbnteam/Cataclysm-BN/pull/2908 is merged, adds the following professions to the new assassination scenario:
* Bio-Weapon Delta
* Super Scout
* Bionic Silencer

Not relevant for DDA since it seems their implementation was done purely via missions attached to the relevant professions.