### PR TITLE
Update for wasteland drifter, DDA fixes

### DIFF
--- a/nocts_cata_mod_BN/Char_creation/c_classes_r.json
+++ b/nocts_cata_mod_BN/Char_creation/c_classes_r.json
@@ -3,13 +3,23 @@
     "type": "item_group",
     "subtype": "collection",
     "id": "flintlock_pouch_surv_drifter",
-    "entries": [ { "item": "36navy_makeshift_magnum", "charges": 20 } ]
+    "entries": [ { "item": "36navy_makeshift_magnum", "charges": 19 } ]
   },
   {
     "type": "item_group",
     "subtype": "collection",
     "id": "cowboy_hat_surv_surv_drifter",
-    "entries": [ { "item": "36navy_makeshift_magnum", "charges": 12 } ]
+    "entries": [ { "item": "44army_makeshift_magnum", "charges": 12 } ]
+  },
+  {
+    "type": "item_group",
+    "subtype": "collection",
+    "id": "legrig_surv_surv_drifter",
+    "entries": [
+      { "item": "colt_navy", "ammo-item": "36navy_makeshift_magnum", "charges": 6 },
+      { "item": "colt_army", "ammo-item": "44army_makeshift_magnum", "charges": 6 },
+      { "item": "knife_hunting" }
+    ]
   },
   {
     "type": "profession",
@@ -84,13 +94,12 @@
         ],
         "entries": [
           { "item": "cowboy_hat_surv", "contents-group": "cowboy_hat_surv_surv_drifter" },
-          { "item": "colt_navy", "ammo-item": "36navy_makeshift_magnum", "charges": 6, "container-item": "holster" },
+          { "item": "legrig_surv", "contents-group": "legrig_surv_surv_drifter" },
           { "item": "flintlock_pouch", "contents-group": "flintlock_pouch_surv_drifter" },
-          { "item": "knife_hunting", "container-item": "sheath" },
           { "item": "ear_plugs", "custom-flags": [ "no_auto_equip" ] },
           { "item": "vinegar", "container-item": "bottle_plastic_small" },
           { "item": "lamp_oil", "container-item": "bottle_plastic_small" },
-          { "item": "36navy_makeshift_magnum", "charges": 2 }
+          { "item": "44army_makeshift_magnum", "charges": 7 }
         ]
       },
       "male": [ "boxer_shorts" ],

--- a/nocts_cata_mod_DDA/Char_creation/c_classes_r.json
+++ b/nocts_cata_mod_DDA/Char_creation/c_classes_r.json
@@ -9,7 +9,17 @@
     "type": "item_group",
     "subtype": "collection",
     "id": "cowboy_hat_surv_surv_drifter",
-    "entries": [ { "item": "36navy_makeshift_magnum", "charges": 12 } ]
+    "entries": [ { "item": "44army_makeshift_magnum", "charges": 12 } ]
+  },
+  {
+    "type": "item_group",
+    "subtype": "collection",
+    "id": "legrig_surv_surv_drifter",
+    "entries": [
+      { "item": "colt_navy", "ammo-item": "36navy_makeshift_magnum", "charges": 6 },
+      { "item": "colt_army", "ammo-item": "44army_makeshift_magnum", "charges": 6 },
+      { "item": "knife_hunting" }
+    ]
   },
   {
     "type": "profession",
@@ -99,18 +109,13 @@
         ],
         "entries": [
           { "item": "cowboy_hat_surv", "contents-group": "cowboy_hat_surv_surv_drifter" },
-          {
-            "item": "colt_navy",
-            "ammo-item": "36navy_makeshift_magnum",
-            "charges": 6,
-            "container-item": "XL_holster"
-          },
+          { "item": "legrig_surv", "contents-group": "legrig_surv_surv_drifter" },
           { "item": "flintlock_pouch", "contents-group": "flintlock_pouch_surv_drifter" },
-          { "item": "knife_hunting", "container-item": "sheath" },
           { "item": "ear_plugs", "custom-flags": [ "no_auto_equip" ] },
           { "item": "vinegar", "container-item": "bottle_plastic_small" },
           { "item": "lamp_oil", "container-item": "bottle_plastic_small" },
-          { "item": "36navy_makeshift_magnum", "charges": 8 },
+          { "item": "36navy_makeshift_magnum", "charges": 5 },
+          { "item": "44army_makeshift_magnum", "charges": 7 },
           { "group": "charged_ref_lighter" }
         ]
       },

