### PR TITLE
Pending BN Update: bionics_survivalist itemgroup

### DIFF
--- a/nocts_cata_mod_BN/Surv_help/c_item_groups.json
+++ b/nocts_cata_mod_BN/Surv_help/c_item_groups.json
@@ -543,6 +543,11 @@
     "items": [ [ "bio_atomic_battery", 5 ], [ "bio_plasma_cell", 5 ], [ "bio_hazard_shield", 5 ], [ "bio_cutting_torch", 10 ] ]
   },
   {
+    "id": "bionics_survivalist",
+    "type": "item_group",
+    "items": [ [ "bio_atomic_battery", 5 ], [ "bio_hazard_shield", 5 ], [ "bio_animal_empathy", 5 ], [ "bio_cutting_torch", 10 ] ]
+  },
+  {
     "id": "female_underwear_top",
     "type": "item_group",
     "items": [ [ "fancy_bra", 10 ] ]


### PR DESCRIPTION
Set aside for when https://github.com/cataclysmbnteam/Cataclysm-BN/pull/3781 is merged. Adds the atomic battery, hazard shield, biopattern distortion, and cutting torch CBMs to the new `bionics_survivalist` item group.