### PR TITLE
Update vehicle JSON, other fixes

### DIFF
--- a/nocts_cata_mod_BN/Vehicles/c_carts.json
+++ b/nocts_cata_mod_BN/Vehicles/c_carts.json
@@ -5,10 +5,7 @@
     "name": "Chemistry Station",
     "blueprint": [ "&" ],
     "parts": [
-      { "x": 0, "y": 0, "part": "xlframe_vertical_2" },
-      { "x": 0, "y": 0, "part": "wheel_caster" },
-      { "x": 0, "y": 0, "part": "small_storage_battery" },
-      { "x": 0, "y": 0, "part": "chemlab" }
+      { "x": 0, "y": 0, "parts": ["xlframe_vertical_2", "wheel_caster", "small_storage_battery", "chemlab"] }
     ]
   },
   {
@@ -17,10 +14,7 @@
     "name": "Survivor Station",
     "blueprint": [ "&" ],
     "parts": [
-      { "x": 0, "y": 0, "part": "xlframe_vertical_2" },
-      { "x": 0, "y": 0, "part": "wheel_caster" },
-      { "x": 0, "y": 0, "part": "small_storage_battery" },
-      { "x": 0, "y": 0, "part": "surv_station_t" }
+      { "x": 0, "y": 0, "parts": ["xlframe_vertical_2", "wheel_caster", "small_storage_battery", "surv_station_t"] }
     ]
   },
   {
@@ -30,8 +24,7 @@
     "blueprint": [ "&" ],
     "parts": [
       { "x": 0, "y": 0, "parts": [ "xlframe_horizontal", "wheel_caster", "medium_storage_battery", "autoclave" ] },
-      { "x": 1, "y": 0, "parts": [ "xlframe_horizontal", "wheel_caster", "box", "water_faucet" ] },
-      { "x": 1, "y": 0, "part": "tank_little", "fuel": "water" }
+      { "x": 1, "y": 0, "parts": [ "xlframe_horizontal", "wheel_caster", "box", "water_faucet", { "part": "tank_little", "fuel": "water" } ] }
     ],
     "items": [ { "x": 0, "y": 0, "chance": 90, "items": [ "pouch_autoclave" ] } ]
   }