--- a/nocts_cata_mod_DDA/Monsters/c_monsters.json
+++ b/nocts_cata_mod_DDA/Monsters/c_monsters.json
@@ -128,7 +128,7 @@
       [ "TAZER", 15 ],
       [ "PARROT", 80 ],
       [ "SMASH", 20 ],
-      [ "BIO_OP_TAKEDOWN", 10 ],
+      { "id": "bio_op_takedown", "cooldown": 10 },
       {
         "type": "gun",
         "cooldown": 10,
@@ -249,7 +249,7 @@
     "regen_morale": true,
     "harvest": "CBM_SOLDAT_ZOMBIE_GENERIC",
     "dissect": "dissect_CBM_SOLDAT_ZOMBIE_GENERIC",
-    "special_attacks": [ [ "GRAB", 10 ] ],
+    "special_attacks": [ { "id": "grab", "cooldown": 10 } ],
     "special_when_hit": [ "ZAPBACK", 60 ],
     "anger_triggers": [ "FRIEND_DIED", "FRIEND_ATTACKED", "HURT", "STALK", "PLAYER_CLOSE" ],
     "placate_triggers": [ "PLAYER_WEAK" ],
@@ -289,7 +289,7 @@
     "regen_morale": true,
     "harvest": "CBM_SOLDAT_ZOMBIE_GENERIC",
     "dissect": "dissect_CBM_SOLDAT_ZOMBIE_GENERIC",
-    "special_attacks": [ [ "GRAB", 10 ] ],
+    "special_attacks": [ { "id": "grab", "cooldown": 10 } ],
     "special_when_hit": [ "ZAPBACK", 60 ],
     "anger_triggers": [ "FRIEND_DIED", "FRIEND_ATTACKED", "HURT", "STALK", "PLAYER_CLOSE" ],
     "placate_triggers": [ "PLAYER_WEAK" ],
@@ -312,7 +312,7 @@
     "melee_damage": [ { "damage_type": "cut", "amount": 10 } ],
     "path_settings": { "max_dist": 20 },
     "vision_night": 20,
-    "special_attacks": [ [ "GRAB", 10 ], [ "BIO_OP_TAKEDOWN", 30 ], [ "LUNGE", 20 ] ],
+    "special_attacks": [ { "id": "grab", "cooldown": 10 }, { "id": "bio_op_takedown", "cooldown": 30 }, [ "LUNGE", 20 ] ],
     "death_drops": "mon_zombie_bio_knife_death_drops",
     "zombify_into": "mon_zombie_bio_reanimated",
     "flags": [ "HARDTOSHOOT", "SEES", "HEARS", "SMELLS", "POISON", "NO_BREATHE", "FILTHY", "PATH_AVOID_DANGER_1" ],
@@ -374,8 +374,8 @@
         "description": "The super soldier fires its ARC rifle!",
         "no_ammo_sound": "beep-beep-beep!"
       },
-      [ "GRAB", 10 ],
-      [ "BIO_OP_TAKEDOWN", 30 ]
+      { "id": "grab", "cooldown": 10 },
+      { "id": "bio_op_takedown", "cooldown": 30 }
     ],
     "special_when_hit": [ "ZAPBACK", 60 ],
     "anger_triggers": [ "FRIEND_DIED", "FRIEND_ATTACKED", "HURT", "STALK", "PLAYER_CLOSE" ],
@@ -440,8 +440,8 @@
         "description": "The super soldier fires its XARM scattergun!",
         "no_ammo_sound": "beep-beep-beep!"
       },
