### PR TITLE
Add some relevant vanilla professions to scenario

### DIFF
--- a/nocts_cata_mod_BN/Char_creation/c_scenarios.json
+++ b/nocts_cata_mod_BN/Char_creation/c_scenarios.json
@@ -124,7 +124,7 @@
       "Bio_Weapon_Lab",
       "haz_sar_1_2"
     ],
-    "professions": [ "bio_infantry", "bio_scout", "bio_knight", "bio_tool" ],
+    "professions": [ "power_armor_soldier", "bio_soldier", "bio_sniper", "bio_infantry", "bio_scout", "bio_knight", "bio_tool" ],
     "traits": [ "MARTIAL_ARTS_BIOJUTSU" ]
   },
   {

--- a/nocts_cata_mod_BN/Char_creation/c_scenarios.json
+++ b/nocts_cata_mod_BN/Char_creation/c_scenarios.json
@@ -124,7 +124,16 @@
       "Bio_Weapon_Lab",
       "haz_sar_1_2"
     ],
-    "professions": [ "power_armor_soldier", "bio_soldier", "bio_sniper", "bio_infantry", "bio_scout", "bio_knight", "bio_tool" ],
+    "professions": [
+      "power_armor_soldier",
+      "bionic_spy",
+      "bio_soldier",
+      "bio_sniper",
+      "bio_infantry",
+      "bio_scout",
+      "bio_knight",
+      "bio_tool"
+    ],
     "traits": [ "MARTIAL_ARTS_BIOJUTSU" ]
   },
   {


### PR DESCRIPTION
Adds a couple of vanilla military professions to Experimental Soldier scenario, mainly bionic soldiers. Only in BN version because none of the vanilla professions in DDA really matched the theme, no bionics or experimental tech.

Set aside as WIP since one of the professions included is the power armor soldier to be added when https://github.com/cataclysmbnteam/Cataclysm-BN/pull/3771 is merged.