### PR TITLE
Pending BN update: bionic harvest variation

### DIFF
--- a/nocts_cata_mod_BN/Monsters/c_monster_harvest.json
+++ b/nocts_cata_mod_BN/Monsters/c_monster_harvest.json
@@ -3,39 +3,39 @@
     "id": "CBM_FAILED_BIO",
     "type": "harvest",
     "entries": [
-      { "drop": "bionic_power_storage_mil", "type": "bionic_group", "faults": [ "fault_bionic_nonsterile" ] },
-      { "drop": "bionic_power_storage_mil", "type": "bionic_group", "faults": [ "fault_bionic_nonsterile" ] },
-      { "drop": "bionics_failed_bio", "type": "bionic_group", "faults": [ "fault_bionic_nonsterile" ] },
+      { "drop": "harvest_power_storage_mil", "type": "bionic_group", "faults": [ "fault_bionic_nonsterile" ] },
+      { "drop": "harvest_power_storage_mil", "type": "bionic_group", "faults": [ "fault_bionic_nonsterile" ] },
+      { "drop": "harvest_bionics_failed_bio", "type": "bionic_group", "faults": [ "fault_bionic_nonsterile" ] },
       { "drop": "mutant_human_flesh", "type": "flesh", "mass_ratio": 0.2 },
       { "drop": "hstomach_large", "scale_num": [ 1, 1 ], "max": 1, "type": "offal" },
       { "drop": "mutant_human_fat", "type": "flesh", "mass_ratio": 0.1 },
       { "drop": "bone_human", "type": "bone", "mass_ratio": 0.12 },
       { "drop": "sinew", "type": "bone", "mass_ratio": 0.001 },
       { "drop": "raw_hleather", "type": "skin", "mass_ratio": 0.01 },
-      { "drop": "alloy_sheet", "type": "skin", "mass_ratio": 0.015 }
+      { "drop": "alloy_sheet", "type": "skin", "mass_ratio": 0.035 }
     ]
   },
   {
     "id": "CBM_FAILED_BIO_ZOMBIE",
     "type": "harvest",
     "entries": [
-      { "drop": "bionic_power_storage_mil", "type": "bionic_group", "faults": [ "fault_bionic_nonsterile" ] },
-      { "drop": "bionic_power_storage_mil", "type": "bionic_group", "faults": [ "fault_bionic_nonsterile" ] },
-      { "drop": "bionics_failed_bio", "type": "bionic_group", "faults": [ "fault_bionic_nonsterile" ] },
+      { "drop": "harvest_power_storage_mil", "type": "bionic_group", "faults": [ "fault_bionic_nonsterile" ] },
+      { "drop": "harvest_power_storage_mil", "type": "bionic_group", "faults": [ "fault_bionic_nonsterile" ] },
+      { "drop": "harvest_bionics_failed_bio", "type": "bionic_group", "faults": [ "fault_bionic_nonsterile" ] },
       { "drop": "meat_tainted", "type": "flesh", "mass_ratio": 0.25 },
       { "drop": "fat_tainted", "type": "flesh", "mass_ratio": 0.08 },
       { "drop": "bone_tainted", "type": "bone", "mass_ratio": 0.1 },
       { "drop": "raw_tainted_leather", "type": "skin", "mass_ratio": 0.01 },
-      { "drop": "alloy_sheet", "type": "skin", "mass_ratio": 0.015 }
+      { "drop": "alloy_sheet", "type": "skin", "mass_ratio": 0.035 }
     ]
   },
   {
     "id": "CBM_APOPHIS",
     "type": "harvest",
     "entries": [
-      { "drop": "bionic_power_storage_mil", "type": "bionic_group", "faults": [ "fault_bionic_nonsterile" ] },
-      { "drop": "bionic_power_storage_mil", "type": "bionic_group", "faults": [ "fault_bionic_nonsterile" ] },
-      { "drop": "bionic_power_storage_mil", "type": "bionic_group", "faults": [ "fault_bionic_nonsterile" ] },
+      { "drop": "harvest_power_storage_mil", "type": "bionic_group", "faults": [ "fault_bionic_nonsterile" ] },
+      { "drop": "harvest_power_storage_mil", "type": "bionic_group", "faults": [ "fault_bionic_nonsterile" ] },
+      { "drop": "harvest_power_storage_mil", "type": "bionic_group", "faults": [ "fault_bionic_nonsterile" ] },
       { "drop": "bionics_apophis_off", "type": "bionic_group", "faults": [ "fault_bionic_nonsterile" ] },
       { "drop": "bionics_apophis_def", "type": "bionic_group", "faults": [ "fault_bionic_nonsterile" ] },
       { "drop": "bionics_apophis_util", "type": "bionic_group", "faults": [ "fault_bionic_nonsterile" ] },
@@ -45,15 +45,15 @@
       { "drop": "bone_human", "type": "bone", "mass_ratio": 0.12 },
       { "drop": "sinew", "type": "bone", "mass_ratio": 0.001 },
       { "drop": "raw_hleather", "type": "skin", "mass_ratio": 0.01 },
-      { "drop": "alloy_sheet", "type": "skin", "mass_ratio": 0.015 }
+      { "drop": "alloy_sheet", "type": "skin", "mass_ratio": 0.035 }
     ]
   },
   {
     "id": "CBM_SOLDAT_ZOMBIE_GENERIC",
     "type": "harvest",
     "entries": [
-      { "drop": "bio_power_storage_sentinel", "type": "bionic", "faults": [ "fault_bionic_nonsterile" ] },
-      { "drop": "bionics_soldat_zombie_generic", "type": "bionic_group", "faults": [ "fault_bionic_nonsterile" ] },
+      { "drop": "harvest_power_storage_sentinel", "type": "bionic_group", "faults": [ "fault_bionic_nonsterile" ] },
+      { "drop": "harvest_soldat_zombie_generic", "type": "bionic_group", "faults": [ "fault_bionic_nonsterile" ] },
       { "drop": "meat_tainted", "type": "flesh", "mass_ratio": 0.25 },
       { "drop": "fat_tainted", "type": "flesh", "mass_ratio": 0.08 },
       { "drop": "bone_tainted", "type": "bone", "mass_ratio": 0.1 }
@@ -63,8 +63,8 @@
     "id": "CBM_SOLDAT_ZOMBIE",
     "type": "harvest",
     "entries": [
-      { "drop": "bio_power_storage_sentinel", "type": "bionic", "faults": [ "fault_bionic_nonsterile" ] },
-      { "drop": "bionics_soldat_zombie", "type": "bionic_group", "faults": [ "fault_bionic_nonsterile" ] },
+      { "drop": "harvest_power_storage_sentinel", "type": "bionic_group", "faults": [ "fault_bionic_nonsterile" ] },
+      { "drop": "harvest_soldat_zombie", "type": "bionic_group", "faults": [ "fault_bionic_nonsterile" ] },
       { "drop": "meat_tainted", "type": "flesh", "mass_ratio": 0.25 },
       { "drop": "fat_tainted", "type": "flesh", "mass_ratio": 0.08 },
       { "drop": "bone_tainted", "type": "bone", "mass_ratio": 0.1 }
@@ -74,8 +74,8 @@
     "id": "CBM_SOLDAT_KNIGHT_ZOMBIE",
     "type": "harvest",
     "entries": [
-      { "drop": "bio_power_storage_sentinel", "type": "bionic", "faults": [ "fault_bionic_nonsterile" ] },
-      { "drop": "bionics_soldat_knight_zombie", "type": "bionic_group", "faults": [ "fault_bionic_nonsterile" ] },
+      { "drop": "harvest_power_storage_sentinel", "type": "bionic_group", "faults": [ "fault_bionic_nonsterile" ] },
+      { "drop": "harvest_soldat_knight_zombie", "type": "bionic_group", "faults": [ "fault_bionic_nonsterile" ] },
       { "drop": "meat_tainted", "type": "flesh", "mass_ratio": 0.25 },
       { "drop": "fat_tainted", "type": "flesh", "mass_ratio": 0.08 },
       { "drop": "bone_tainted", "type": "bone", "mass_ratio": 0.1 }
@@ -85,8 +85,8 @@
     "id": "CBM_SOLDAT_SNIPER_ZOMBIE",
     "type": "harvest",
     "entries": [
-      { "drop": "bio_power_storage_sentinel", "type": "bionic", "faults": [ "fault_bionic_nonsterile" ] },
-      { "drop": "bionics_soldat_sniper_zombie", "type": "bionic_group", "faults": [ "fault_bionic_nonsterile" ] },
+      { "drop": "harvest_power_storage_sentinel", "type": "bionic_group", "faults": [ "fault_bionic_nonsterile" ] },
+      { "drop": "harvest_soldat_sniper_zombie", "type": "bionic_group", "faults": [ "fault_bionic_nonsterile" ] },
       { "drop": "meat_tainted", "type": "flesh", "mass_ratio": 0.25 },
       { "drop": "fat_tainted", "type": "flesh", "mass_ratio": 0.08 },
       { "drop": "bone_tainted", "type": "bone", "mass_ratio": 0.1 }
@@ -96,8 +96,8 @@
     "id": "CBM_SOLDAT_TOOL_ZOMBIE",
     "type": "harvest",
     "entries": [
-      { "drop": "bio_power_storage_sentinel", "type": "bionic", "faults": [ "fault_bionic_nonsterile" ] },
-      { "drop": "bionics_soldat_tool_zombie", "type": "bionic_group", "faults": [ "fault_bionic_nonsterile" ] },
+      { "drop": "harvest_power_storage_sentinel", "type": "bionic_group", "faults": [ "fault_bionic_nonsterile" ] },
+      { "drop": "harvest_soldat_tool_zombie", "type": "bionic_group", "faults": [ "fault_bionic_nonsterile" ] },
       { "drop": "meat_tainted", "type": "flesh", "mass_ratio": 0.25 },
       { "drop": "fat_tainted", "type": "flesh", "mass_ratio": 0.08 },
       { "drop": "bone_tainted", "type": "bone", "mass_ratio": 0.1 }

--- a/nocts_cata_mod_BN/Surv_help/c_item_groups.json
+++ b/nocts_cata_mod_BN/Surv_help/c_item_groups.json
@@ -739,6 +739,77 @@
     ]
   },
   {
+    "id": "harvest_bionics_failed_bio",
+    "type": "item_group",
+    "subtype": "distribution",
+    "entries": [
+      { "item": "null", "prob": 25 },
+      { "item": "burnt_out_bionic", "prob": 10 },
+      { "group": "bionic_salvage_junk_mil", "prob": 15 },
+      { "group": "bionics_failed_bio", "prob": 50 }
+    ]
+  },
+  {
+    "id": "harvest_power_storage_sentinel",
+    "type": "item_group",
+    "subtype": "distribution",
+    "entries": [
+      { "item": "null", "prob": 25 },
+      { "item": "bionic_salvage_junk_mil", "prob": 25 },
+      { "item": "bio_power_storage_sentinel", "prob": 50 }
+    ]
+  },
+  {
+    "id": "harvest_soldat_zombie_generic",
+    "type": "item_group",
+    "subtype": "distribution",
+    "entries": [
+      { "item": "null", "prob": 25 },
+      { "item": "bionic_salvage_junk_mil", "prob": 25 },
+      { "group": "bionics_soldat_zombie_generic", "prob": 50 }
+    ]
+  },
+  {
+    "id": "harvest_soldat_zombie",
+    "type": "item_group",
+    "subtype": "distribution",
+    "entries": [
+      { "item": "null", "prob": 25 },
+      { "item": "bionic_salvage_junk_mil", "prob": 25 },
+      { "group": "bionics_soldat_zombie", "prob": 50 }
+    ]
+  },
+  {
+    "id": "harvest_soldat_knight_zombie",
+    "type": "item_group",
+    "subtype": "distribution",
+    "entries": [
+      { "item": "null", "prob": 25 },
+      { "item": "bionic_salvage_junk_mil", "prob": 25 },
+      { "group": "bionics_soldat_knight_zombie", "prob": 50 }
+    ]
+  },
+  {
+    "id": "harvest_soldat_sniper_zombie",
+    "type": "item_group",
+    "subtype": "distribution",
+    "entries": [
+      { "item": "null", "prob": 25 },
+      { "item": "bionic_salvage_junk_mil", "prob": 25 },
+      { "group": "bionics_soldat_sniper_zombie", "prob": 50 }
+    ]
+  },
+  {
+    "id": "harvest_soldat_tool_zombie",
+    "type": "item_group",
+    "subtype": "distribution",
+    "entries": [
+      { "item": "null", "prob": 25 },
+      { "item": "bionic_salvage_junk_mil", "prob": 25 },
+      { "group": "bionics_soldat_tool_zombie", "prob": 50 }
+    ]
+  },
+  {
     "type": "item_group",
     "id": "bionics_failed_bio",
     "subtype": "distribution",
@@ -966,37 +1037,74 @@
     "type": "item_group",
     "id": "c_mi_go_advanced_dissection_worker",
     "subtype": "distribution",
-    "items": [ [ "c_mi_go_extruder_broken", 1 ], [ "c_mi_go_wings_broken", 1 ] ]
+    "items": [
+      [ "null", 25 ],
+      [ "resin_chunk", 20 ],
+      [ "fetid_goop", 5 ],
+      [ "c_mi_go_extruder_broken", 25 ],
+      [ "c_mi_go_wings_broken", 25 ]
+    ]
   },
   {
     "type": "item_group",
     "id": "c_mi_go_advanced_dissection_slaver",
     "subtype": "distribution",
-    "items": [ [ "c_mi_go_beam_broken", 3 ], [ "c_mi_go_wings_broken", 1 ] ]
+    "items": [
+      [ "null", 25 ],
+      [ "resin_chunk", 20 ],
+      [ "fetid_goop", 5 ],
+      [ "c_mi_go_beam_broken", 40 ],
+      [ "c_mi_go_wings_broken", 10 ]
+    ]
   },
   {
     "type": "item_group",
     "id": "c_mi_go_advanced_dissection_surgeon",
     "subtype": "distribution",
-    "items": [ [ "c_mi_go_claw_broken", 3 ], [ "c_mi_go_wings_broken", 1 ] ]
+    "items": [
+      [ "null", 25 ],
+      [ "resin_chunk", 20 ],
+      [ "fetid_goop", 5 ],
+      [ "c_mi_go_claw_broken", 40 ],
+      [ "c_mi_go_wings_broken", 10 ]
+    ]
   },
   {
     "type": "item_group",
     "id": "c_mi_go_advanced_dissection_guard",
     "subtype": "distribution",
-    "items": [ [ "c_mi_go_carapace_broken", 2 ], [ "c_mi_go_beam_broken", 1 ] ]
+    "items": [
+      [ "null", 25 ],
+      [ "resin_chunk", 20 ],
+      [ "fetid_goop", 5 ],
+      [ "c_mi_go_carapace_broken", 30 ],
+      [ "c_mi_go_beam_broken", 20 ]
+    ]
   },
   {
     "type": "item_group",
     "id": "c_mi_go_advanced_dissection_myrmidon",
     "subtype": "distribution",
-    "items": [ [ "c_mi_go_carapace_broken", 3 ], [ "c_mi_go_beam_broken", 1 ], [ "c_mi_go_claw_broken", 1 ] ]
+    "items": [
+      [ "null", 25 ],
+      [ "resin_chunk", 20 ],
+      [ "fetid_goop", 5 ],
+      [ "c_mi_go_carapace_broken", 30 ],
+      [ "c_mi_go_beam_broken", 10 ],
+      [ "c_mi_go_claw_broken", 10 ]
+    ]
   },
   {
     "type": "item_group",
     "id": "c_mi_go_advanced_dissection_scout",
     "subtype": "distribution",
-    "items": [ [ "c_mi_go_rifle_broken", 3 ], [ "c_mi_go_wings_broken", 1 ] ]
+    "items": [
+      [ "null", 25 ],
+      [ "resin_chunk", 20 ],
+      [ "fetid_goop", 5 ],
+      [ "c_mi_go_rifle_broken", 40 ],
+      [ "c_mi_go_wings_broken", 10 ]
+    ]
   },
   {
     "id": "sewer",

--- a/nocts_cata_mod_DDA/Monsters/c_monster_harvest.json
+++ b/nocts_cata_mod_DDA/Monsters/c_monster_harvest.json
@@ -9,7 +9,7 @@
       { "drop": "bone_human", "type": "bone", "mass_ratio": 0.12 },
       { "drop": "sinew", "type": "bone", "mass_ratio": 0.001 },
       { "drop": "raw_hleather", "type": "skin", "mass_ratio": 0.01 },
-      { "drop": "alloy_sheet", "type": "skin", "mass_ratio": 0.015 }
+      { "drop": "alloy_sheet", "type": "skin", "mass_ratio": 0.035 }
     ]
   },
   {
@@ -20,7 +20,7 @@
       { "drop": "fat_tainted", "type": "flesh", "mass_ratio": 0.08 },
       { "drop": "bone_tainted", "type": "bone", "mass_ratio": 0.1 },
       { "drop": "raw_tainted_leather", "type": "skin", "mass_ratio": 0.01 },
-      { "drop": "alloy_sheet", "type": "skin", "mass_ratio": 0.015 }
+      { "drop": "alloy_sheet", "type": "skin", "mass_ratio": 0.035 }
     ]
   },
   {
@@ -33,7 +33,7 @@
       { "drop": "bone_human", "type": "bone", "mass_ratio": 0.12 },
       { "drop": "sinew", "type": "bone", "mass_ratio": 0.001 },
       { "drop": "raw_hleather", "type": "skin", "mass_ratio": 0.01 },
-      { "drop": "alloy_sheet", "type": "skin", "mass_ratio": 0.015 }
+      { "drop": "alloy_sheet", "type": "skin", "mass_ratio": 0.035 }
     ]
   },
   {

--- a/nocts_cata_mod_DDA/Surv_help/c_item_groups.json
+++ b/nocts_cata_mod_DDA/Surv_help/c_item_groups.json
@@ -382,19 +382,19 @@
     "type": "item_group",
     "id": "c_mi_go_advanced_dissection_slaver",
     "subtype": "distribution",
-    "items": [ [ "c_mi_go_beam_broken", 3 ], [ "c_mi_go_wings_broken", 1 ] ]
+    "items": [ [ "c_mi_go_beam_broken", 4 ], [ "c_mi_go_wings_broken", 1 ] ]
   },
   {
     "type": "item_group",
     "id": "c_mi_go_advanced_dissection_surgeon",
     "subtype": "distribution",
-    "items": [ [ "c_mi_go_claw_broken", 3 ], [ "c_mi_go_wings_broken", 1 ] ]
+    "items": [ [ "c_mi_go_claw_broken", 4 ], [ "c_mi_go_wings_broken", 1 ] ]
   },
   {
     "type": "item_group",
     "id": "c_mi_go_advanced_dissection_guard",
     "subtype": "distribution",
-    "items": [ [ "c_mi_go_carapace_broken", 2 ], [ "c_mi_go_beam_broken", 1 ] ]
+    "items": [ [ "c_mi_go_carapace_broken", 3 ], [ "c_mi_go_beam_broken", 2 ] ]
   },
   {
     "type": "item_group",


### PR DESCRIPTION
Set aside for when https://github.com/cataclysmbnteam/Cataclysm-BN/pull/3719 is merged. Uses the new system of harvest itemgroups to make CBM generation less predictable, defining relevant itemgroups for dissecting failed bio-weapons, augmented undead soldiers, etc. Also now the BN version includes relevant non-biotech items for dissecting mi-gos.

Went ahead and allowed Apophis to stay at generating his CBMs at a 100% rate on the basis that he's a special boss critter so he can afford to reward CBMs more reliably than the norm.

Also belatedly applied a minor change influenced by https://github.com/cataclysmbnteam/Cataclysm-BN/pull/3538 to make superalloy skin more prominant for augmented abomination harvests.