-      [ "GRAB", 10 ],
-      [ "BIO_OP_TAKEDOWN", 30 ]
+      { "id": "grab", "cooldown": 10 },
+      { "id": "bio_op_takedown", "cooldown": 30 }
     ],
     "special_when_hit": [ "ZAPBACK", 60 ],
     "anger_triggers": [ "FRIEND_DIED", "FRIEND_ATTACKED", "HURT", "STALK", "PLAYER_CLOSE" ],
@@ -504,7 +504,7 @@
         "description": "The super soldier fires its LMG!",
         "no_ammo_sound": "beep-beep-beep!"
       },
-      [ "GRAB_DRAG", 10 ],
+      { "id": "grab_drag", "cooldown": 10 },
       [ "SMASH", 30 ],
       { "id": "slam" }
     ],
@@ -569,7 +569,7 @@
         "description": "The super soldier fires its launcher!",
         "no_ammo_sound": "beep-beep-beep!"
       },
-      [ "GRAB_DRAG", 10 ],
+      { "id": "grab_drag", "cooldown": 10 },
       [ "SMASH", 30 ],
       { "id": "slam" }
     ],
@@ -635,8 +635,8 @@
         "description": "The super scout fires its rifle!",
         "no_ammo_sound": "beep-beep-beep!"
       },
-      [ "GRAB", 10 ],
-      [ "BIO_OP_TAKEDOWN", 30 ],
+      { "id": "grab", "cooldown": 10 },
+      { "id": "bio_op_takedown", "cooldown": 30 },
       [ "LUNGE", 20 ]
     ],
     "special_when_hit": [ "ZAPBACK", 60 ],
@@ -701,7 +701,7 @@
         "description": "The super soldier fires its pistol!",
         "no_ammo_sound": "beep-beep-beep!"
       },
-      [ "GRAB", 10 ],
+      { "id": "grab", "cooldown": 10 },
       [ "scratch", 20 ]
     ],
     "special_when_hit": [ "ZAPBACK", 60 ],
@@ -766,7 +766,7 @@
         "description": "The super soldier fires its smg!",
         "no_ammo_sound": "beep-beep-beep!"
       },
-      [ "GRAB", 10 ],
+      { "id": "grab", "cooldown": 10 },
       [ "scratch", 20 ]
     ],
     "special_when_hit": [ "ZAPBACK", 60 ],
@@ -811,8 +811,8 @@
     "dissect": "dissect_CBM_SOLDAT_ZOMBIE_GENERIC",
     "special_attacks": [
       { "type": "leap", "cooldown": 10, "max_range": 5 },
-      [ "GRAB", 5 ],
-      [ "BIO_OP_TAKEDOWN", 20 ],
+      { "id": "grab", "cooldown": 5 },
+      { "id": "bio_op_takedown", "cooldown": 20 },
       [ "scratch", 15 ],
       { "type": "bite", "cooldown": 5 }
     ],


### PR DESCRIPTION
Sets it so that wasteland drifter starts with both a Colt Navy and Army, with a total of 1 stack of ammo for each, divided up as their storage items allow.

During testing I learned that DDA managed to screw it up such that the Colt Army can't fit in any vanilla holster as far as I could determine:
![image](https://github.com/Noctifer-de-Mortem/nocts_cata_mod/assets/11582235/833c9a9d-0176-4684-acaa-da139530e3db)
![image](https://github.com/Noctifer-de-Mortem/nocts_cata_mod/assets/11582235/a9f1c696-b576-49d6-9252-7c47a275261a)

As such I shrugged, said "fuck it" and decided to upgrade them to a survivor's leg rig in both versions, despite them lacking the base skills needed to make it. Also makes it feel less messy in the BN version via fixing the the layering problems that came from juggling a holster, sheath, and canteen. Not a big buff aside from saving a tiny bit of leg encumbrance and making inventory juggling less hassle.

Also fixes grab attacks for monsters in the DDA version.