### PR TITLE
Pending BN update: new bionic itemgroup

### DIFF
--- a/nocts_cata_mod_BN/Surv_help/c_item_groups.json
+++ b/nocts_cata_mod_BN/Surv_help/c_item_groups.json
@@ -509,6 +509,11 @@
     ]
   },
   {
+    "id": "bionics_heavy_mil",
+    "type": "item_group",
+    "items": [ [ "bio_plasma_cell", 10 ], [ "bio_atomic_battery", 5 ], [ "bio_hazard_shield", 5 ], [ "bio_cutting_torch", 10 ] ]
+  },
+  {
     "id": "bionic_power_storage_mil",
     "type": "item_group",
     "items": [ [ "bio_power_storage_sentinel", 10 ] ]


### PR DESCRIPTION
Set aside for when https://github.com/cataclysmbnteam/Cataclysm-BN/pull/3769 is merged, which adds a new bionic itemgroup for military stuff that Cata++ could logically add to.