### PR TITLE
Flintlock updates for BN version

### DIFF
--- a/nocts_cata_mod_BN/Surv_help/c_armor.json
+++ b/nocts_cata_mod_BN/Surv_help/c_armor.json
@@ -858,6 +858,7 @@
         "20x66mm",
         "signal_flare",
         "flintlock",
+        "flintlockshot",
         "36paper",
         "44paper",
         "blunderbuss",

--- a/nocts_cata_mod_BN/Weapons/c_ranged.json
+++ b/nocts_cata_mod_BN/Weapons/c_ranged.json
@@ -1125,7 +1125,7 @@
     "bashing": 12,
     "to_hit": -1,
     "ranged_damage": { "damage_type": "bullet", "amount": 10 },
-    "range": 7,
+    "range": 16,
     "dispersion": 150,
     "durability": 5,
     "blackpowder_tolerance": 80,


### PR DESCRIPTION
1. Reworked range of the survivor's flintlock sniper to be a but less than the new range the long rifle has.
2. Updated the survivor's cowboy hat so it can hold paper shot, which got shifted to a separate ammotype to preclude rifles using them.

Simple updates in response to https://github.com/cataclysmbnteam/Cataclysm-BN/pull/3171/files