### PR TITLE
NPC zone updates

### DIFF
--- a/nocts_cata_mod_BN/Terrain/makeshift_command_center.json
+++ b/nocts_cata_mod_BN/Terrain/makeshift_command_center.json
@@ -240,6 +240,10 @@
         { "item": "broken_manhack", "x": 1, "y": 17 },
         { "item": "broken_manhack", "x": 5, "y": 17 }
       ],
+      "place_zones": [
+        { "type": "NPC_NO_INVESTIGATE", "faction": "commandeers", "x": [ 0, 23 ], "y": [ 0, 23 ] },
+        { "type": "NPC_NO_INVESTIGATE", "faction": "bio_weapons", "x": [ 0, 23 ], "y": [ 0, 23 ] }
+      ],
       "place_npcs": [
         { "class": "main_bio_sci", "x": 20, "y": 22 },
         { "class": "bio_weapon_1", "x": 22, "y": 10 },

--- a/nocts_cata_mod_BN/Terrain/sketchy_cabin.json
+++ b/nocts_cata_mod_BN/Terrain/sketchy_cabin.json
@@ -95,6 +95,10 @@
         { "group": "dojo_manuals", "x": 13, "y": [ 11, 14 ], "chance": 50, "repeat": 3 },
         { "group": "homebooks", "x": 21, "y": [ 15, 17 ], "chance": 50, "repeat": 4 },
         { "group": "dojo_manuals", "x": 21, "y": [ 15, 17 ], "chance": 50, "repeat": 2 }
+      ],
+      "place_zones": [
+        { "type": "NPC_NO_INVESTIGATE", "faction": "slave_fighter", "x": [ 0, 23 ], "y": [ 0, 23 ] },
+        { "type": "NPC_NO_INVESTIGATE", "faction": "slave_fighter_allied", "x": [ 0, 23 ], "y": [ 0, 23 ] }
       ]
     }
   },
@@ -149,6 +153,10 @@
       "place_loot": [
         { "group": "sketchy_cabin_guard_weapons", "x": 21, "y": 13, "chance": 90 },
         { "item": "money_bundle", "x": 21, "y": 13, "chance": 50, "repeat": 5 }
+      ],
+      "place_zones": [
+        { "type": "NPC_NO_INVESTIGATE", "faction": "slave_fighter", "x": [ 0, 23 ], "y": [ 0, 23 ] },
+        { "type": "NPC_NO_INVESTIGATE", "faction": "slave_fighter_allied", "x": [ 0, 23 ], "y": [ 0, 23 ] }
       ]
     }
   },
@@ -166,21 +174,21 @@
         "      |S...hS|||-=---=--",
         " ||||||S....S||u________",
         " |llll|||++||||_________",
-        " |.....+___||||__--=---=",
-        " |.rr..+___X__X__-B..-B.",
-        " |.rr..||__X__X__-B.~-B.",
-        " |.....l|__||||----.----",
+        " |.....+___||||__||=|||=",
+        " |.rr..+___X__X__|B..|B.",
+        " |.rr..||__X__X__|B.~|B.",
+        " |.....l|__|||||||-.-|--",
         " |llll.l|_____+_________",
         " ||||||||_____+_________",
-        " |.66.ll|__||||---------",
-        " |.ee...+__X__X__-B.T-B.",
-        " |......|__X__X__-B..-B.",
-        " |CCCCC||__||||__--=---=",
+        " |.66.ll|__|||||||---|--",
+        " |.ee...+__X__X__|B.T|B.",
+        " |......|__X__X__|B..|B.",
+        " |CCCCC||__||||__||=|||=",
         " |||||||_____]|_________",
         "  |C.on|_____]|u________",
-        "  |s...+__||||||-=---=--",
-        "  |F...+__+<<| |B..-B..-",
-        "  |F..t|__+<<| |B.T-B.T-",
+        "  |s...+__||||||-=-|-=-|",
+        "  |F...+__+<<| |B..|B..|",
+        "  |F..t|__+<<| |B.T|B.T|",
         "  |||||||||||| |||||||||",
         "                        "
       ],
@@ -261,7 +269,16 @@
         { "group": "trash", "x": 6, "y": 21, "repeat": [ 1, 3 ] },
         { "group": "dojo_manuals", "x": 13, "y": [ 17, 18 ], "chance": 50, "repeat": 4 }
       ],
