### PR TITLE
Add 'manual' category to skillbooks

### DIFF
--- a/nocts_cata_mod_DDA/Surv_help/c_books.json
+++ b/nocts_cata_mod_DDA/Surv_help/c_books.json
@@ -2,6 +2,7 @@
   {
     "id": "encyclopedia_mechanics",
     "type": "BOOK",
+    "category": "manuals",
     "looks_like": "textbook_chemistry",
     "name": { "str_sp": "Rebuilding Civilization: Mechanics" },
     "description": "The mechanics volume of the Rebuilding Civilization encyclopedia.  This book contains everything from simple machines to the inner workings of submarine engines in extremely fine detail.  This book is so technical, longwinded and dry that even bookworms and fast readers would find it hard to read.  Literally any other book on the subject would be a more efficient way to learn but if the books you have are missing specific information then this is a good substitute until you find something better.",
@@ -28,6 +29,7 @@
   {
     "id": "encyclopedia_fabrication",
     "type": "BOOK",
+    "category": "manuals",
     "looks_like": "textbook_chemistry",
     "name": { "str_sp": "Rebuilding Civilization: Fabrication" },
     "description": "The fabrication volume of the Rebuilding Civilization encyclopedia.  This book contains everything from creating how to create simple stone tools to the creation of the pyramids of Egypt in fine detail.  This book is so technical, longwinded and dry that even bookworms and fast readers would find it hard to read.  Literally any other book on the subject would be a more efficient way to learn but if the books you have are missing specific information then this is a good substitute until you find something better.",
@@ -60,6 +62,7 @@
   {
     "id": "encyclopedia_archery",
     "type": "BOOK",
+    "category": "manuals",
     "looks_like": "textbook_chemistry",
     "name": { "str_sp": "Rebuilding Civilization: Archery" },
     "description": "The archery volume of the Rebuilding Civilization encyclopedia.  This book contains everything from correct positioning to the usage of advanced bows in fine detail.  This book is so technical, longwinded and dry that even bookworms and fast readers would find it hard to read.  Literally any other book on the subject would be a more efficient way to learn but if the books you have are missing specific information then this is a good substitute until you find something better.",
@@ -81,6 +84,7 @@
   {
     "id": "encyclopedia_bashing",
     "type": "BOOK",
+    "category": "manuals",
     "looks_like": "textbook_chemistry",
     "name": { "str_sp": "Rebuilding Civilization: Bashing Weapons" },
     "description": "The bashing weapons volume of the Rebuilding Civilization encyclopedia.  This book contains everything from self defense with a pipe to the proper swinging technique for a sledge hammer in fine detail.  This book is so technical, longwinded and dry that even bookworms and fast readers would find it hard to read.  Literally any other book on the subject would be a more efficient way to learn but if the books you have are missing specific information then this is a good substitute until you find something better.",
@@ -102,6 +106,7 @@
   {
     "id": "encyclopedia_chemistry",
     "type": "BOOK",
+    "category": "manuals",
     "looks_like": "textbook_chemistry",
     "name": { "str_sp": "Rebuilding Civilization: Applied Science" },
     "description": "The applied science volume of the Rebuilding Civilization encyclopedia.  This book contains everything from cooking small game to acid-base reactions to polymer synthesis in fine detail.  This book is so technical, longwinded and dry that even bookworms and fast readers would find it hard to read.  Literally any other book on the subject would be a more efficient way to learn but if the books you have are missing specific information then this is a good substitute until you find something better.",
@@ -133,6 +138,7 @@
   {
     "id": "encyclopedia_computer",
     "type": "BOOK",
+    "category": "manuals",
     "looks_like": "textbook_chemistry",
     "name": { "str_sp": "Rebuilding Civilization: Computers" },
     "description": "The computer volume of the Rebuilding Civilization encyclopedia.  This book contains everything from basic programming to cyber security algorithms in fine detail.  This book is so technical, longwinded and dry that even bookworms and fast readers would find it hard to read.  Literally any other book on the subject would be a more efficient way to learn but if the books you have are missing specific information then this is a good substitute until you find something better.",
@@ -154,6 +160,7 @@
   {
     "id": "encyclopedia_cooking",
     "type": "BOOK",
+    "category": "manuals",
     "looks_like": "textbook_chemistry",
     "name": { "str_sp": "Rebuilding Civilization: Food Handling" },
     "description": "The food handling volume of the Rebuilding Civilization encyclopedia.  This book contains everything from cooking small game to gourmet meal preparation in fine detail.  This book is so technical, longwinded and dry that even bookworms and fast readers would find it hard to read.  Literally any other book on the subject would be a more efficient way to learn but if the books you have are missing specific information then this is a good substitute until you find something better.",
@@ -186,6 +193,7 @@
   {
     "id": "encyclopedia_cutting",
     "type": "BOOK",
+    "category": "manuals",
     "looks_like": "textbook_chemistry",
     "name": { "str_sp": "Rebuilding Civilization: Cutting Weapons" },
     "description": "The cutting weapons volume of the Rebuilding Civilization encyclopedia.  This book contains everything from using a glass shiv to medieval swordsmanship in fine detail.  This book is so technical, longwinded and dry that even bookworms and fast readers would find it hard to read.  Literally any other book on the subject would be a more efficient way to learn but if the books you have are missing specific information then this is a good substitute until you find something better.",
@@ -207,6 +215,7 @@
   {
     "id": "encyclopedia_dodge",
     "type": "BOOK",
+    "category": "manuals",
     "looks_like": "textbook_chemistry",
     "name": { "str_sp": "Rebuilding Civilization: Dodging" },
     "description": "The dodging volume of the Rebuilding Civilization encyclopedia.  This book contains everything from dancing for beginners to parkour in fine detail.  This book is so technical, longwinded and dry that even bookworms and fast readers would find it hard to read.  Literally any other book on the subject would be a more efficient way to learn but if the books you have are missing specific information then this is a good substitute until you find something better.",
@@ -228,6 +237,7 @@
   {
     "id": "encyclopedia_driving",
     "type": "BOOK",
+    "category": "manuals",
     "looks_like": "textbook_chemistry",
     "name": { "str_sp": "Rebuilding Civilization: Vehicles" },
     "description": "The vehicles volume of the Rebuilding Civilization encyclopedia.  This book contains everything from acquiring a driving license to professional racing in fine detail.  This book is so technical, longwinded and dry that even bookworms and fast readers would find it hard to read.  Literally any other book on the subject would be a more efficient way to learn but if the books you have are missing specific information then this is a good substitute until you find something better.",
@@ -249,6 +259,7 @@
   {
     "id": "encyclopedia_electronics",
     "type": "BOOK",
+    "category": "manuals",
     "looks_like": "textbook_chemistry",
     "name": { "str_sp": "Rebuilding Civilization: Electronics" },
     "description": "The electronics volume of the Rebuilding Civilization encyclopedia.  This book contains everything from simple circuits to military robotics in fine detail.  This book is so technical, longwinded and dry that even bookworms and fast readers would find it hard to read.  Literally any other book on the subject would be a more efficient way to learn but if the books you have are missing specific information then this is a good substitute until you find something better.",
@@ -275,6 +286,7 @@
   {
     "id": "encyclopedia_firstaid",
     "type": "BOOK",
+    "category": "manuals",
     "looks_like": "textbook_chemistry",
     "name": { "str_sp": "Rebuilding Civilization: Health Care" },
     "description": "The health care volume of the Rebuilding Civilization encyclopedia.  This book contains everything from proper bandage application to exploratory surgery in fine detail.  This book is so technical, longwinded and dry that even bookworms and fast readers would find it hard to read.  Literally any other book on the subject would be a more efficient way to learn but if the books you have are missing specific information then this is a good substitute until you find something better.",
@@ -300,6 +312,7 @@
   {
     "id": "encyclopedia_gun",
     "type": "BOOK",
+    "category": "manuals",
     "looks_like": "textbook_chemistry",
     "name": { "str_sp": "Rebuilding Civilization: Marksmanship" },
     "description": "The marksmanship volume of the Rebuilding Civilization encyclopedia.  This book contains everything from proper iron sight aiming to military sniper techniques in fine detail.  This book is so technical, longwinded and dry that even bookworms and fast readers would find it hard to read.  Literally any other book on the subject would be a more efficient way to learn but if the books you have are missing specific information then this is a good substitute until you find something better.",
@@ -321,6 +334,7 @@
   {
     "id": "encyclopedia_launcher",
     "type": "BOOK",
+    "category": "manuals",
     "looks_like": "textbook_chemistry",
     "name": { "str_sp": "Rebuilding Civilization: Launchers" },
     "description": "The launchers volume of the Rebuilding Civilization encyclopedia.  This book contains everything from the use of spraycan flamethrowers to recoiless rifles in fine detail.  This book is so technical, longwinded and dry that even bookworms and fast readers would find it hard to read.  Literally any other book on the subject would be a more efficient way to learn but if the books you have are missing specific information then this is a good substitute until you find something better.",
@@ -342,6 +356,7 @@
   {
     "id": "encyclopedia_melee",
     "type": "BOOK",
+    "category": "manuals",
     "looks_like": "textbook_chemistry",
     "name": { "str_sp": "Rebuilding Civilization: Melee Combat" },
     "description": "The melee combat volume of the Rebuilding Civilization encyclopedia.  This book contains everything from using a branch to martial arts techniques in fine detail.  This book is so technical, longwinded and dry that even bookworms and fast readers would find it hard to read.  Literally any other book on the subject would be a more efficient way to learn but if the books you have are missing specific information then this is a good substitute until you find something better.",
@@ -363,6 +378,7 @@
   {
     "id": "encyclopedia_pistol",
     "type": "BOOK",
+    "category": "manuals",
     "looks_like": "textbook_chemistry",
     "name": { "str": "Rebuilding Civilization: Pistols", "str_pl": "Rebuilding Civilization: Pistols" },
     "description": "The pistols volume of the Rebuilding Civilization encyclopedia.  This book contains everything from using zip pistols to laser pistols in fine detail.  This book is so technical, longwinded and dry that even bookworms and fast readers would find it hard to read.  Literally any other book on the subject would be a more efficient way to learn but if the books you have are missing specific information then this is a good substitute until you find something better.",
@@ -384,6 +400,7 @@
   {
     "id": "encyclopedia_rifle",
     "type": "BOOK",
+    "category": "manuals",
     "looks_like": "textbook_chemistry",
     "name": { "str_sp": "Rebuilding Civilization: Rifles" },
     "description": "The rifles volume of the Rebuilding Civilization encyclopedia.  This book contains everything from using zip rifles to laser rifles in fine detail.  This book is so technical, longwinded and dry that even bookworms and fast readers would find it hard to read.  Literally any other book on the subject would be a more efficient way to learn but if the books you have are missing specific information then this is a good substitute until you find something better.",
@@ -405,6 +422,7 @@
   {
     "id": "encyclopedia_shotgun",
     "type": "BOOK",
+    "category": "manuals",
     "looks_like": "textbook_chemistry",
     "name": { "str_sp": "Rebuilding Civilization: Shotguns" },
     "description": "The shotguns volume of the Rebuilding Civilization encyclopedia.  This book contains everything from using zip shotguns to laser scatter guns in fine detail.  This book is so technical, longwinded and dry that even bookworms and fast readers would find it hard to read.  Literally any other book on the subject would be a more efficient way to learn but if the books you have are missing specific information then this is a good substitute until you find something better.",
@@ -426,6 +444,7 @@
   {
     "id": "encyclopedia_smg",
     "type": "BOOK",
+    "category": "manuals",
     "looks_like": "textbook_chemistry",
     "name": { "str_sp": "Rebuilding Civilization: Sub Machineguns" },
     "description": "The sub machineguns volume of the Rebuilding Civilization encyclopedia.  This book contains everything from using makeshift smgs to automatic laser carbines in fine detail.  This book is so technical, longwinded and dry that even bookworms and fast readers would find it hard to read.  Literally any other book on the subject would be a more efficient way to learn but if the books you have are missing specific information then this is a good substitute until you find something better.",
@@ -447,6 +466,7 @@
   {
     "id": "encyclopedia_speech",
     "type": "BOOK",
+    "category": "manuals",
     "looks_like": "textbook_chemistry",
     "name": { "str_sp": "Rebuilding Civilization: Social" },
     "description": "The social volume of the Rebuilding Civilization encyclopedia.  This book contains everything from recruiting survivors to running for political office in fine detail.  This book is so technical, longwinded and dry that even bookworms and fast readers would find it hard to read.  Literally any other book on the subject would be a more efficient way to learn but if the books you have are missing specific information then this is a good substitute until you find something better.",
@@ -468,6 +488,7 @@
   {
     "id": "encyclopedia_stabbing",
     "type": "BOOK",
+    "category": "manuals",
     "looks_like": "textbook_chemistry",
     "name": { "str_sp": "Rebuilding Civilization: Piercing Weapons" },
     "description": "The piercing weapons volume of the Rebuilding Civilization encyclopedia.  This book contains everything from using switchblades to spear combat in fine detail.  This book is so technical, longwinded and dry that even bookworms and fast readers would find it hard to read.  Literally any other book on the subject would be a more efficient way to learn but if the books you have are missing specific information then this is a good substitute until you find something better.",
@@ -489,6 +510,7 @@
   {
     "id": "encyclopedia_survival",
     "type": "BOOK",
+    "category": "manuals",
     "looks_like": "textbook_chemistry",
     "name": { "str_sp": "Rebuilding Civilization: Survival" },
     "description": "The survival volume of the Rebuilding Civilization encyclopedia.  This book contains everything from camping to survival on a deserted island in fine detail.  This book is so technical, longwinded and dry that even bookworms and fast readers would find it hard to read.  Literally any other book on the subject would be a more efficient way to learn but if the books you have are missing specific information then this is a good substitute until you find something better.",
@@ -518,6 +540,7 @@
   {
     "id": "encyclopedia_swimming",
     "type": "BOOK",
+    "category": "manuals",
     "looks_like": "textbook_chemistry",
     "name": { "str_sp": "Rebuilding Civilization: Athletics" },
     "description": "The athletics volume of the Rebuilding Civilization encyclopedia.  This book contains everything from recreational swimming to crossing rivers in fine detail.  This book is so technical, longwinded and dry that even bookworms and fast readers would find it hard to read.  Literally any other book on the subject would be a more efficient way to learn but if the books you have are missing specific information then this is a good substitute until you find something better.",
@@ -539,6 +562,7 @@
   {
     "id": "encyclopedia_tailor",
     "type": "BOOK",
+    "category": "manuals",
     "looks_like": "textbook_chemistry",
     "name": { "str_sp": "Rebuilding Civilization: Tailoring" },
     "description": "The tailoring volume of the Rebuilding Civilization encyclopedia.  This book contains everything from fixing clothing tears to fashion designing in fine detail.  This book is so technical, longwinded and dry that even bookworms and fast readers would find it hard to read.  Literally any other book on the subject would be a more efficient way to learn but if the books you have are missing specific information then this is a good substitute until you find something better.",
@@ -567,6 +591,7 @@
   {
     "id": "encyclopedia_throw",
     "type": "BOOK",
+    "category": "manuals",
     "looks_like": "textbook_chemistry",
     "name": { "str_sp": "Rebuilding Civilization: Throwing" },
     "description": "The throwing volume of the Rebuilding Civilization encyclopedia.  This book contains everything from throwing stones to spear hunting in fine detail.  This book is so technical, longwinded and dry that even bookworms and fast readers would find it hard to read.  Literally any other book on the subject would be a more efficient way to learn but if the books you have are missing specific information then this is a good substitute until you find something better.",
@@ -588,6 +613,7 @@
   {
     "id": "encyclopedia_traps",
     "type": "BOOK",
+    "category": "manuals",
     "looks_like": "textbook_chemistry",
     "name": { "str_sp": "Rebuilding Civilization: Devices" },
     "description": "The traps volume of the Rebuilding Civilization encyclopedia.  This book contains everything from lockpicking to disarming landmines in fine detail.  This book is so technical, longwinded and dry that even bookworms and fast readers would find it hard to read.  Literally any other book on the subject would be a more efficient way to learn but if the books you have are missing specific information then this is a good substitute until you find something better.",
@@ -616,6 +642,7 @@
   {
     "id": "encyclopedia_unarmed",
     "type": "BOOK",
+    "category": "manuals",
     "looks_like": "textbook_chemistry",
     "name": { "str_sp": "Rebuilding Civilization: Unarmed Combat" },
     "description": "The unarmed volume of the Rebuilding Civilization encyclopedia.  This book contains everything from self defense techniques to MMA fighting in fine detail.  This book is so technical, longwinded and dry that even bookworms and fast readers would find it hard to read.  Literally any other book on the subject would be a more efficient way to learn but if the books you have are missing specific information then this is a good substitute until you find something better.",
@@ -637,6 +664,7 @@
   {
     "id": "evil_invitation",
     "type": "BOOK",
+    "category": "manuals",
     "name": { "str": "introduction packet - classified", "str_pl": "introduction packets - classified" },
     "description": "This is a journal with what seems to be an invitation of some sort from some unknown organization.  While its contents are rather boring to read, some bits offer promises of 'forbidden knowledge' and that said contents are 'just a taste of true power'…  Science has definitely gone too far…",
     "weight": "1700 g",
@@ -656,6 +684,7 @@
   {
     "id": "omnitech_weapon_ups_manual",
     "type": "BOOK",
+    "category": "manuals",
     "name": { "str": "Omnitech UPS conversion manual" },
     "description": "This is a booklet dealing the instructions on how to convert an Omnitech laser weapon from using atomic batteries to use UPS power.  If you can find one of the kits mentioned, you could replicate the steps on this booklet.",
     "weight": "1700 g",


### PR DESCRIPTION
CDDA added the 'manual' category to skillbooks in https://github.com/CleverRaven/Cataclysm-DDA/pull/53852#issue-1090194548 . Adding this category to skillbooks in cataclysm++ so there isn't a mismatch