### PR TITLE
New profession and misc

### DIFF
--- a/nocts_cata_mod_BN/Char_creation/c_classes_r.json
+++ b/nocts_cata_mod_BN/Char_creation/c_classes_r.json
@@ -165,7 +165,7 @@
     "items": {
       "both": {
         "ammo": 100,
-        "items": [ "loincloth", "footrags", "backpack", "waterskin", "flint_steel", "clay_pot", "press_dowel", "puller" ],
+        "items": [ "loincloth", "footrags", "backpack", "waterskin", "flint_steel", "clay_pot" ],
         "entries": [
           { "item": "c_power_armor_surv", "ammo-item": "lamp_oil", "charges": 2000 },
           { "item": "greatsword_makeshift", "custom-flags": [ "auto_wield" ] },

--- a/nocts_cata_mod_BN/Char_creation/c_classes_r.json
+++ b/nocts_cata_mod_BN/Char_creation/c_classes_r.json
@@ -131,7 +131,7 @@
           "boots_plate_surv",
           "helmet_plate_surv",
           "gloves_plate_surv",
-          "shield_leather_large",
+          "shield_riot_surv",
           "backpack_leather",
           "waterskin",
           "flint_steel",
@@ -143,6 +143,36 @@
       },
       "male": [ "boxer_briefs" ],
       "female": [ "bra", "panties" ]
+    },
+    "flags": [ "SCEN_ONLY" ]
+  },
+  {
+    "type": "profession",
+    "id": "surv_techno_barbarian",
+    "name": "Wasteland Techno-Barbarian",
+    "description": "The end of the world brings out the best and worst in everyone.  For you, it was a chance to channel your pre-Cataclysm expertise into something more primal.  Whether you have the might to use such armament remains to be seen.",
+    "points": 12,
+    "skills": [
+      { "level": 6, "name": "fabrication" },
+      { "level": 4, "name": "mechanics" },
+      { "level": 2, "name": "electronics" },
+      { "level": 2, "name": "cooking" },
+      { "level": 3, "name": "survival" },
+      { "level": 1, "name": "melee" },
+      { "level": 1, "name": "bashing" },
+      { "level": 1, "name": "cutting" }
+    ],
+    "items": {
+      "both": {
+        "ammo": 100,
+        "items": [ "loincloth", "footrags", "backpack", "waterskin", "flint_steel", "clay_pot", "press_dowel", "puller" ],
+        "entries": [
+          { "item": "c_power_armor_surv", "ammo-item": "lamp_oil", "charges": 2000 },
+          { "item": "greatsword_makeshift", "custom-flags": [ "auto_wield" ] },
+          { "item": "makeshift_knife", "container-item": "sheath" }
+        ]
+      },
+      "female": [ "chestwrap" ]
     },
     "flags": [ "SCEN_ONLY" ]
   },

--- a/nocts_cata_mod_BN/Char_creation/c_scenarios.json
+++ b/nocts_cata_mod_BN/Char_creation/c_scenarios.json
@@ -44,7 +44,20 @@
     "points": 2,
     "start_name": "Boarded Up House",
     "allowed_locs": [ "sloc_house_boarded" ],
-    "professions": [ "survivalist", "jr_survivalist", "bionic_prepper", "prepper", "fisher", "camper", "groundskeeper", "blacksmith" ],
+    "professions": [
+      "survivalist",
+      "jr_survivalist",
+      "bionic_prepper",
+      "prepper",
+      "fisher",
+      "camper",
+      "groundskeeper",
+      "blacksmith",
+      "bionic_silencer",
+      "surv_drifter",
+      "surv_knight_errant",
+      "surv_techno_barbarian"
+    ],
     "traits": [ "MARTIAL_ARTS_SURV_COM" ]
   },
   {
@@ -136,7 +149,8 @@
         "bio_knight",
         "bio_tool",
         "surv_drifter",
-        "surv_knight_errant"
+        "surv_knight_errant",
+        "surv_techno_barbarian"
       ]
     }
   },
@@ -156,7 +170,8 @@
         "bio_knight",
         "bio_tool",
         "surv_drifter",
-        "surv_knight_errant"
+        "surv_knight_errant",
+        "surv_techno_barbarian"
       ]
     }
   },
@@ -170,7 +185,7 @@
     "copy-from": "wilderness",
     "type": "scenario",
     "add_professions": true,