--- a/nocts_cata_mod_BN/Vehicles/c_vehicles.json
+++ b/nocts_cata_mod_BN/Vehicles/c_vehicles.json
@@ -5,81 +5,222 @@
     "name": "Survivor's Militarized RV",
     "parts": [
       { "x": 1, "y": -1, "parts": [ "hdframe_nw", "reinforced_windshield", "omnicam", "plating_hard" ] },
-      { "x": 1, "y": 0, "parts": [ "hdframe_horizontal", "reinforced_windshield", "storage_battery", "headlight_reinforced", "plating_hard" ] },
-      { "x": 1, "y": 1, "parts": [ "hdframe_horizontal", "reinforced_windshield","storage_battery", "plating_hard" ] },
-      { "x": 1, "y": 2, "parts": [ "hdframe_horizontal", "reinforced_windshield", "storage_battery", "plating_hard" ] },
-      { "x": 1, "y": 3, "parts": [ "hdframe_horizontal", "reinforced_windshield", "storage_battery", "headlight_reinforced", "plating_hard" ] },
+      {
+        "x": 1,
+        "y": 0,
+        "parts": [ "hdframe_horizontal", "reinforced_windshield", "storage_battery", "headlight_reinforced", "plating_hard" ]
+      },
+      {
+        "x": 1,
+        "y": 1,
+        "parts": [ "hdframe_horizontal", "reinforced_windshield", "storage_battery", "plating_hard" ]
+      },
+      {
+        "x": 1,
+        "y": 2,
+        "parts": [ "hdframe_horizontal", "reinforced_windshield", "storage_battery", "plating_hard" ]
+      },
+      {
+        "x": 1,
+        "y": 3,
+        "parts": [ "hdframe_horizontal", "reinforced_windshield", "storage_battery", "headlight_reinforced", "plating_hard" ]
+      },
       { "x": 1, "y": 4, "parts": [ "hdframe_ne", "reinforced_windshield", "omnicam", "plating_hard" ] },
-
-      { "x": 0, "y": -1, "parts": [ "hdframe_vertical", "wheel_mount_heavy_steerable", "wheel_armor", "hddoor", "inboard_mirror", "plating_hard", "door_motor" ] },
-      { "x": 0, "y": 0, "parts": [ "hdframe_vertical_2", "turret_mount", "ups_rifle_t", "hdroof", "seat", "seatbelt_heavyduty", "cam_control", "controls", "dashboard", "vehicle_clock", "vehicle_alarm", "stereo" ] },
-      { "x": 0, "y": 1, "parts": [ "hdframe_vertical_2", "tracker", "inboard_mirror", "horn_big", "trunk_floor", "hdroof" ] },
+      {
+        "x": 0,
+        "y": -1,
+        "parts": [
+          "hdframe_vertical",
+          "wheel_mount_heavy_steerable",
+          "wheel_armor",
+          "hddoor",
+          "inboard_mirror",
+          "plating_hard",
+          "door_motor"
+        ]
+      },
+      {
+        "x": 0,
+        "y": 0,
+        "parts": [
+          "hdframe_vertical_2",
+          "turret_mount",
+          "ups_rifle_t",
+          "hdroof",
+          "seat",
+          "seatbelt_heavyduty",
+          "cam_control",
+          "controls",
+          "dashboard",
+          "vehicle_clock",
+          "vehicle_alarm",
+          "stereo"
+        ]
+      },
+      {
+        "x": 0,
+        "y": 1,
+        "parts": [ "hdframe_vertical_2", "tracker", "inboard_mirror", "horn_big", "trunk_floor", "hdroof" ]
+      },
       { "x": 0, "y": 2, "parts": [ "hdframe_vertical_2", "tracker", "trunk_floor", "hdroof" ] },
-      { "x": 0, "y": 3, "parts": [ "hdframe_vertical_2", "turret_mount", "ups_rifle_t", "hdroof", "seat", "seatbelt_heavyduty" ] },
-      { "x": 0, "y": 4, "parts": [ "hdframe_vertical", "wheel_mount_heavy_steerable", "wheel_armor", "hddoor", "inboard_mirror", "plating_hard", "door_motor" ] },
-
+      {
+        "x": 0,
+        "y": 3,
+        "parts": [ "hdframe_vertical_2", "turret_mount", "ups_rifle_t", "hdroof", "seat", "seatbelt_heavyduty" ]
+      },
+      {
+        "x": 0,
+        "y": 4,
+        "parts": [
+          "hdframe_vertical",
+          "wheel_mount_heavy_steerable",
+          "wheel_armor",
+          "hddoor",
+          "inboard_mirror",
+          "plating_hard",
+          "door_motor"
+        ]
+      },
       { "x": -1, "y": -1, "parts": [ "hdframe_vertical", "hdboard_vertical", "floodlight", "plating_hard" ] },
-      { "x": -1, "y": 0, "parts": [ "hdframe_vertical_2", "stowboard_horizontal", "minireactor", "engine_electric_enhanced" ] },
+      {
+        "x": -1,
+        "y": 0,
+        "parts": [ "hdframe_vertical_2", "stowboard_horizontal", "minireactor", "engine_electric_enhanced" ]
+      },
       { "x": -1, "y": 1, "parts": [ "hdframe_vertical_2", "hdroof", "door_internal", "door_motor" ] },
       { "x": -1, "y": 2, "parts": [ "hdframe_vertical_2", "stowboard_horizontal" ] },
-      { "x": -1, "y": 3, "parts": [ "hdframe_vertical_2", "stowboard_horizontal", "minireactor", "engine_electric_enhanced" ] },
+      {
+        "x": -1,
+        "y": 3,
+        "parts": [ "hdframe_vertical_2", "stowboard_horizontal", "minireactor", "engine_electric_enhanced" ]
+      },
       { "x": -1, "y": 4, "parts": [ "hdframe_vertical", "hdboard_vertical", "floodlight", "plating_hard" ] },
-
       { "x": -2, "y": -1, "parts": [ "hdframe_vertical", "reinforced_windshield", "v_curtain", "plating_hard" ] },
       { "x": -2, "y": 0, "parts": [ "hdframe_vertical_2", "lit_aisle_horizontal", "hdroof" ] },
       { "x": -2, "y": 1, "parts": [ "hdframe_vertical_2", "aisle_horizontal", "hdroof" ] },
       { "x": -2, "y": 2, "parts": [ "hdframe_vertical_2", "aisle_horizontal", "hdroof" ] },
       { "x": -2, "y": 3, "parts": [ "hdframe_vertical_2", "lit_aisle_horizontal", "hdroof" ] },
       { "x": -2, "y": 4, "parts": [ "hdframe_vertical", "door_opaque", "plating_hard", "door_motor" ] },
-
       { "x": -3, "y": -1, "parts": [ "hdframe_vertical", "hdboard_vertical", "plating_hard" ] },
       { "x": -3, "y": 0, "parts": [ "hdframe_vertical_2", "hdroof", "minifreezer" ] },
       { "x": -3, "y": 1, "parts": [ "hdframe_vertical_2", "aisle_horizontal", "hdroof" ] },
       { "x": -3, "y": 2, "parts": [ "hdframe_vertical_2", "aisle_horizontal", "hdroof" ] },
       { "x": -3, "y": 3, "parts": [ "hdframe_vertical_2", "hdroof", "aisle_horizontal" ] },
       { "x": -3, "y": 4, "parts": [ "hdframe_vertical", "reinforced_windshield", "v_curtain", "plating_hard" ] },
-
       { "x": -4, "y": -1, "parts": [ "hdframe_vertical", "floodlight", "hdboard_vertical", "plating_hard" ] },
       { "x": -4, "y": 0, "parts": [ "hdframe_vertical_2", "hdroof", "minifridge" ] },
       { "x": -4, "y": 1, "parts": [ "hdframe_vertical_2", "aisle_horizontal", "hdroof" ] },
       { "x": -4, "y": 2, "parts": [ "hdframe_vertical_2", "aisle_horizontal", "hdroof" ] },
       { "x": -4, "y": 3, "parts": [ "hdframe_vertical_2", "hdroof", "veh_table_wood" ] },
-      { "x": -4, "y": 4, "parts": [ "hdframe_vertical", "floodlight", "reinforced_windshield", "v_curtain", "plating_hard" ] },
-
+      {
+        "x": -4,
+        "y": 4,
+        "parts": [ "hdframe_vertical", "floodlight", "reinforced_windshield", "v_curtain", "plating_hard" ]
+      },
       { "x": -5, "y": -1, "parts": [ "hdframe_vertical", "omnicam", "hdboard_vertical", "plating_hard" ] },
       { "x": -5, "y": 0, "parts": [ "hdframe_vertical_2", "hdroof", "surv_station_t", "tank" ] },
       { "x": -5, "y": 1, "parts": [ "hdframe_vertical_2", "lit_aisle_horizontal", "hdroof" ] },
       { "x": -5, "y": 2, "parts": [ "hdframe_vertical_2", "aisle_horizontal", "hdroof" ] },
       { "x": -5, "y": 3, "parts": [ "hdframe_vertical_2", "hdroof", "seat_wood" ] },
-      { "x": -5, "y": 4, "parts": [ "hdframe_vertical", "omnicam", "reinforced_windshield", "v_curtain", "plating_hard" ] },
-
+      {
+        "x": -5,
+        "y": 4,
+        "parts": [ "hdframe_vertical", "omnicam", "reinforced_windshield", "v_curtain", "plating_hard" ]
+      },
       { "x": -6, "y": -1, "parts": [ "hdframe_vertical", "hdboard_vertical", "funnel", "tank", "plating_hard" ] },
       { "x": -6, "y": 0, "parts": [ "hdframe_vertical_2", "stowboard_horizontal", "recharge_station" ] },
       { "x": -6, "y": 1, "parts": [ "hdframe_vertical_2", "hdroof", "door_internal" ] },
       { "x": -6, "y": 2, "parts": [ "hdframe_vertical_2", "stowboard_horizontal", "recharge_station" ] },
       { "x": -6, "y": 3, "parts": [ "hdframe_vertical_2", "stowboard_horizontal", "recharge_station" ] },
       { "x": -6, "y": 4, "parts": [ "hdframe_vertical", "hdboard_vertical", "funnel", "tank", "plating_hard" ] },
-
       { "x": -7, "y": -1, "parts": [ "hdframe_vertical", "reinforced_windshield", "v_curtain", "plating_hard" ] },
       { "x": -7, "y": 0, "parts": [ "hdframe_vertical_2", "hdroof", "reinforced_solar_panel_v2", "cargo_space" ] },
-      { "x": -7, "y": 1, "parts": [ "hdframe_vertical_2", "hdroof", "reinforced_solar_panel_v2", "aisle_horizontal" ] },
-      { "x": -7, "y": 2, "parts": [ "hdframe_vertical_2", "hdroof", "reinforced_solar_panel_v2", "aisle_horizontal" ] },
-      { "x": -7, "y": 3, "parts": [ "hdframe_vertical_2", "hdroof", "reinforced_solar_panel_v2", "veh_table_wood", "atomic_lamp" ] },
+      {
+        "x": -7,
+        "y": 1,
+        "parts": [ "hdframe_vertical_2", "hdroof", "reinforced_solar_panel_v2", "aisle_horizontal" ]
+      },
+      {
+        "x": -7,
+        "y": 2,
+        "parts": [ "hdframe_vertical_2", "hdroof", "reinforced_solar_panel_v2", "aisle_horizontal" ]
+      },
+      {
+        "x": -7,
+        "y": 3,
+        "parts": [ "hdframe_vertical_2", "hdroof", "reinforced_solar_panel_v2", "veh_table_wood", "atomic_lamp" ]
+      },
       { "x": -7, "y": 4, "parts": [ "hdframe_vertical", "reinforced_windshield", "v_curtain", "plating_hard" ] },
-
-      { "x": -8, "y": -1, "parts": [ "hdframe_vertical", "wheel_mount_heavy", "wheel_armor", "reinforced_windshield", "v_curtain", "plating_hard" ] },
+      {
+        "x": -8,
+        "y": -1,
+        "parts": [ "hdframe_vertical", "wheel_mount_heavy", "wheel_armor", "reinforced_windshield", "v_curtain", "plating_hard" ]
+      },
       { "x": -8, "y": 0, "parts": [ "hdframe_vertical_2", "hdroof", "reinforced_solar_panel_v2", "cargo_space" ] },
-      { "x": -8, "y": 1, "parts": [ "hdframe_vertical_2", "hdroof", "reinforced_solar_panel_v2", "aisle_horizontal" ] },
-      { "x": -8, "y": 2, "parts": [ "hdframe_vertical_2", "hdroof", "reinforced_solar_panel_v2", "aisle_horizontal" ] },
+      {
+        "x": -8,
+        "y": 1,
+        "parts": [ "hdframe_vertical_2", "hdroof", "reinforced_solar_panel_v2", "aisle_horizontal" ]
+      },
+      {
+        "x": -8,
+        "y": 2,
+        "parts": [ "hdframe_vertical_2", "hdroof", "reinforced_solar_panel_v2", "aisle_horizontal" ]
+      },
       { "x": -8, "y": 3, "parts": [ "hdframe_vertical_2", "hdroof", "reinforced_solar_panel_v2", "bed" ] },
-      { "x": -8, "y": 4, "parts": [ "hdframe_vertical", "wheel_mount_heavy", "wheel_armor", "reinforced_windshield", "v_curtain", "plating_hard" ] },
-
-      { "x": -9, "y": -1, "parts": [ "hdframe_sw", "wheel_mount_heavy", "wheel_armor", "hdboard_sw", "omnicam", "storage_battery_mount", "storage_battery_removable", "plating_hard" ] },
-      { "x": -9, "y": 0, "parts": [ "hdframe_horizontal", "stowboard_horizontal", "turret_mount", "ups_rifle_t", "bike_rack", "muffler", "plating_hard" ] },
-      { "x": -9, "y": 1, "parts": [ "hdframe_horizontal", "stowboard_horizontal", "bike_rack", "floodlight", "plating_hard" ] },
-      { "x": -9, "y": 2, "parts": [ "hdframe_horizontal", "stowboard_horizontal", "bike_rack", "floodlight", "plating_hard" ] },
-      { "x": -9, "y": 3, "parts": [ "hdframe_horizontal", "stowboard_horizontal", "turret_mount", "ups_rifle_t", "bike_rack", "muffler", "plating_hard" ] },
-      { "x": -9, "y": 4, "parts": [ "hdframe_se", "wheel_mount_heavy", "wheel_armor", "hdboard_se", "omnicam", "storage_battery_mount", "storage_battery_removable", "plating_hard" ] }
+      {
+        "x": -8,
+        "y": 4,
+        "parts": [ "hdframe_vertical", "wheel_mount_heavy", "wheel_armor", "reinforced_windshield", "v_curtain", "plating_hard" ]
+      },
+      {
+        "x": -9,
+        "y": -1,
+        "parts": [
+          "hdframe_sw",
+          "wheel_mount_heavy",
+          "wheel_armor",
+          "hdboard_sw",
+          "omnicam",
+          "storage_battery_mount",
+          "storage_battery_removable",
+          "plating_hard"
+        ]
+      },
+      {
+        "x": -9,
+        "y": 0,
+        "parts": [ "hdframe_horizontal", "stowboard_horizontal", "turret_mount", "ups_rifle_t", "bike_rack", "muffler", "plating_hard" ]
+      },
+      {
+        "x": -9,
+        "y": 1,
+        "parts": [ "hdframe_horizontal", "stowboard_horizontal", "bike_rack", "floodlight", "plating_hard" ]
+      },
+      {
+        "x": -9,
+        "y": 2,
+        "parts": [ "hdframe_horizontal", "stowboard_horizontal", "bike_rack", "floodlight", "plating_hard" ]
+      },
+      {
+        "x": -9,
+        "y": 3,
+        "parts": [ "hdframe_horizontal", "stowboard_horizontal", "turret_mount", "ups_rifle_t", "bike_rack", "muffler", "plating_hard" ]
+      },
+      {
+        "x": -9,
+        "y": 4,
+        "parts": [
+          "hdframe_se",
+          "wheel_mount_heavy",
+          "wheel_armor",
+          "hdboard_se",
+          "omnicam",
+          "storage_battery_mount",
+          "storage_battery_removable",
+          "plating_hard"
+        ]
+      }
     ],
     "items": [
       { "x": -9, "y": 0, "chance": 50, "items": [ "folding_bicycle" ] },
@@ -107,61 +248,68 @@
     "id": "surv_tractor",
     "type": "vehicle",
     "name": "Survivor Tractor",
-    "blueprint": [ [ "O---O" ], [ "8|=x|" ], [ "O-+-O" ] ],
-    "parts": [
-      { "x": 0, "y": 1, "part": "hdframe_vertical" },
-      { "x": 0, "y": 1, "part": "door_opaque" },
-      { "x": 0, "y": 0, "part": "hdframe_vertical_2" },
-      { "x": 0, "y": 0, "part": "reaper_advanced" },
-      { "x": 0, "y": 0, "part": "hdroof" },
-      { "x": 0, "y": -1, "part": "hdframe_vertical" },
-      { "x": 0, "y": -1, "part": "hdboard_vertical" },
-      { "x": 1, "y": 1, "part": "hdframe_vertical" },
-      { "x": 1, "y": 1, "part": "reinforced_windshield" },
-      { "x": 1, "y": 0, "part": "hdframe_vertical_2" },
-      { "x": 1, "y": 0, "part": "controls" },
-      { "x": 1, "y": 0, "part": "seat" },
-      { "x": 1, "y": 0, "part": "seatbelt_heavyduty" },
-      { "x": 1, "y": 0, "part": "hdroof" },
-      { "x": 1, "y": -1, "part": "hdframe_vertical" },
-      { "x": 1, "y": -1, "part": "reinforced_windshield" },
-      { "x": 2, "y": 1, "part": "hdframe_ne" },
-      { "x": 2, "y": 1, "part": "headlight" },
-      { "x": 2, "y": 1, "parts": [ "wheel_mount_medium_steerable", "wheel_wide_or" ] },
-      { "x": 2, "y": 1, "part": "reinforced_windshield" },
-      { "x": 2, "y": 0, "part": "hdframe_horizontal" },
-      { "x": 2, "y": 0, "part": "reinforced_windshield" },
-      { "x": 2, "y": 0, "part": "omnicam" },
-      { "x": 2, "y": -1, "part": "hdframe_nw" },
-      { "x": 2, "y": -1, "part": "headlight" },
-      { "x": 2, "y": -1, "parts": [ "wheel_mount_medium_steerable", "wheel_wide_or" ] },
-      { "x": 2, "y": -1, "part": "reinforced_windshield" },
-      { "x": -1, "y": 1, "part": "hdframe_cross" },
-      { "x": -1, "y": 1, "part": "storage_battery_mount" },
-      { "x": -1, "y": 1, "part": "storage_battery_removable" },
-      { "x": -1, "y": 1, "part": "hdboard_se" },
-      { "x": -1, "y": 0, "part": "hdframe_horizontal" },
-      { "x": -1, "y": 0, "part": "plow" },
-      { "x": -1, "y": 0, "part": "hdboard_horizontal" },
-      { "x": -1, "y": -1, "part": "hdframe_cross" },
-      { "x": -1, "y": -1, "part": "storage_battery_mount" },
-      { "x": -1, "y": -1, "part": "storage_battery_removable" },
-      { "x": -1, "y": -1, "part": "hdboard_sw" },
-      { "x": -2, "y": 1, "part": "hdframe_se" },
-      { "x": -2, "y": 1, "part": "engine_electric" },
-      { "x": -2, "y": 1, "part": "storage_battery_mount" },
-      { "x": -2, "y": 1, "part": "storage_battery_removable" },
-      { "x": -2, "y": 1, "part": "cargo_space" },
-      { "x": -2, "y": 1, "parts": [ "wheel_mount_medium_steerable", "wheel_wide_or" ] },
-      { "x": -2, "y": 0, "part": "seed_drill_advanced" },
-      { "x": -2, "y": -1, "part": "hdframe_sw" },
-      { "x": -2, "y": -1, "part": "engine_electric" },
-      { "x": -2, "y": -1, "part": "storage_battery_mount" },
-      { "x": -2, "y": -1, "part": "storage_battery_removable" },
-      { "x": -2, "y": -1, "part": "cargo_space" },
-      { "x": -2, "y": -1, "parts": [ "wheel_mount_medium_steerable", "wheel_wide_or" ] }
+    "blueprint": [
+      [ "O---O" ],
+      [ "8|=x|" ],
+      [ "O-+-O" ]
     ],
-    "items": [  ]
+    "parts": [
+      { "x": 0, "y": 1, "parts": [ "hdframe_vertical", "door_opaque" ] },
+      { "x": 0, "y": 0, "parts": [ "hdframe_vertical_2", "reaper_advanced", "hdroof" ] },
+      { "x": 0, "y": -1, "parts": [ "hdframe_vertical", "hdboard_vertical" ] },
+      { "x": 1, "y": 1, "parts": [ "hdframe_vertical", "reinforced_windshield" ] },
+      { "x": 1, "y": 0, "parts": [ "hdframe_vertical_2", "controls", "seat", "seatbelt_heavyduty", "hdroof" ] },
+      { "x": 1, "y": -1, "parts": [ "hdframe_vertical", "reinforced_windshield" ] },
+      {
+        "x": 2,
+        "y": 1,
+        "parts": [ "hdframe_ne", "headlight", "wheel_mount_medium_steerable", "wheel_wide_or", "reinforced_windshield" ]
+      },
+      { "x": 2, "y": 0, "parts": [ "hdframe_horizontal", "reinforced_windshield", "omnicam" ] },
+      {
+        "x": 2,
+        "y": -1,
+        "parts": [ "hdframe_nw", "headlight", "wheel_mount_medium_steerable", "wheel_wide_or", "reinforced_windshield" ]
+      },
+      {
+        "x": -1,
+        "y": 1,
+        "parts": [ "hdframe_cross", "storage_battery_mount", "storage_battery_removable", "hdboard_se" ]
+      },
+      { "x": -1, "y": 0, "parts": [ "hdframe_horizontal", "plow", "hdboard_horizontal" ] },
+      {
+        "x": -1,
+        "y": -1,
+        "parts": [ "hdframe_cross", "storage_battery_mount", "storage_battery_removable", "hdboard_sw" ]
+      },
+      {
+        "x": -2,
+        "y": 1,
+        "parts": [
+          "hdframe_se",
+          "engine_electric",
+          "storage_battery_mount",
+          "storage_battery_removable",
+          "cargo_space",
+          "wheel_mount_medium_steerable",
+          "wheel_wide_or"
+        ]
+      },
+      { "x": -2, "y": 0, "part": "seed_drill_advanced" },
+      {
+        "x": -2,
+        "y": -1,
+        "parts": [
+          "hdframe_sw",
+          "engine_electric",
+          "storage_battery_mount",
+          "storage_battery_removable",
+          "cargo_space",
+          "wheel_mount_medium_steerable",
+          "wheel_wide_or"
+        ]
+      }
+    ]
   },
   {
     "id": "surv_tachanka",
@@ -174,7 +322,16 @@
     ],
     "parts": [
       { "x": -2, "y": -1, "parts": [ "frame_wood_cross", "wheel_wood_b", "wooden_aisle_vertical" ] },
-      { "x": -2, "y": 0, "parts": [ "frame_wood_cross", "seat_wood", "turret_mount", { "ammo_types": [ "reloaded_762_54R" ], "part": "surv_lmg_762R_t", "ammo": 60, "ammo_qty": [ 5, 75 ] } ] },
+      {
+        "x": -2,
+        "y": 0,
+        "parts": [
+          "frame_wood_cross",
+          "seat_wood",
+          "turret_mount",
+          { "ammo_types": [ "reloaded_762_54R" ], "part": "surv_lmg_762R_t", "ammo": 60, "ammo_qty": [ 5, 75 ] }
+        ]
+      },
       { "x": -2, "y": 1, "parts": [ "frame_wood_cross", "wheel_wood_b", "wooden_aisle_vertical" ] },
       { "x": -1, "y": 0, "parts": [ "frame_wood_cross", "wood box" ] },
       { "x": 0, "y": 0, "parts": [ "frame_wood_cross", "seat_wood", "reins_tackle" ] },

--- a/nocts_cata_mod_DDA/Surv_help/c_techniques.json
+++ b/nocts_cata_mod_DDA/Surv_help/c_techniques.json
@@ -108,7 +108,8 @@
     "unarmed_allowed": true,
     "melee_allowed": true,
     "crit_tec": true,
-    "downed_target": true,
+    "condition": { "npc_has_effect": "downed" },
+    "condition_desc": "* Only works on a <info>downed</info> target",
     "stun_dur": 1,
     "flat_bonuses": [
       { "stat": "arpen", "type": "bash", "scaling-stat": "str", "scale": 0.5 },

--- a/nocts_cata_mod_DDA/Vehicles/c_carts.json
+++ b/nocts_cata_mod_DDA/Vehicles/c_carts.json
@@ -5,10 +5,7 @@
     "name": "Chemistry Station",
     "blueprint": [ "&" ],
     "parts": [
-      { "x": 0, "y": 0, "part": "xlframe_vertical_2" },
-      { "x": 0, "y": 0, "part": "wheel_caster" },
-      { "x": 0, "y": 0, "part": "small_storage_battery" },
-      { "x": 0, "y": 0, "part": "veh_tools_kitchen" }
+      { "x": 0, "y": 0, "parts": ["xlframe#vertical_2", "wheel_caster", "small_storage_battery", "veh_tools_kitchen"] }
     ]
   },
   {
@@ -17,10 +14,7 @@
     "name": "Survivor Station",
     "blueprint": [ "&" ],
     "parts": [
-      { "x": 0, "y": 0, "part": "xlframe_vertical_2" },
-      { "x": 0, "y": 0, "part": "wheel_caster" },
-      { "x": 0, "y": 0, "part": "small_storage_battery" },
-      { "x": 0, "y": 0, "part": "surv_station_t" }
+      { "x": 0, "y": 0, "parts": ["xlframe#vertical_2", "wheel_caster", "small_storage_battery", "surv_station_t"] }
     ]
   },
   {
@@ -29,9 +23,8 @@
     "name": "Autoclave Station",
     "blueprint": [ "&O" ],
     "parts": [
-      { "x": 0, "y": 0, "parts": [ "xlframe_horizontal", "wheel_caster", "medium_storage_battery", "autoclave" ] },
-      { "x": 1, "y": 0, "parts": [ "xlframe_horizontal", "wheel_caster", "box", "water_faucet" ] },
-      { "x": 1, "y": 0, "part": "tank_little", "fuel": "water" }
+      { "x": 0, "y": 0, "parts": [ "xlframe#horizontal", "wheel_caster", "medium_storage_battery", "autoclave" ] },
+      { "x": 1, "y": 0, "parts": [ "xlframe#horizontal", "wheel_caster", "box", "water_faucet", { "part": "tank_little", "fuel": "water" } ] }
     ],
     "items": [ { "x": 1, "y": 0, "chance": 90, "items": [ "pouch_autoclave" ] } ]
   }

--- a/nocts_cata_mod_DDA/Vehicles/c_vehicles.json
+++ b/nocts_cata_mod_DDA/Vehicles/c_vehicles.json
@@ -4,82 +4,235 @@
     "type": "vehicle",
     "name": "Survivor's Militarized RV",
     "parts": [
-      { "x": 1, "y": -1, "parts": [ "hdframe_nw", "reinforced_windshield", "omnicam", "plating_hard" ] },
-      { "x": 1, "y": 0, "parts": [ "hdframe_horizontal", "reinforced_windshield", "storage_battery", "headlight_reinforced", "plating_hard" ] },
-      { "x": 1, "y": 1, "parts": [ "hdframe_horizontal", "reinforced_windshield","storage_battery", "plating_hard" ] },
-      { "x": 1, "y": 2, "parts": [ "hdframe_horizontal", "reinforced_windshield", "storage_battery", "plating_hard" ] },
-      { "x": 1, "y": 3, "parts": [ "hdframe_horizontal", "reinforced_windshield", "storage_battery", "headlight_reinforced", "plating_hard" ] },
-      { "x": 1, "y": 4, "parts": [ "hdframe_ne", "reinforced_windshield", "omnicam", "plating_hard" ] },
-
-      { "x": 0, "y": -1, "parts": [ "hdframe_vertical", "wheel_mount_heavy_steerable", "wheel_armor", "hddoor", "inboard_mirror", "plating_hard", "door_motor" ] },
-      { "x": 0, "y": 0, "parts": [ "hdframe_vertical_2", "turret_mount", "turret_ups_rifle", "hdroof", "seat", "seatbelt_heavyduty", "cam_control", "controls", "dashboard", "vehicle_clock", "vehicle_alarm", "stereo" ] },
-      { "x": 0, "y": 1, "parts": [ "hdframe_vertical_2", "inboard_mirror", "horn_big", "trunk_floor", "hdroof" ] },
-      { "x": 0, "y": 2, "parts": [ "hdframe_vertical_2", "trunk_floor", "hdroof" ] },
-      { "x": 0, "y": 3, "parts": [ "hdframe_vertical_2", "turret_mount", "turret_ups_rifle", "hdroof", "seat", "seatbelt_heavyduty" ] },
-      { "x": 0, "y": 4, "parts": [ "hdframe_vertical", "wheel_mount_heavy_steerable", "wheel_armor", "hddoor", "inboard_mirror", "plating_hard", "door_motor" ] },
-
-      { "x": -1, "y": -1, "parts": [ "hdframe_vertical", "hdboard_vertical", "floodlight", "plating_hard" ] },
-      { "x": -1, "y": 0, "parts": [ "hdframe_vertical_2", "stowboard_horizontal", "minireactor", "engine_electric_enhanced" ] },
-      { "x": -1, "y": 1, "parts": [ "hdframe_vertical_2", "hdroof", "door_internal", "door_motor" ] },
-      { "x": -1, "y": 2, "parts": [ "hdframe_vertical_2", "stowboard_horizontal" ] },
-      { "x": -1, "y": 3, "parts": [ "hdframe_vertical_2", "stowboard_horizontal", "minireactor", "engine_electric_enhanced" ] },
-      { "x": -1, "y": 4, "parts": [ "hdframe_vertical", "hdboard_vertical", "floodlight", "plating_hard" ] },
-
-      { "x": -2, "y": -1, "parts": [ "hdframe_vertical", "reinforced_windshield", "v_curtain", "plating_hard" ] },
-      { "x": -2, "y": 0, "parts": [ "hdframe_vertical_2", "aisle_horizontal", "aisle_lights", "hdroof" ] },
-      { "x": -2, "y": 1, "parts": [ "hdframe_vertical_2", "aisle_horizontal", "hdroof" ] },
-      { "x": -2, "y": 2, "parts": [ "hdframe_vertical_2", "aisle_horizontal", "hdroof" ] },
-      { "x": -2, "y": 3, "parts": [ "hdframe_vertical_2", "aisle_horizontal", "aisle_lights", "hdroof" ] },
-      { "x": -2, "y": 4, "parts": [ "hdframe_vertical", "door_opaque", "plating_hard", "door_motor" ] },
-
-      { "x": -3, "y": -1, "parts": [ "hdframe_vertical", "hdboard_vertical", "plating_hard" ] },
-      { "x": -3, "y": 0, "parts": [ "hdframe_vertical_2", "hdroof", "minifreezer" ] },
-      { "x": -3, "y": 1, "parts": [ "hdframe_vertical_2", "aisle_horizontal", "hdroof" ] },
-      { "x": -3, "y": 2, "parts": [ "hdframe_vertical_2", "aisle_horizontal", "hdroof" ] },
-      { "x": -3, "y": 3, "parts": [ "hdframe_vertical_2", "hdroof", "aisle_horizontal" ] },
-      { "x": -3, "y": 4, "parts": [ "hdframe_vertical", "reinforced_windshield", "v_curtain", "plating_hard" ] },
-
-      { "x": -4, "y": -1, "parts": [ "hdframe_vertical", "floodlight", "hdboard_vertical", "plating_hard" ] },
-      { "x": -4, "y": 0, "parts": [ "hdframe_vertical_2", "hdroof", "minifridge" ] },
-      { "x": -4, "y": 1, "parts": [ "hdframe_vertical_2", "aisle_horizontal", "hdroof" ] },
-      { "x": -4, "y": 2, "parts": [ "hdframe_vertical_2", "aisle_horizontal", "hdroof" ] },
-      { "x": -4, "y": 3, "parts": [ "hdframe_vertical_2", "hdroof", "veh_table_wood" ] },
-      { "x": -4, "y": 4, "parts": [ "hdframe_vertical", "floodlight", "reinforced_windshield", "v_curtain", "plating_hard" ] },
-
-      { "x": -5, "y": -1, "parts": [ "hdframe_vertical", "omnicam", "hdboard_vertical", "plating_hard" ] },
-      { "x": -5, "y": 0, "parts": [ "hdframe_vertical_2", "hdroof", "surv_station_t", "tank" ] },
-      { "x": -5, "y": 1, "parts": [ "hdframe_vertical_2", "aisle_horizontal", "aisle_lights", "hdroof" ] },
-      { "x": -5, "y": 2, "parts": [ "hdframe_vertical_2", "aisle_horizontal", "hdroof" ] },
-      { "x": -5, "y": 3, "parts": [ "hdframe_vertical_2", "hdroof", "seat_wood" ] },
-      { "x": -5, "y": 4, "parts": [ "hdframe_vertical", "omnicam", "reinforced_windshield", "v_curtain", "plating_hard" ] },
-
-      { "x": -6, "y": -1, "parts": [ "hdframe_vertical", "hdboard_vertical", "funnel", "tank", "plating_hard" ] },
-      { "x": -6, "y": 0, "parts": [ "hdframe_vertical_2", "stowboard_horizontal", "recharge_station" ] },
-      { "x": -6, "y": 1, "parts": [ "hdframe_vertical_2", "hdroof", "door_internal" ] },
-      { "x": -6, "y": 2, "parts": [ "hdframe_vertical_2", "stowboard_horizontal", "recharge_station" ] },
-      { "x": -6, "y": 3, "parts": [ "hdframe_vertical_2", "stowboard_horizontal", "recharge_station" ] },
-      { "x": -6, "y": 4, "parts": [ "hdframe_vertical", "hdboard_vertical", "funnel", "tank", "plating_hard" ] },
-
-      { "x": -7, "y": -1, "parts": [ "hdframe_vertical", "reinforced_windshield", "v_curtain", "plating_hard" ] },
-      { "x": -7, "y": 0, "parts": [ "hdframe_vertical_2", "hdroof", "reinforced_solar_panel_v2", "cargo_space" ] },
-      { "x": -7, "y": 1, "parts": [ "hdframe_vertical_2", "hdroof", "reinforced_solar_panel_v2", "aisle_horizontal" ] },
-      { "x": -7, "y": 2, "parts": [ "hdframe_vertical_2", "hdroof", "reinforced_solar_panel_v2", "aisle_horizontal" ] },
-      { "x": -7, "y": 3, "parts": [ "hdframe_vertical_2", "hdroof", "reinforced_solar_panel_v2", "veh_table_wood", "atomic_lamp" ] },
-      { "x": -7, "y": 4, "parts": [ "hdframe_vertical", "reinforced_windshield", "v_curtain", "plating_hard" ] },
-
-      { "x": -8, "y": -1, "parts": [ "hdframe_vertical", "wheel_mount_heavy", "wheel_armor", "reinforced_windshield", "v_curtain", "plating_hard" ] },
-      { "x": -8, "y": 0, "parts": [ "hdframe_vertical_2", "hdroof", "reinforced_solar_panel_v2", "cargo_space" ] },
-      { "x": -8, "y": 1, "parts": [ "hdframe_vertical_2", "hdroof", "reinforced_solar_panel_v2", "aisle_horizontal" ] },
-      { "x": -8, "y": 2, "parts": [ "hdframe_vertical_2", "hdroof", "reinforced_solar_panel_v2", "aisle_horizontal" ] },
-      { "x": -8, "y": 3, "parts": [ "hdframe_vertical_2", "hdroof", "reinforced_solar_panel_v2", "bed" ] },
-      { "x": -8, "y": 4, "parts": [ "hdframe_vertical", "wheel_mount_heavy", "wheel_armor", "reinforced_windshield", "v_curtain", "plating_hard" ] },
-
-      { "x": -9, "y": -1, "parts": [ "hdframe_sw", "wheel_mount_heavy", "wheel_armor", "hdboard_sw", "omnicam", "storage_battery_mount", "storage_battery_removable", "plating_hard" ] },
-      { "x": -9, "y": 0, "parts": [ "hdframe_horizontal", "stowboard_horizontal", "turret_mount", "turret_ups_rifle", "bike_rack", "muffler", "plating_hard" ] },
-      { "x": -9, "y": 1, "parts": [ "hdframe_horizontal", "stowboard_horizontal", "bike_rack", "floodlight", "plating_hard" ] },
-      { "x": -9, "y": 2, "parts": [ "hdframe_horizontal", "stowboard_horizontal", "bike_rack", "floodlight", "plating_hard" ] },
-      { "x": -9, "y": 3, "parts": [ "hdframe_horizontal", "stowboard_horizontal", "turret_mount", "turret_ups_rifle", "bike_rack", "muffler", "plating_hard" ] },
-      { "x": -9, "y": 4, "parts": [ "hdframe_se", "wheel_mount_heavy", "wheel_armor", "hdboard_se", "omnicam", "storage_battery_mount", "storage_battery_removable", "plating_hard" ] }
+      { "x": 1, "y": -1, "parts": [ "hdframe#nw", "reinforced_windshield", "omnicam", "plating_hard" ] },
+      {
+        "x": 1,
+        "y": 0,
+        "parts": [ "hdframe#horizontal", "reinforced_windshield", "storage_battery", "headlight_reinforced", "plating_hard" ]
+      },
+      {
+        "x": 1,
+        "y": 1,
+        "parts": [ "hdframe#horizontal", "reinforced_windshield", "storage_battery", "plating_hard" ]
+      },
+      {
+        "x": 1,
+        "y": 2,
+        "parts": [ "hdframe#horizontal", "reinforced_windshield", "storage_battery", "plating_hard" ]
+      },
+      {
+        "x": 1,
+        "y": 3,
+        "parts": [ "hdframe#horizontal", "reinforced_windshield", "storage_battery", "headlight_reinforced", "plating_hard" ]
+      },
+      { "x": 1, "y": 4, "parts": [ "hdframe#ne", "reinforced_windshield", "omnicam", "plating_hard" ] },
+      {
+        "x": 0,
+        "y": -1,
+        "parts": [
+          "hdframe#vertical",
+          "wheel_mount_heavy_steerable",
+          "wheel_armor",
+          "hddoor",
+          "inboard_mirror",
+          "plating_hard",
+          "door_motor"
+        ]
+      },
+      {
+        "x": 0,
+        "y": 0,
+        "parts": [
+          "hdframe#vertical_2",
+          "turret_mount",
+          "turret_ups_rifle",
+          "hdroof",
+          "seat",
+          "seatbelt_heavyduty",
+          "cam_control",
+          "controls",
+          "dashboard",
+          "vehicle_clock",
+          "vehicle_alarm",
+          "stereo"
+        ]
+      },
+      { "x": 0, "y": 1, "parts": [ "hdframe#vertical_2", "inboard_mirror", "horn_big", "trunk_floor", "hdroof" ] },
+      { "x": 0, "y": 2, "parts": [ "hdframe#vertical_2", "trunk_floor", "hdroof" ] },
+      {
+        "x": 0,
+        "y": 3,
+        "parts": [ "hdframe#vertical_2", "turret_mount", "turret_ups_rifle", "hdroof", "seat", "seatbelt_heavyduty" ]
+      },
+      {
+        "x": 0,
+        "y": 4,
+        "parts": [
+          "hdframe#vertical",
+          "wheel_mount_heavy_steerable",
+          "wheel_armor",
+          "hddoor",
+          "inboard_mirror",
+          "plating_hard",
+          "door_motor"
+        ]
+      },
+      { "x": -1, "y": -1, "parts": [ "hdframe#vertical", "hdboard#vertical", "floodlight", "plating_hard" ] },
+      {
+        "x": -1,
+        "y": 0,
+        "parts": [ "hdframe#vertical_2", "stowboard#horizontal", "minireactor", "engine_electric_enhanced" ]
+      },
+      { "x": -1, "y": 1, "parts": [ "hdframe#vertical_2", "hdroof", "door_internal", "door_motor" ] },
+      { "x": -1, "y": 2, "parts": [ "hdframe#vertical_2", "stowboard#horizontal" ] },
+      {
+        "x": -1,
+        "y": 3,
+        "parts": [ "hdframe#vertical_2", "stowboard#horizontal", "minireactor", "engine_electric_enhanced" ]
+      },
+      { "x": -1, "y": 4, "parts": [ "hdframe#vertical", "hdboard#vertical", "floodlight", "plating_hard" ] },
+      { "x": -2, "y": -1, "parts": [ "hdframe#vertical", "reinforced_windshield", "v_curtain", "plating_hard" ] },
+      { "x": -2, "y": 0, "parts": [ "hdframe#vertical_2", "aisle#horizontal", "aisle_lights", "hdroof" ] },
+      { "x": -2, "y": 1, "parts": [ "hdframe#vertical_2", "aisle#horizontal", "hdroof" ] },
+      { "x": -2, "y": 2, "parts": [ "hdframe#vertical_2", "aisle#horizontal", "hdroof" ] },
+      { "x": -2, "y": 3, "parts": [ "hdframe#vertical_2", "aisle#horizontal", "aisle_lights", "hdroof" ] },
+      { "x": -2, "y": 4, "parts": [ "hdframe#vertical", "door_opaque", "plating_hard", "door_motor" ] },
+      { "x": -3, "y": -1, "parts": [ "hdframe#vertical", "hdboard#vertical", "plating_hard" ] },
+      { "x": -3, "y": 0, "parts": [ "hdframe#vertical_2", "hdroof", "minifreezer" ] },
+      { "x": -3, "y": 1, "parts": [ "hdframe#vertical_2", "aisle#horizontal", "hdroof" ] },
+      { "x": -3, "y": 2, "parts": [ "hdframe#vertical_2", "aisle#horizontal", "hdroof" ] },
+      { "x": -3, "y": 3, "parts": [ "hdframe#vertical_2", "hdroof", "aisle#horizontal" ] },
+      { "x": -3, "y": 4, "parts": [ "hdframe#vertical", "reinforced_windshield", "v_curtain", "plating_hard" ] },
+      { "x": -4, "y": -1, "parts": [ "hdframe#vertical", "floodlight", "hdboard#vertical", "plating_hard" ] },
+      { "x": -4, "y": 0, "parts": [ "hdframe#vertical_2", "hdroof", "minifridge" ] },
+      { "x": -4, "y": 1, "parts": [ "hdframe#vertical_2", "aisle#horizontal", "hdroof" ] },
+      { "x": -4, "y": 2, "parts": [ "hdframe#vertical_2", "aisle#horizontal", "hdroof" ] },
+      { "x": -4, "y": 3, "parts": [ "hdframe#vertical_2", "hdroof", "veh_table_wood" ] },
+      {
+        "x": -4,
+        "y": 4,
+        "parts": [ "hdframe#vertical", "floodlight", "reinforced_windshield", "v_curtain", "plating_hard" ]
+      },
+      { "x": -5, "y": -1, "parts": [ "hdframe#vertical", "omnicam", "hdboard#vertical", "plating_hard" ] },
+      { "x": -5, "y": 0, "parts": [ "hdframe#vertical_2", "hdroof", "surv_station_t", "tank" ] },
+      { "x": -5, "y": 1, "parts": [ "hdframe#vertical_2", "aisle#horizontal", "aisle_lights", "hdroof" ] },
+      { "x": -5, "y": 2, "parts": [ "hdframe#vertical_2", "aisle#horizontal", "hdroof" ] },
+      { "x": -5, "y": 3, "parts": [ "hdframe#vertical_2", "hdroof", "seat_wood" ] },
+      {
+        "x": -5,
+        "y": 4,
+        "parts": [ "hdframe#vertical", "omnicam", "reinforced_windshield", "v_curtain", "plating_hard" ]
+      },
+      { "x": -6, "y": -1, "parts": [ "hdframe#vertical", "hdboard#vertical", "funnel", "tank", "plating_hard" ] },
+      { "x": -6, "y": 0, "parts": [ "hdframe#vertical_2", "stowboard#horizontal", "recharge_station" ] },
+      { "x": -6, "y": 1, "parts": [ "hdframe#vertical_2", "hdroof", "door_internal" ] },
+      { "x": -6, "y": 2, "parts": [ "hdframe#vertical_2", "stowboard#horizontal", "recharge_station" ] },
+      { "x": -6, "y": 3, "parts": [ "hdframe#vertical_2", "stowboard#horizontal", "recharge_station" ] },
+      { "x": -6, "y": 4, "parts": [ "hdframe#vertical", "hdboard#vertical", "funnel", "tank", "plating_hard" ] },
+      { "x": -7, "y": -1, "parts": [ "hdframe#vertical", "reinforced_windshield", "v_curtain", "plating_hard" ] },
+      { "x": -7, "y": 0, "parts": [ "hdframe#vertical_2", "hdroof", "reinforced_solar_panel_v2", "cargo_space" ] },
+      {
+        "x": -7,
+        "y": 1,
+        "parts": [ "hdframe#vertical_2", "hdroof", "reinforced_solar_panel_v2", "aisle#horizontal" ]
+      },
+      {
+        "x": -7,
+        "y": 2,
+        "parts": [ "hdframe#vertical_2", "hdroof", "reinforced_solar_panel_v2", "aisle#horizontal" ]
+      },
+      {
+        "x": -7,
+        "y": 3,
+        "parts": [ "hdframe#vertical_2", "hdroof", "reinforced_solar_panel_v2", "veh_table_wood", "atomic_lamp" ]
+      },
+      { "x": -7, "y": 4, "parts": [ "hdframe#vertical", "reinforced_windshield", "v_curtain", "plating_hard" ] },
+      {
+        "x": -8,
+        "y": -1,
+        "parts": [ "hdframe#vertical", "wheel_mount_heavy", "wheel_armor", "reinforced_windshield", "v_curtain", "plating_hard" ]
+      },
+      { "x": -8, "y": 0, "parts": [ "hdframe#vertical_2", "hdroof", "reinforced_solar_panel_v2", "cargo_space" ] },
+      {
+        "x": -8,
+        "y": 1,
+        "parts": [ "hdframe#vertical_2", "hdroof", "reinforced_solar_panel_v2", "aisle#horizontal" ]
+      },
+      {
+        "x": -8,
+        "y": 2,
+        "parts": [ "hdframe#vertical_2", "hdroof", "reinforced_solar_panel_v2", "aisle#horizontal" ]
+      },
+      { "x": -8, "y": 3, "parts": [ "hdframe#vertical_2", "hdroof", "reinforced_solar_panel_v2", "bed" ] },
+      {
+        "x": -8,
+        "y": 4,
+        "parts": [ "hdframe#vertical", "wheel_mount_heavy", "wheel_armor", "reinforced_windshield", "v_curtain", "plating_hard" ]
+      },
+      {
+        "x": -9,
+        "y": -1,
+        "parts": [
+          "hdframe#sw",
+          "wheel_mount_heavy",
+          "wheel_armor",
+          "hdboard#sw",
+          "omnicam",
+          "storage_battery_mount",
+          "storage_battery_removable",
+          "plating_hard"
+        ]
+      },
+      {
+        "x": -9,
+        "y": 0,
+        "parts": [
+          "hdframe#horizontal",
+          "stowboard#horizontal",
+          "turret_mount",
+          "turret_ups_rifle",
+          "bike_rack",
+          "muffler",
+          "plating_hard"
+        ]
+      },
+      {
+        "x": -9,
+        "y": 1,
+        "parts": [ "hdframe#horizontal", "stowboard#horizontal", "bike_rack", "floodlight", "plating_hard" ]
+      },
+      {
+        "x": -9,
+        "y": 2,
+        "parts": [ "hdframe#horizontal", "stowboard#horizontal", "bike_rack", "floodlight", "plating_hard" ]
+      },
+      {
+        "x": -9,
+        "y": 3,
+        "parts": [
+          "hdframe#horizontal",
+          "stowboard#horizontal",
+          "turret_mount",
+          "turret_ups_rifle",
+          "bike_rack",
+          "muffler",
+          "plating_hard"
+        ]
+      },
+      {
+        "x": -9,
+        "y": 4,
+        "parts": [
+          "hdframe#se",
+          "wheel_mount_heavy",
+          "wheel_armor",
+          "hdboard#se",
+          "omnicam",
+          "storage_battery_mount",
+          "storage_battery_removable",
+          "plating_hard"
+        ]
+      }
     ],
     "items": [
       { "x": -9, "y": 0, "chance": 50, "items": [ "folded_bicycle" ] },
@@ -107,61 +260,68 @@
     "id": "surv_tractor",
     "type": "vehicle",
     "name": "Survivor Tractor",
-    "blueprint": [ [ "O---O" ], [ "8|=x|" ], [ "O-+-O" ] ],
-    "parts": [
-      { "x": 0, "y": 1, "part": "hdframe_vertical" },
-      { "x": 0, "y": 1, "part": "door_opaque" },
-      { "x": 0, "y": 0, "part": "hdframe_vertical_2" },
-      { "x": 0, "y": 0, "part": "reaper_advanced" },
-      { "x": 0, "y": 0, "part": "hdroof" },
-      { "x": 0, "y": -1, "part": "hdframe_vertical" },
-      { "x": 0, "y": -1, "part": "hdboard_vertical" },
-      { "x": 1, "y": 1, "part": "hdframe_vertical" },
-      { "x": 1, "y": 1, "part": "reinforced_windshield" },
-      { "x": 1, "y": 0, "part": "hdframe_vertical_2" },
-      { "x": 1, "y": 0, "part": "controls" },
-      { "x": 1, "y": 0, "part": "seat" },
-      { "x": 1, "y": 0, "part": "seatbelt_heavyduty" },
-      { "x": 1, "y": 0, "part": "hdroof" },
-      { "x": 1, "y": -1, "part": "hdframe_vertical" },
-      { "x": 1, "y": -1, "part": "reinforced_windshield" },
-      { "x": 2, "y": 1, "part": "hdframe_ne" },
-      { "x": 2, "y": 1, "part": "headlight" },
-      { "x": 2, "y": 1, "parts": [ "wheel_mount_medium_steerable", "wheel_wide_or" ] },
-      { "x": 2, "y": 1, "part": "reinforced_windshield" },
-      { "x": 2, "y": 0, "part": "hdframe_horizontal" },
-      { "x": 2, "y": 0, "part": "reinforced_windshield" },
-      { "x": 2, "y": 0, "part": "omnicam" },
-      { "x": 2, "y": -1, "part": "hdframe_nw" },
-      { "x": 2, "y": -1, "part": "headlight" },
-      { "x": 2, "y": -1, "parts": [ "wheel_mount_medium_steerable", "wheel_wide_or" ] },
-      { "x": 2, "y": -1, "part": "reinforced_windshield" },
-      { "x": -1, "y": 1, "part": "hdframe_cross" },
-      { "x": -1, "y": 1, "part": "storage_battery_mount" },
-      { "x": -1, "y": 1, "part": "storage_battery_removable" },
-      { "x": -1, "y": 1, "part": "hdboard_se" },
-      { "x": -1, "y": 0, "part": "hdframe_horizontal" },
-      { "x": -1, "y": 0, "part": "plow" },
-      { "x": -1, "y": 0, "part": "hdboard_horizontal" },
-      { "x": -1, "y": -1, "part": "hdframe_cross" },
-      { "x": -1, "y": -1, "part": "storage_battery_mount" },
-      { "x": -1, "y": -1, "part": "storage_battery_removable" },
-      { "x": -1, "y": -1, "part": "hdboard_sw" },
-      { "x": -2, "y": 1, "part": "hdframe_se" },
-      { "x": -2, "y": 1, "part": "engine_electric" },
-      { "x": -2, "y": 1, "part": "storage_battery_mount" },
-      { "x": -2, "y": 1, "part": "storage_battery_removable" },
-      { "x": -2, "y": 1, "part": "cargo_space" },
-      { "x": -2, "y": 1, "parts": [ "wheel_mount_medium_steerable", "wheel_wide_or" ] },
-      { "x": -2, "y": 0, "part": "seed_drill_advanced" },
-      { "x": -2, "y": -1, "part": "hdframe_sw" },
-      { "x": -2, "y": -1, "part": "engine_electric" },
-      { "x": -2, "y": -1, "part": "storage_battery_mount" },
-      { "x": -2, "y": -1, "part": "storage_battery_removable" },
-      { "x": -2, "y": -1, "part": "cargo_space" },
-      { "x": -2, "y": -1, "parts": [ "wheel_mount_medium_steerable", "wheel_wide_or" ] }
+    "blueprint": [
+      [ "O---O" ],
+      [ "8|=x|" ],
+      [ "O-+-O" ]
     ],
-    "items": [  ]
+    "parts": [
+      { "x": 0, "y": 1, "parts": [ "hdframe#vertical", "door_opaque" ] },
+      { "x": 0, "y": 0, "parts": [ "hdframe#vertical_2", "reaper_advanced", "hdroof" ] },
+      { "x": 0, "y": -1, "parts": [ "hdframe#vertical", "hdboard#vertical" ] },
+      { "x": 1, "y": 1, "parts": [ "hdframe#vertical", "reinforced_windshield" ] },
+      { "x": 1, "y": 0, "parts": [ "hdframe#vertical_2", "controls", "seat", "seatbelt_heavyduty", "hdroof" ] },
+      { "x": 1, "y": -1, "parts": [ "hdframe#vertical", "reinforced_windshield" ] },
+      {
+        "x": 2,
+        "y": 1,
+        "parts": [ "hdframe#ne", "headlight", "wheel_mount_medium_steerable", "wheel_wide_or", "reinforced_windshield" ]
+      },
+      { "x": 2, "y": 0, "parts": [ "hdframe#horizontal", "reinforced_windshield", "omnicam" ] },
+      {
+        "x": 2,
+        "y": -1,
+        "parts": [ "hdframe#nw", "headlight", "wheel_mount_medium_steerable", "wheel_wide_or", "reinforced_windshield" ]
+      },
+      {
+        "x": -1,
+        "y": 1,
+        "parts": [ "hdframe#cross", "storage_battery_mount", "storage_battery_removable", "hdboard#se" ]
+      },
+      { "x": -1, "y": 0, "parts": [ "hdframe#horizontal", "plow", "hdboard#horizontal" ] },
+      {
+        "x": -1,
+        "y": -1,
+        "parts": [ "hdframe#cross", "storage_battery_mount", "storage_battery_removable", "hdboard#sw" ]
+      },
+      {
+        "x": -2,
+        "y": 1,
+        "parts": [
+          "hdframe#se",
+          "engine_electric",
+          "storage_battery_mount",
+          "storage_battery_removable",
+          "cargo_space",
+          "wheel_mount_medium_steerable",
+          "wheel_wide_or"
+        ]
+      },
+      { "x": -2, "y": 0, "parts": [ "seed_drill_advanced" ] },
+      {
+        "x": -2,
+        "y": -1,
+        "parts": [
+          "hdframe#sw",
+          "engine_electric",
+          "storage_battery_mount",
+          "storage_battery_removable",
+          "cargo_space",
+          "wheel_mount_medium_steerable",
+          "wheel_wide_or"
+        ]
+      }
+    ]
   },
   {
     "id": "surv_tachanka",
@@ -173,15 +333,36 @@
       [ "O O-" ]
     ],
     "parts": [
-      { "x": -2, "y": -1, "parts": [ "frame_wood_cross", "wheel_mount_wood", "wheel_wood_b", "wooden_aisle_vertical" ] },
-      { "x": -2, "y": 0, "parts": [ "frame_wood_cross", "seat_wood", "turret_mount", { "ammo_types": [ "reloaded_762_54R" ], "part": "turret_surv_lmg_762R", "ammo": 60, "ammo_qty": [ 5, 75 ] } ] },
-      { "x": -2, "y": 1, "parts": [ "frame_wood_cross", "wheel_mount_wood", "wheel_wood_b", "wooden_aisle_vertical" ] },
-      { "x": -1, "y": 0, "parts": [ "frame_wood_cross", "wood box" ] },
-      { "x": 0, "y": 0, "parts": [ "frame_wood_cross", "seat_wood", "reins_tackle" ] },
-      { "x": 0, "y": -1, "parts": [ "frame_wood_cross", "wheel_mount_wood_steerable", "wheel_wood_b", "wooden_aisle_vertical" ] },
-      { "x": 0, "y": 1, "parts": [ "frame_wood_cross", "wheel_mount_wood_steerable", "wheel_wood_b", "wooden_aisle_vertical" ] },
-      { "x": 1, "y": 1, "part": "yoke_harness" },
-      { "x": 1, "y": -1, "part": "yoke_harness" }
+      { "x": -2, "y": -1, "parts": [ "frame_wood#cross", "wheel_mount_wood", "wheel_wood_b", "wooden_aisle#vertical" ] },
+      {
+        "x": -2,
+        "y": 0,
+        "parts": [
+          "frame_wood#cross",
+          "seat_wood",
+          "turret_mount",
+          { "ammo_types": [ "reloaded_762_54R" ], "part": "turret_surv_lmg_762R", "ammo": 60, "ammo_qty": [ 5, 75 ] }
+        ]
+      },
+      {
+        "x": -2,
+        "y": 1,
+        "parts": [ "frame_wood#cross", "wheel_mount_wood", "wheel_wood_b", "wooden_aisle#vertical" ]
+      },
+      { "x": -1, "y": 0, "parts": [ "frame_wood#cross", "wood box" ] },
+      { "x": 0, "y": 0, "parts": [ "frame_wood#cross", "seat_wood", "reins_tackle" ] },
+      {
+        "x": 0,
+        "y": -1,
+        "parts": [ "frame_wood#cross", "wheel_mount_wood_steerable", "wheel_wood_b", "wooden_aisle#vertical" ]
+      },
+      {
+        "x": 0,
+        "y": 1,
+        "parts": [ "frame_wood#cross", "wheel_mount_wood_steerable", "wheel_wood_b", "wooden_aisle#vertical" ]
+      },
+      { "x": 1, "y": 1, "parts": [ "yoke_harness" ] },
+      { "x": 1, "y": -1, "parts": [ "yoke_harness" ] }
     ],
     "items": [ { "x": -1, "y": 0, "chance": 100, "item_groups": [ "tachanka_loot" ] } ]
   }


### PR DESCRIPTION
Discovered that DDA prefers `parts` array exclusively for vehicle definitions. So this meant now was as good a time as any to convert vehicle defs to use parts array in both versions since it's less annoying to read. Also fixes forgotten change to how frame variations are handled in DDA version and an update to martial arts.