-      "place_npcs": [ { "class": "slave_fight", "x": 16, "y": 3 }, { "class": "slave_fight", "x": 15, "y": 12 } ],
+      "place_zones": [
+        { "type": "NPC_NO_INVESTIGATE", "faction": "slave_fighter", "x": [ 0, 23 ], "y": [ 0, 23 ] },
+        { "type": "NPC_NO_INVESTIGATE", "faction": "slave_fighter_allied", "x": [ 0, 23 ], "y": [ 0, 23 ] }
+      ],
+      "place_npcs": [
+        { "class": "slave_fight_ally", "x": 16, "y": 14 },
+        { "class": "slave_fight_ally", "x": 21, "y": 17 },
+        { "class": "slave_fight", "x": 16, "y": 3 },
+        { "class": "slave_fight", "x": 15, "y": 12 }
+      ],
       "place_vehicles": [ { "vehicle": "autoclave_cart", "x": 9, "y": 2, "chance": 99, "fuel": 25, "status": 25, "rotation": 0 } ]
     }
   },
@@ -275,11 +292,11 @@
         "                        ",
         "||||             |||||| ",
         "B.T|             |T..s| ",
-        "B..|||||||||||   |t..s| ",
-        "-=-|______+__|   ||++|| ",
-        "___u______+__|   |V..V| ",
-        "______|||||++|||||....| ",
-        "-|____|urr____rruW....| ",
+        "B..|||||||||||||||t..s| ",
+        "-=-|______+__x___||++|| ",
+        "___u______+__|___x...V| ",
+        "______|||||++|||||...V| ",
+        "||____|urr____rruW....| ",
         ".|____|__________W.b.b| ",
         "T|----|__________W.b.b| ",
         "-|....W__________W.b.b| ",
@@ -288,10 +305,10 @@
         "-|..ddW__________W.b.b| ",
         "T|----|__________W.b.b| ",
         ".|____|__________W.b.b| ",
-        "-|____|urr____rruW....| ",
+        "||____|urr____rruW....| ",
         "______|||||++|||||....| ",
         "___u______+__|   |t...| ",
-        "-=-|______+__|   |||..| ",
+        "-=-|______+__|   |||XX| ",
         "B..|||||||||||     |<<| ",
         "B.T|               |<<| ",
         "||||               |||| ",
@@ -312,14 +329,16 @@
         "S": "t_floor",
         "T": "t_floor",
         "V": "t_floor",
-        "W": "t_thconc_glass_port",
+        "W": "t_reinforced_glass",
+        "X": "t_rdoor_boarded",
         "b": "t_floor",
         "d": "t_floor",
         "h": "t_floor",
         "r": "t_thconc_floor",
         "s": "t_floor",
         "t": "t_floor",
-        "u": "t_thconc_floor_olight"
+        "u": "t_thconc_floor_olight",
+        "x": "t_door_metal_pickable"
       },
       "furniture": {
         "B": "f_bed",
@@ -342,14 +361,16 @@
         { "item": "note_sketchy_cabin", "x": 4, "y": 13 },
         { "group": "sketchy_cabin_guard_weapons", "x": 5, "y": 13, "chance": 60 },
         { "group": "trash", "x": 18, "y": 18, "repeat": [ 1, 3 ] },
-        { "group": "vending_food_items", "x": 18, "y": 5, "chance": 50, "repeat": 10 },
-        { "group": "vending_drink_items", "x": 21, "y": 5, "chance": 50, "repeat": 10 }
+        { "group": "vending_food_items", "x": 21, "y": 5, "chance": 50, "repeat": 10 },
+        { "group": "vending_drink_items", "x": 21, "y": 6, "chance": 50, "repeat": 10 }
+      ],
+      "place_zones": [
+        { "type": "NPC_NO_INVESTIGATE", "faction": "slave_fighter", "x": [ 0, 23 ], "y": [ 0, 23 ] },
+        { "type": "NPC_NO_INVESTIGATE", "faction": "slave_fighter_allied", "x": [ 0, 23 ], "y": [ 0, 23 ] }
       ],
       "place_npcs": [
-        { "class": "slave_fight_ally", "x": 10, "y": 15 },
-        { "class": "slave_fight_ally", "x": 12, "y": 16 },
-        { "class": "slave_fight_ally", "x": 8, "y": 14 },
-        { "class": "slave_fight_ally", "x": 15, "y": 13 },
+        { "class": "slave_fight_ally", "x": 7, "y": 18 },
+        { "class": "slave_fight_ally", "x": 12, "y": 19 },
         { "class": "slave_fight", "x": 4, "y": 4 },
         { "class": "slave_fight", "x": 11, "y": 8 },
         { "class": "slave_fight", "x": 14, "y": 10 }
@@ -390,7 +411,11 @@
         "                        "
       ],
       "palettes": [ "roof_palette" ],
