### PR TITLE
Update c_armor.json

### DIFF
--- a/nocts_cata_mod_BN/Surv_help/c_armor.json
+++ b/nocts_cata_mod_BN/Surv_help/c_armor.json
@@ -896,7 +896,6 @@
       "min_volume": "50 ml",
       "max_volume": "2 L",
       "skills": [ "pistol", "smg", "shotgun", "rifle" ],
-      "draw_cost": 75,
       "flags": [ "SHEATH_KNIFE", "BELT_CLIP", "SHEATH_SWORD", "MAG_COMPACT", "MAG_BULKY", "SPEEDLOADER" ]
     },
     "flags": [ "WATER_FRIENDLY", "BELTED", "OVERSIZE", "NO_QUICKDRAW" ]


### PR DESCRIPTION
Updated draw costs of items in the BN version based off changes in https://github.com/cataclysmbnteam/Cataclysm-BN/pull/3173 No real need to have it as a draft this time since no code dependencies involved and super simple change.

Survivor's leg rig got its draw cost set to the default to match what belts in general are getting and what the XL holster already has, smol and easy change. Survivor scout suits don't even need any change since they're using the same value as fast draw holsters, which is what I intended to set them at if they weren't.

Dunno yet what we'll do with mag pouches so left military armor untouched for now.