### PR TITLE
Add professions to CVN Sailor scenario

### DIFF
--- a/nocts_cata_mod_BN/Char_creation/c_scenarios.json
+++ b/nocts_cata_mod_BN/Char_creation/c_scenarios.json
@@ -240,6 +240,12 @@
     "extend": { "professions": [ "bio_infantry", "bio_scout", "bio_knight", "bio_tool" ] }
   },
   {
+    "copy-from": "aircraft_carrier_start",
+    "type": "scenario",
+    "id": "aircraft_carrier_start",
+    "extend": { "professions": [ "bio_infantry", "bio_scout", "bio_knight", "bio_tool" ] }
+  },
+  {
     "copy-from": "surrounded",
     "type": "scenario",
     "add_professions": true,

--- a/nocts_cata_mod_DDA/Char_creation/c_scenarios.json
+++ b/nocts_cata_mod_DDA/Char_creation/c_scenarios.json
@@ -230,6 +230,12 @@
     "extend": { "professions": [ "bio_infantry", "bio_scout", "bio_knight", "bio_tool" ] }
   },
   {
+    "copy-from": "aircraft_carrier_start",
+    "type": "scenario",
+    "id": "aircraft_carrier_start",
+    "extend": { "professions": [ "bio_infantry", "bio_scout", "bio_knight", "bio_tool" ] }
+  },
+  {
     "copy-from": "surrounded",
     "type": "scenario",
     "add_professions": true,


### PR DESCRIPTION
Adds the super soldier professions to the aircraft carrier scenario in BN version, now that it's been ported from DDA, and add to DDA version too while I'm at it.