-      "terrain": { ".": "t_shingle_flat_roof" }
+      "terrain": { ".": "t_shingle_flat_roof" },
+      "place_zones": [
+        { "type": "NPC_NO_INVESTIGATE", "faction": "slave_fighter", "x": [ 0, 23 ], "y": [ 0, 23 ] },
+        { "type": "NPC_NO_INVESTIGATE", "faction": "slave_fighter_allied", "x": [ 0, 23 ], "y": [ 0, 23 ] }
+      ]
     }
   },
   {
@@ -428,7 +453,11 @@
       ],
       "palettes": [ "roof_palette" ],
       "terrain": { ",": "t_metal_flat_roof", "^": "t_metal_flat_roof", "N": "t_metal_flat_roof", "X": "t_metal_flat_roof" },
-      "furniture": { "C": "f_solar_unit" }
+      "furniture": { "C": "f_solar_unit" },
+      "place_zones": [
+        { "type": "NPC_NO_INVESTIGATE", "faction": "slave_fighter", "x": [ 0, 23 ], "y": [ 0, 23 ] },
+        { "type": "NPC_NO_INVESTIGATE", "faction": "slave_fighter_allied", "x": [ 0, 23 ], "y": [ 0, 23 ] }
+      ]
     }
   }
 ]

--- a/nocts_cata_mod_DDA/Terrain/makeshift_command_center.json
+++ b/nocts_cata_mod_DDA/Terrain/makeshift_command_center.json
@@ -240,6 +240,10 @@
         { "item": "broken_manhack", "x": 1, "y": 17 },
         { "item": "broken_manhack", "x": 5, "y": 17 }
       ],
+      "place_zones": [
+        { "type": "NPC_NO_INVESTIGATE", "faction": "commandeers", "x": [ 0, 23 ], "y": [ 0, 23 ] },
+        { "type": "NPC_NO_INVESTIGATE", "faction": "bio_weapons", "x": [ 0, 23 ], "y": [ 0, 23 ] }
+      ],
       "place_npcs": [
         { "class": "main_bio_sci", "x": 20, "y": 22 },
         { "class": "bio_weapon_1", "x": 22, "y": 10 },

--- a/nocts_cata_mod_DDA/Terrain/sketchy_cabin.json
+++ b/nocts_cata_mod_DDA/Terrain/sketchy_cabin.json
@@ -95,6 +95,10 @@
         { "group": "dojo_manuals", "x": 13, "y": [ 11, 14 ], "chance": 50, "repeat": 3 },
         { "group": "homebooks", "x": 21, "y": [ 15, 17 ], "chance": 50, "repeat": 4 },
         { "group": "dojo_manuals", "x": 21, "y": [ 15, 17 ], "chance": 50, "repeat": 2 }
+      ],
+      "place_zones": [
+        { "type": "NPC_NO_INVESTIGATE", "faction": "slave_fighter", "x": [ 0, 23 ], "y": [ 0, 23 ] },
+        { "type": "NPC_NO_INVESTIGATE", "faction": "slave_fighter_allied", "x": [ 0, 23 ], "y": [ 0, 23 ] }
       ]
     }
   },
@@ -149,6 +153,10 @@
       "place_loot": [
         { "group": "sketchy_cabin_guard_weapons", "x": 21, "y": 13, "chance": 90 },
         { "item": "money_bundle_twenty", "x": 21, "y": 13, "chance": 50, "repeat": 5 }
+      ],
+      "place_zones": [
+        { "type": "NPC_NO_INVESTIGATE", "faction": "slave_fighter", "x": [ 0, 23 ], "y": [ 0, 23 ] },
+        { "type": "NPC_NO_INVESTIGATE", "faction": "slave_fighter_allied", "x": [ 0, 23 ], "y": [ 0, 23 ] }
       ]
     }
   },
