### PR TITLE
Update to makeshift thermal lance recipe

### DIFF
--- a/nocts_cata_mod_BN/Recipe/c_recipes.json
+++ b/nocts_cata_mod_BN/Recipe/c_recipes.json
@@ -2095,8 +2095,8 @@
     "tools": [ [ [ "smoxygen_tank", 12 ], [ "oxygen_tank", 12 ], [ "oxygen_cylinder", 100 ] ] ],
     "components": [
       [ [ "pipe", 1 ] ],
-      [ [ "hose", 1 ] ],
-      [ [ "canister_empty", 1 ] ],
+      [ [ "hose", 1 ], [ "makeshift_hose", 1 ] ],
+      [ [ "canister_empty", 1 ], [ "clay_canister", 1 ] ],
       [ [ "pilot_light", 1 ] ],
       [ [ "magnesium", 50 ], [ "incendiary", 50 ] ]
     ]
@@ -2106,7 +2106,7 @@
     "type": "uncraft",
     "time": "2 m",
     "qualities": [ { "id": "SCREW", "level": 1 } ],
-    "components": [ [ [ "canister_empty", 1 ] ], [ [ "hose", 1 ] ], [ [ "scrap", 1 ] ] ]
+    "components": [ [ [ "canister_empty", 1 ] ], [ [ "pilot_light", 1 ] ], [ [ "hose", 1 ] ], [ [ "scrap", 1 ] ] ]
   },
   {
     "result": "lmil_armor",

--- a/nocts_cata_mod_BN/Recipe/c_recipes.json
+++ b/nocts_cata_mod_BN/Recipe/c_recipes.json
@@ -2098,7 +2098,7 @@
       [ [ "hose", 1 ], [ "makeshift_hose", 1 ] ],
       [ [ "canister_empty", 1 ], [ "clay_canister", 1 ] ],
       [ [ "pilot_light", 1 ] ],
-      [ [ "magnesium", 50 ], [ "incendiary", 50 ] ]
+      [ [ "magnesium", 50 ], [ "chem_aluminium_powder", 50 ], [ "incendiary", 50 ] ]
     ]
   },
   {

--- a/nocts_cata_mod_DDA/Recipe/c_recipes.json
+++ b/nocts_cata_mod_DDA/Recipe/c_recipes.json
@@ -2231,7 +2231,7 @@
       [ [ "hose", 1 ], [ "makeshift_hose", 1 ] ],
       [ [ "canister_empty", 1 ], [ "clay_canister", 1 ] ],
       [ [ "pilot_light", 1 ] ],
-      [ [ "magnesium", 50 ], [ "incendiary", 50 ] ]
+      [ [ "magnesium", 50 ], [ "chem_aluminium_powder", 50 ], [ "incendiary", 50 ] ]
     ]
   },
   {

--- a/nocts_cata_mod_DDA/Recipe/c_recipes.json
+++ b/nocts_cata_mod_DDA/Recipe/c_recipes.json
@@ -2228,8 +2228,8 @@
     "tools": [ [ [ "smoxygen_tank", 12 ], [ "oxygen_tank", 12 ], [ "oxygen_cylinder", 100 ] ] ],
     "components": [
       [ [ "pipe", 1 ] ],
-      [ [ "hose", 1 ] ],
-      [ [ "canister_empty", 1 ] ],
+      [ [ "hose", 1 ], [ "makeshift_hose", 1 ] ],
+      [ [ "canister_empty", 1 ], [ "clay_canister", 1 ] ],
       [ [ "pilot_light", 1 ] ],
       [ [ "magnesium", 50 ], [ "incendiary", 50 ] ]
     ]
@@ -2240,7 +2240,7 @@
     "activity_level": "LIGHT_EXERCISE",
     "time": "2 m",
     "qualities": [ { "id": "SCREW", "level": 1 } ],
-    "components": [ [ [ "canister_empty", 1 ] ], [ [ "hose", 1 ] ], [ [ "scrap", 1 ] ] ]
+    "components": [ [ [ "canister_empty", 1 ] ], [ [ "pilot_light", 1 ] ], [ [ "hose", 1 ] ], [ [ "scrap", 1 ] ] ]
   },
   {
     "result": "lmil_armor",


### PR DESCRIPTION
Added a few alternatives to some items for the makeshift thermal lance recipe. Splitting it up into the main tool itself and refillable tanks, like the acetylene torch, would be the overall more complete way to fix this since the whole "uncraft it into surviving components" thing effectively transmutates clay canisters into canisters and leather hoses into rubber hoses, but doing so isn't really exploitable. Less hassle than trying to work around needing to use oxygen packs as tools in the recipe, if not for that I could just make the main recipe itself reversible and add `NO_RECOVER` to the components that will be lost on uncraft.