### PR TITLE
BN anvil quality update

### DIFF
--- a/nocts_cata_mod_BN/Recipe/c_recipes.json
+++ b/nocts_cata_mod_BN/Recipe/c_recipes.json
@@ -1330,16 +1330,9 @@
     "difficulty": 9,
     "time": "240 m",
     "book_learn": [ [ "recipe_surv", 6 ], [ "manual_rifle", 6 ], [ "mag_rifle", 7 ] ],
-    "qualities": [
-      { "id": "ANVIL", "level": 3 },
-      { "id": "CUT", "level": 1 },
-      { "id": "HAMMER_FINE", "level": 1 },
-      { "id": "SAW_M_FINE", "level": 1 },
-      { "id": "SCREW_FINE", "level": 1 },
-      { "id": "CHISEL", "level": 3 }
-    ],
-    "using": [ [ "forging_standard", 4 ], [ "steel_standard", 3 ] ],
-    "tools": [ [ [ "tongs", -1 ] ], [ [ "swage", -1 ] ], [ [ "small_repairkit", 120 ], [ "large_repairkit", 120 ] ] ],
+    "qualities": [ { "id": "CUT", "level": 1 }, { "id": "SAW_M_FINE", "level": 1 }, { "id": "SCREW_FINE", "level": 1 } ],
+    "using": [ [ "blacksmithing_advanced", 4 ], [ "steel_standard", 3 ] ],
+    "tools": [ [ [ "small_repairkit", 120 ], [ "large_repairkit", 120 ] ] ],
     "components": [ [ [ "2x4", 2 ] ], [ [ "pipe", 2 ] ], [ [ "spring", 2 ] ], [ [ "pilot_light", 1 ] ] ]
   },
   {

--- a/nocts_cata_mod_DDA/Recipe/c_recipes.json
+++ b/nocts_cata_mod_DDA/Recipe/c_recipes.json
@@ -1386,15 +1386,8 @@
     "difficulty": 9,
     "time": "240 m",
     "book_learn": [ [ "recipe_surv", 6 ], [ "manual_rifle", 6 ], [ "mag_rifle", 7 ] ],
-    "qualities": [
-      { "id": "ANVIL", "level": 3 },
-      { "id": "CUT", "level": 1 },
-      { "id": "HAMMER_FINE", "level": 1 },
-      { "id": "SAW_M_FINE", "level": 1 },
-      { "id": "SCREW_FINE", "level": 1 },
-      { "id": "CHISEL", "level": 3 }
-    ],
-    "using": [ [ "forging_standard", 4 ], [ "steel_standard", 3 ] ],
+    "qualities": [ { "id": "CUT", "level": 1 }, { "id": "SAW_M_FINE", "level": 1 }, { "id": "SCREW_FINE", "level": 1 } ],
+    "using": [ [ "blacksmithing_standard", 4 ], [ "steel_standard", 3 ] ],
     "proficiencies": [
       { "proficiency": "prof_metalworking" },
       { "proficiency": "prof_blacksmithing" },
@@ -1402,7 +1395,7 @@
       { "proficiency": "prof_gunsmithing_antique" },
       { "proficiency": "prof_carving" }
     ],
-    "tools": [ [ [ "tongs", -1 ] ], [ [ "swage", -1 ] ], [ [ "small_repairkit", 120 ], [ "large_repairkit", 120 ] ] ],
+    "tools": [ [ [ "small_repairkit", 120 ], [ "large_repairkit", 120 ] ] ],
     "components": [ [ [ "2x4", 2 ] ], [ [ "pipe", 2 ] ], [ [ "spring", 2 ] ], [ [ "pilot_light", 1 ] ] ]
   },
   {


### PR DESCRIPTION
Belated update now that https://github.com/cataclysmbnteam/Cataclysm-BN/pull/3008 is merged, stuff came up and sidetracked me before I could PR this one.

Converted the survivor sniper recipe to actually use the blacksmithing crafting quality instead of explicit tools and qualities, also means use of hammering quality instead of fine hammering. Comes with a consistency update to DDA version too.

Turned out to be fairly simple since only one recipe really used smithing, the other users of anvil quality are more welding-focused.