@@ -166,21 +174,21 @@
         "      |S...hS|||-=---=--",
         " ||||||S....S||u________",
         " |llll|||++||||_________",
-        " |.....+___||||__--=---=",
-        " |.rr..+___X__X__-B..-B.",
-        " |.rr..||__X__X__-B.~-B.",
-        " |.....l|__||||----.----",
+        " |.....+___||||__||=|||=",
+        " |.rr..+___X__X__|B..|B.",
+        " |.rr..||__X__X__|B.~|B.",
+        " |.....l|__|||||||-.-|--",
         " |llll.l|_____+_________",
         " ||||||||_____+_________",
-        " |.66.ll|__||||---------",
-        " |.ee...+__X__X__-B.T-B.",
-        " |......|__X__X__-B..-B.",
-        " |CCCCC||__||||__--=---=",
+        " |.66.ll|__|||||||---|--",
+        " |.ee...+__X__X__|B.T|B.",
+        " |......|__X__X__|B..|B.",
+        " |CCCCC||__||||__||=|||=",
         " |||||||_____]|_________",
         "  |C.on|_____]|u________",
-        "  |s...+__||||||-=---=--",
-        "  |F...+__+<<| |B..-B..-",
-        "  |F..t|__+<<| |B.T-B.T-",
+        "  |s...+__||||||-=-|-=-|",
+        "  |F...+__+<<| |B..|B..|",
+        "  |F..t|__+<<| |B.T|B.T|",
         "  |||||||||||| |||||||||",
         "                        "
       ],
@@ -262,7 +270,16 @@
         { "group": "trash", "x": 6, "y": 21, "repeat": [ 1, 3 ] },
         { "group": "dojo_manuals", "x": 13, "y": [ 17, 18 ], "chance": 50, "repeat": 4 }
       ],
-      "place_npcs": [ { "class": "slave_fight", "x": 16, "y": 3 }, { "class": "slave_fight", "x": 15, "y": 12 } ],
+      "place_zones": [
+        { "type": "NPC_NO_INVESTIGATE", "faction": "slave_fighter", "x": [ 0, 23 ], "y": [ 0, 23 ] },
+        { "type": "NPC_NO_INVESTIGATE", "faction": "slave_fighter_allied", "x": [ 0, 23 ], "y": [ 0, 23 ] }
+      ],
+      "place_npcs": [
+        { "class": "slave_fight_ally", "x": 16, "y": 14 },
+        { "class": "slave_fight_ally", "x": 21, "y": 17 },
+        { "class": "slave_fight", "x": 16, "y": 3 },
+        { "class": "slave_fight", "x": 15, "y": 12 }
+      ],
       "place_vehicles": [ { "vehicle": "autoclave_cart", "x": 9, "y": 2, "chance": 99, "fuel": 25, "status": 25, "rotation": 0 } ]
     }
   },
@@ -276,11 +293,11 @@
         "                        ",
         "||||             |||||| ",
         "B.T|             |T..s| ",
-        "B..|||||||||||   |t..s| ",
-        "-=-|______+__|   ||++|| ",
-        "___u______+__|   |V..V| ",
-        "______|||||++|||||....| ",
-        "-|____|urr____rruW....| ",
+        "B..|||||||||||||||t..s| ",
+        "-=-|______+__x___||++|| ",
+        "___u______+__|___x...V| ",
+        "______|||||++|||||...V| ",
+        "||____|urr____rruW....| ",
         ".|____|__________W.b.b| ",
         "T|----|__________W.b.b| ",
         "-|....W__________W.b.b| ",
@@ -289,10 +306,10 @@
         "-|..ddW__________W.b.b| ",
         "T|----|__________W.b.b| ",
         ".|____|__________W.b.b| ",
-        "-|____|urr____rruW....| ",
+        "||____|urr____rruW....| ",
         "______|||||++|||||....| ",
         "___u______+__|   |t...| ",
-        "-=-|______+__|   |||..| ",
+        "-=-|______+__|   |||XX| ",
         "B..|||||||||||     |<<| ",
         "B.T|               |<<| ",
         "||||               |||| ",
