### PR TITLE
Pending BN update: battery rebalancing

### DIFF
--- a/nocts_cata_mod_BN/Recipe/c_recipes.json
+++ b/nocts_cata_mod_BN/Recipe/c_recipes.json
@@ -955,7 +955,6 @@
     "tools": [ [ [ "welder", 10 ], [ "welder_crude", 10 ], [ "soldering_iron", 10 ], [ "toolset", 10 ] ] ],
     "components": [
       [
-        [ "medium_plus_battery_cell", 1 ],
         [ "light_plus_battery_cell", 4 ],
         [ "light_battery_cell", 6 ],
         [ "light_minus_battery_cell", 12 ]

--- a/nocts_cata_mod_BN/Weapons/c_magazines.json
+++ b/nocts_cata_mod_BN/Weapons/c_magazines.json
@@ -238,7 +238,7 @@
     "category": "spare_parts",
     "name": { "str": "crank rifle capacitor bank" },
     "description": "This is a homemade power cell made from household batteries along with a series of capacitors, designed to translate mechanical force into enough voltage to more efficiently power a survivor's crank rifle.  It's a wonder this thing isn't an electrocution hazard.",
-    "weight": "500 g",
+    "weight": "900 g",
     "volume": "600 ml",
     "price": "50 USD",
     "price_postapoc": "3 USD",


### PR DESCRIPTION
Set aside for when https://github.com/cataclysmbnteam/Cataclysm-BN/pull/3836 is merged, turns out only thing really affected by this was the balance of the UPS crank rifle's magazine. Since it's implied to be 600 kJ's worth of storage (but holds less technically for game balance reasons since hand crank charging is slow as fuck), item accordingly tweaked to match new expected weight and volume while recipe no longer uses a 750-kJ option.