-    "extend": { "allowed_locs": [ "surv_camp_l" ], "professions": [ "surv_drifter", "surv_knight_errant" ] },
+    "extend": { "allowed_locs": [ "surv_camp_l" ], "professions": [ "surv_drifter", "surv_knight_errant", "surv_techno_barbarian" ] },
     "id": "wilderness"
   },
   {
@@ -219,7 +234,7 @@
     "copy-from": "surrounded",
     "type": "scenario",
     "add_professions": true,
-    "extend": { "allowed_locs": [ "sloc_mansion" ], "professions": [ "surv_drifter", "surv_knight_errant" ] },
+    "extend": { "allowed_locs": [ "sloc_mansion" ], "professions": [ "surv_drifter", "surv_knight_errant", "surv_techno_barbarian" ] },
     "id": "surrounded"
   },
   {

--- a/nocts_cata_mod_BN/Surv_help/c_armor.json
+++ b/nocts_cata_mod_BN/Surv_help/c_armor.json
@@ -893,7 +893,7 @@
       "holster_msg": "You stash your %s.",
       "multi": 4,
       "min_volume": "50 ml",
-      "max_volume": "1750 ml",
+      "max_volume": "2 L",
       "skills": [ "pistol", "smg", "shotgun", "rifle" ],
       "draw_cost": 75,
       "flags": [ "SHEATH_KNIFE", "BELT_CLIP", "SHEATH_SWORD", "MAG_COMPACT", "MAG_BULKY", "SPEEDLOADER" ]

--- a/nocts_cata_mod_BN/Weapons/c_mods.json
+++ b/nocts_cata_mod_BN/Weapons/c_mods.json
@@ -191,6 +191,7 @@
       [ "FLAMETHROWERS" ]
     ],
     "volume": "250 ml",
+    "integral_volume": "125 ml",
     "price": "850 USD",
     "price_postapoc": "850 cent",
     "install_time": "30 m",

--- a/nocts_cata_mod_DDA/Char_creation/c_classes_r.json
+++ b/nocts_cata_mod_DDA/Char_creation/c_classes_r.json
@@ -165,6 +165,37 @@
   },
   {
     "type": "profession",
+    "id": "surv_techno_barbarian",
+    "name": "Wasteland Techno-Barbarian",
+    "description": "The end of the world brings out the best and worst in everyone.  For you, it was a chance to channel your pre-Cataclysm expertise into something more primal.  Whether you have the might to use such armament remains to be seen.",
+    "points": 12,
+    "skills": [
+      { "level": 6, "name": "fabrication" },
+      { "level": 4, "name": "mechanics" },
+      { "level": 2, "name": "electronics" },
+      { "level": 2, "name": "cooking" },
+      { "level": 3, "name": "survival" },
+      { "level": 1, "name": "melee" },
+      { "level": 1, "name": "bashing" },
+      { "level": 1, "name": "cutting" }
+    ],
+    "proficiencies": [ "prof_metalworking", "prof_intro_chemistry" ],
+    "items": {
+      "both": {
+        "ammo": 100,
+        "items": [ "loincloth", "footrags", "backpack", "waterskin", "flint_steel", "clay_pot" ],
+        "entries": [
+          { "item": "c_power_armor_surv", "ammo-item": "lamp_oil", "charges": 2000 },
+          { "item": "greatsword_makeshift", "custom-flags": [ "auto_wield" ] },
+          { "item": "makeshift_knife", "container-item": "sheath" }
+        ]
+      },
+      "female": [ "chestwrap" ]
+    },
+    "flags": [ "SCEN_ONLY" ]
+  },
+  {
+    "type": "profession",
     "id": "bionic_silencer",
     "name": "Bionic Silencer",
     "description": "You were trained and equipped for infiltrating secure facilities for your mysterious backers, to secure specific objects of interest and silence high-value targets.  Now that they've gone silent themselves, you'll have to use your gifts for simple survival.",

--- a/nocts_cata_mod_DDA/Char_creation/c_scenarios.json
+++ b/nocts_cata_mod_DDA/Char_creation/c_scenarios.json
@@ -59,7 +59,19 @@
     "points": 2,
     "start_name": "Boarded Up House",
     "allowed_locs": [ "sloc_house_boarded" ],
-    "professions": [ "survivalist", "jr_survivalist", "prepper", "fisher", "birder", "groundskeeper", "blacksmith" ],
+    "professions": [
+      "survivalist",
+      "jr_survivalist",
+      "prepper",
+      "fisher",
+      "birder",
+      "groundskeeper",
+      "blacksmith",
+      "bionic_silencer",
+      "surv_drifter",
+      "surv_knight_errant",
+      "surv_techno_barbarian"
+    ],
     "traits": [ "MARTIAL_ARTS_SURV_COM" ]
   },
   {
@@ -151,7 +163,8 @@
         "bio_knight",
         "bio_tool",
         "surv_drifter",
-        "surv_knight_errant"
+        "surv_knight_errant",
+        "surv_techno_barbarian"
       ]
     }
   },