@@ -313,14 +330,16 @@
         "S": "t_floor",
         "T": "t_floor",
         "V": "t_floor",
-        "W": "t_thconc_glass_port",
+        "W": "t_reinforced_glass",
+        "X": "t_rdoor_boarded",
         "b": "t_floor",
         "d": "t_floor",
         "h": "t_floor",
         "r": "t_thconc_floor",
         "s": "t_floor",
         "t": "t_floor",
-        "u": "t_thconc_floor_olight"
+        "u": "t_thconc_floor_olight",
+        "x": "t_door_metal_pickable"
       },
       "furniture": {
         "6": "f_console_broken",
@@ -347,11 +366,13 @@
         { "group": "vending_food_items", "x": 18, "y": 5, "chance": 50, "repeat": 10 },
         { "group": "vending_drink_items", "x": 21, "y": 5, "chance": 50, "repeat": 10 }
       ],
+      "place_zones": [
+        { "type": "NPC_NO_INVESTIGATE", "faction": "slave_fighter", "x": [ 0, 23 ], "y": [ 0, 23 ] },
+        { "type": "NPC_NO_INVESTIGATE", "faction": "slave_fighter_allied", "x": [ 0, 23 ], "y": [ 0, 23 ] }
+      ],
       "place_npcs": [
-        { "class": "slave_fight_ally", "x": 10, "y": 15 },
-        { "class": "slave_fight_ally", "x": 12, "y": 16 },
-        { "class": "slave_fight_ally", "x": 8, "y": 14 },
-        { "class": "slave_fight_ally", "x": 15, "y": 13 },
+        { "class": "slave_fight_ally", "x": 7, "y": 18 },
+        { "class": "slave_fight_ally", "x": 12, "y": 19 },
         { "class": "slave_fight", "x": 4, "y": 4 },
         { "class": "slave_fight", "x": 11, "y": 8 },
         { "class": "slave_fight", "x": 14, "y": 10 }
@@ -392,7 +413,11 @@
         "                        "
       ],
       "palettes": [ "roof_palette" ],
-      "terrain": { ".": "t_shingle_flat_roof" }
+      "terrain": { ".": "t_shingle_flat_roof" },
+      "place_zones": [
+        { "type": "NPC_NO_INVESTIGATE", "faction": "slave_fighter", "x": [ 0, 23 ], "y": [ 0, 23 ] },
+        { "type": "NPC_NO_INVESTIGATE", "faction": "slave_fighter_allied", "x": [ 0, 23 ], "y": [ 0, 23 ] }
+      ]
     }
   },
   {
@@ -430,7 +455,11 @@
       ],
       "palettes": [ "roof_palette" ],
       "terrain": { ",": "t_metal_flat_roof", "^": "t_metal_flat_roof", "N": "t_metal_flat_roof", "X": "t_metal_flat_roof" },
-      "furniture": { "C": "f_solar_unit" }
+      "furniture": { "C": "f_solar_unit" },
+      "place_zones": [
+        { "type": "NPC_NO_INVESTIGATE", "faction": "slave_fighter", "x": [ 0, 23 ], "y": [ 0, 23 ] },
+        { "type": "NPC_NO_INVESTIGATE", "faction": "slave_fighter_allied", "x": [ 0, 23 ], "y": [ 0, 23 ] }
+      ]
     }
   }
 ]


### PR DESCRIPTION
Adjusted the layout and NPC placement of the sketchy cabin NPCs so that they won't immediately fight as soon as you enter the reality bubble. While it makes a neat setpiece for the scenario, when the player encounters the area normally it's pretty much guaranteed that they'll start enough ruckus to attract the others and without the PC Red Team will typically always beat the Blue Team NPCs.

The adjusted layout also includes a side connection to enter the secured area from the spectator's room that's locked up, and boarded-up doors preventing. This way if the player spawns in the spectator area they have a potential way to go either direction, but will have to get past Red Team to do so. This also means no more need to use the special buffed-up viewport terrain that was intended to get the player placement code to stop noping through glass out of the belief that a strong enough character could phase through it.

Lastly, added no-investigate zones to make things a bit more of a stable standoff down below, and added one to the makeshift command center's basement layer so the player won't disrupt the NPCs there constantly and get annoyed by them.