### PR TITLE
Pending BN feature: more use of COMPACT flag

### DIFF
--- a/nocts_cata_mod_BN/Surv_help/c_armor.json
+++ b/nocts_cata_mod_BN/Surv_help/c_armor.json
@@ -757,7 +757,7 @@
     "color": "green",
     "name": { "str": "set of salvaged exo-wings", "str_pl": "sets of salvaged exo-wings" },
     "description": "A harness from which jut thin, green iridescent wings, steel wires and joints meshed with thick alien nervous cords.  Salvaged using pre-cataclysm research into other living weaponry, it's been heavily altered to fit a human (or mutant) wearer.  Activating it will grant immunity to falling damage and vastly speed up movement.  It seems to recharge from sunlight, and being active will also gradually fatigue the user.",
-    "flags": [ "OVERSIZE", "STURDY", "WAIST", "ONLY_ONE" ],
+    "flags": [ "OVERSIZE", "STURDY", "WAIST", "COMPACT", "ONLY_ONE" ],
     "price_postapoc": "40 USD",
     "material": [ "alien_resin", "flesh", "steel" ],
     "weight": "2 kg",
@@ -898,7 +898,7 @@
       "skills": [ "pistol", "smg", "shotgun", "rifle" ],
       "flags": [ "SHEATH_KNIFE", "BELT_CLIP", "SHEATH_SWORD", "MAG_COMPACT", "MAG_BULKY", "SPEEDLOADER" ]
     },
-    "flags": [ "WATER_FRIENDLY", "BELTED", "OVERSIZE", "NO_QUICKDRAW" ]
+    "flags": [ "WATER_FRIENDLY", "BELTED", "COMPACT", "OVERSIZE", "NO_QUICKDRAW" ]
   },
   {
     "type": "mutation",

--- a/nocts_cata_mod_BN/Surv_help/c_tools.json
+++ b/nocts_cata_mod_BN/Surv_help/c_tools.json
@@ -675,7 +675,7 @@
     "max_charges": 250,
     "use_action": { "type": "cast_spell", "spell_id": "c_topographical_scan", "no_fail": true, "level": 0 },
     "relic_data": { "recharge_scheme": [ { "type": "solar", "interval": "10 m", "rate": 1 } ] },
-    "flags": [ "BELTED", "WATCH", "ALARMCLOCK", "RECHARGE", "NO_RELOAD", "NO_UNLOAD" ],
+    "flags": [ "BELTED", "COMPACT", "WATCH", "ALARMCLOCK", "RECHARGE", "NO_RELOAD", "NO_UNLOAD" ],
     "covers": [ "hand_either" ],
     "encumbrance": 5,
     "coverage": 10,
@@ -866,7 +866,7 @@
     "encumbrance": 1,
     "coverage": 5,
     "use_action": [ "WEATHER_TOOL", "DISASSEMBLE", { "type": "firestarter", "moves": 1000, "moves_slow": 25000, "need_sunlight": true } ],
-    "flags": [ "WATCH", "ALARMCLOCK", "BELTED", "FRAGILE", "ALLOWS_NATURAL_ATTACKS", "FIRESTARTER", "THERMOMETER" ]
+    "flags": [ "WATCH", "ALARMCLOCK", "BELTED", "COMPACT", "FRAGILE", "ALLOWS_NATURAL_ATTACKS", "FIRESTARTER", "THERMOMETER" ]
   },
   {
     "id": "parabracelets",
@@ -884,7 +884,7 @@
     "covers": [ "hand_either" ],
     "encumbrance": 1,
     "coverage": 5,
-    "flags": [ "BELTED", "FRAGILE", "ALLOWS_NATURAL_ATTACKS" ],
+    "flags": [ "BELTED", "COMPACT", "FRAGILE", "ALLOWS_NATURAL_ATTACKS" ],
     "use_action": "DISASSEMBLE"
   },
   {
@@ -939,7 +939,7 @@
     "price_postapoc": "60 USD",
     "material": [ "plastic", "aluminum" ],
     "covers": [ "torso" ],
-    "flags": [ "LEAK_DAM", "RADIOACTIVE", "WAIST", "OVERSIZE", "NO_RELOAD", "NO_UNLOAD" ],
+    "flags": [ "LEAK_DAM", "RADIOACTIVE", "WAIST", "COMPACT", "OVERSIZE", "NO_RELOAD", "NO_UNLOAD" ],
     "weight": "2200 g",
     "volume": "3 L",
     "bashing": 4,


### PR DESCRIPTION
Set aside as a draft for if https://github.com/cataclysmbnteam/Cataclysm-BN/pull/3792 is merged. Adds the `COMPACT` flag to the scout's tool, paracord watch, paracord bracelet, inductive CBM charger, salved exo-wings, survivor leg rig