### PR TITLE
Remove  powerful_knockback from DDA technique

### DIFF
--- a/nocts_cata_mod_DDA/Surv_help/c_techniques.json
+++ b/nocts_cata_mod_DDA/Surv_help/c_techniques.json
@@ -83,7 +83,6 @@
     "crit_tec": true,
     "stun_dur": 2,
     "knockback_dist": 4,
-    "powerful_knockback": true,
     "attack_vectors": [ "WEAPON", "HAND" ]
   },
   {


### PR DESCRIPTION
https://github.com/CleverRaven/Cataclysm-DDA/pull/68418 removed the powerful_knockback technique.

The field didn't do anything even before deprecation, so I'm following 68418 as an example by not replacing the field with anything.