@@ -171,7 +184,8 @@
         "bio_knight",
         "bio_tool",
         "surv_drifter",
-        "surv_knight_errant"
+        "surv_knight_errant",
+        "surv_techno_barbarian"
       ]
     }
   },
@@ -179,7 +193,7 @@
     "copy-from": "wilderness",
     "type": "scenario",
     "add_professions": true,
-    "extend": { "allowed_locs": [ "surv_camp_l" ], "professions": [ "surv_drifter", "surv_knight_errant" ] },
+    "extend": { "allowed_locs": [ "surv_camp_l" ], "professions": [ "surv_drifter", "surv_knight_errant", "surv_techno_barbarian" ] },
     "id": "wilderness"
   },
   {
@@ -219,7 +233,7 @@
     "copy-from": "surrounded",
     "type": "scenario",
     "add_professions": true,
-    "extend": { "allowed_locs": [ "sloc_mansion" ], "professions": [ "surv_drifter", "surv_knight_errant" ] },
+    "extend": { "allowed_locs": [ "sloc_mansion" ], "professions": [ "surv_drifter", "surv_knight_errant", "surv_techno_barbarian" ] },
     "id": "surrounded"
   },
   {

--- a/nocts_cata_mod_DDA/Surv_help/c_armor.json
+++ b/nocts_cata_mod_DDA/Surv_help/c_armor.json
@@ -966,7 +966,7 @@
       {
         "moves": 75,
         "min_volume": "50 ml",
-        "max_contains_volume": "1500 ml",
+        "max_contains_volume": "2 L",
         "max_contains_weight": "5 kg",
         "max_item_length": "762 mm",
         "skills": [ "pistol", "smg", "shotgun", "rifle" ],
@@ -975,7 +975,7 @@
       {
         "moves": 75,
         "min_volume": "50 ml",
-        "max_contains_volume": "1500 ml",
+        "max_contains_volume": "2 L",
         "max_contains_weight": "5 kg",
         "max_item_length": "762 mm",
         "skills": [ "pistol", "smg", "shotgun", "rifle" ],
@@ -984,7 +984,7 @@
       {
         "moves": 75,
         "min_volume": "50 ml",
-        "max_contains_volume": "1500 ml",
+        "max_contains_volume": "2 L",
         "max_contains_weight": "5 kg",
         "max_item_length": "762 mm",
         "holster": true,
@@ -993,7 +993,7 @@
       {
         "moves": 75,
         "min_volume": "50 ml",
-        "max_contains_volume": "1500 ml",
+        "max_contains_volume": "2 L",
         "max_contains_weight": "5 kg",
         "max_item_length": "762 mm",
         "holster": true,

--- a/nocts_cata_mod_DDA/Weapons/c_mods.json
+++ b/nocts_cata_mod_DDA/Weapons/c_mods.json
@@ -180,6 +180,7 @@
     "material": [ "plastic", "steel" ],
     "mod_targets": [ "smg", "rifle", "pistol", "shotgun", "crossbow", "bow", "launcher" ],
     "volume": "250 ml",
+    "integral_volume": "125 ml",
     "price": "850 USD",
     "price_postapoc": "850 cent",
     "install_time": "30 m",


### PR DESCRIPTION
1. Added another post-apoc profession: wasteland techno-barbarian. Starts off with the bare minimum needed to craft the makeshift power armor they start with, along with having the means to make lamp oil to keep their armor fueled. Meant to be a way to dive in and mess with content, high strength and/or Strong Back comes in handy for this. Went ahead and kept it melee-focused, original idea was to add the full-auto shotgun too but that adds a fair bit of weight and even more skills when they already start with a lot.
2. Added wasteland techno-barbarian to scenarios that allow wasteland drifter and knight-errant.
3. Added bionic silencer, wasteland drifter, wasteland knight-errant, and wasteland techno-barbarian to prepper house scenario.
4. Set survivor knight-errant to use the survivor's tactical shield instead of generic wooden shield, in the BN version.
5. Set integral volume of 125 ml for survivor's laser sight as per: https://github.com/cataclysmbnteam/Cataclysm-BN/pull/3158
6. Increased max volume of survivor's leg rig to 2 liters as per: https://github.com/cataclysmbnteam/Cataclysm-BN/pull/3159