### PR TITLE
Pending BN update: superalloy versions of craftable steel armor

### DIFF
--- a/nocts_cata_mod_BN/Recipe/c_recipes.json
+++ b/nocts_cata_mod_BN/Recipe/c_recipes.json
@@ -532,7 +532,7 @@
     "skills_required": [ "fabrication", 8 ],
     "time": "500 m",
     "book_learn": [ [ "recipe_surv", 8 ] ],
-    "using": [ [ "sewing_standard", 100 ], [ "steel_tiny", 8 ] ],
+    "using": [ [ "sewing_standard", 100 ], [ "steel_standard", 2 ] ],
     "qualities": [ { "id": "HAMMER", "level": 2 }, { "id": "SAW_M", "level": 1 } ],
     "tools": [ [ [ "welder", 50 ], [ "welder_crude", 100 ], [ "soldering_iron", 100 ], [ "toolset", 100 ] ] ],
     "components": [
@@ -540,6 +540,35 @@
       [ [ "gloves_hsurvivor", 1 ] ],
       [ [ "boots_hsurvivor", 1 ] ],
       [ [ "hood_survivor", 1 ] ],
+      [ [ "hazmat_suit", 1 ], [ "cleansuit", 1 ] ],
+      [ [ "fur", 15 ] ],
+      [ [ "duct_tape", 150 ] ],
+      [ [ "kevlar_plate", 12 ] ],
+      [ [ "cable", 50 ] ],
+      [ [ "wristwatch", 1 ] ]
+    ]
+  },
+  {
+    "result": "surv_armor_suit_superalloy",
+    "//": "Superalloy armor recipes use alloy sheets equal to steel lumps used, difficulty 2 levels higher (maxing out at 10)",
+    "type": "recipe",
+    "category": "CC_ARMOR",
+    "subcategory": "CSC_ARMOR_SUIT",
+    "skill_used": "tailor",
+    "difficulty": 9,
+    "skills_required": [ "fabrication", 10 ],
+    "time": "500 m",
+    "//2": "Fabrication capped at 10, booklearn still elevated as if it could go past 10",
+    "book_learn": [ [ "recipe_surv", 10 ] ],
+    "using": [ [ "sewing_standard", 100 ] ],
+    "qualities": [ { "id": "HAMMER", "level": 2 }, { "id": "SAW_M", "level": 1 } ],
+    "tools": [ [ [ "welder", 50 ], [ "welder_crude", 100 ], [ "soldering_iron", 100 ], [ "toolset", 100 ] ] ],
+    "components": [
+      [ [ "sasurvivor_suit", 1 ] ],
+      [ [ "gloves_sasurvivor", 1 ] ],
+      [ [ "boots_sasurvivor", 1 ] ],
+      [ [ "hood_survivor", 1 ] ],
+      [ [ "alloy_sheet", 2 ] ],
       [ [ "hazmat_suit", 1 ], [ "cleansuit", 1 ] ],
       [ [ "fur", 15 ] ],
       [ [ "duct_tape", 150 ] ],
@@ -1789,6 +1818,48 @@
     "components": [ [ [ "cuirass_lightplate_surv", 1 ] ], [ [ "armguard_lightplate_surv", 1 ] ], [ [ "legguard_lightplate_surv", 1 ] ] ]
   },
   {
+    "result": "armor_lightplate_surv_superalloy",
+    "type": "recipe",
+    "category": "CC_ARMOR",
+    "subcategory": "CSC_ARMOR_SUIT",
+    "skill_used": "fabrication",
+    "difficulty": 7,
+    "skills_required": [ "tailor", 4 ],
+    "time": "4 h",
+    "autolearn": [ [ "fabrication", 8 ], [ "tailor", 5 ] ],
+    "book_learn": [ [ "textbook_armwest", 7 ], [ "recipe_surv", 6 ] ],
+    "using": [ [ "sewing_standard", 150 ], [ "welding_standard", 7 ] ],
+    "components": [
+      [ [ "armor_lightplate_superalloy", 1 ] ],
+      [ [ "rag", 10 ] ],
+      [ [ "leather", 10 ], [ "tanned_hide", 2 ] ],
+      [ [ "coat_rain", 1 ], [ "jacket_windbreaker", 1 ], [ "jacket_evac", 1 ], [ "coat_gut", 1 ] ],
+      [ [ "duct_tape", 300 ] ],
+      [ [ "kevlar", 1 ], [ "swat_armor", 1 ], [ "kevlar_plate", 24 ] ]
+    ]
+  },
+  {
+    "result": "armor_lightplate_surv_superalloy",
+    "type": "recipe",
+    "id_suffix": "assembly",
+    "category": "CC_ARMOR",
+    "subcategory": "CSC_ARMOR_SUIT",
+    "skill_used": "fabrication",
+    "//": "No fabrication increase since we're just putting already-made pieces together",
+    "difficulty": 3,
+    "skills_required": [ "tailor", 3 ],
+    "time": "20 m",
+    "autolearn": [ [ "fabrication", 6 ], [ "tailor", 4 ] ],
+    "reversible": true,
+    "flags": [ "NO_RESIZE" ],
+    "using": [ [ "sewing_standard", 30 ] ],
+    "components": [
+      [ [ "cuirass_lightplate_surv_superalloy", 1 ] ],
+      [ [ "armguard_lightplate_surv_superalloy", 1 ] ],
+      [ [ "legguard_lightplate_surv_superalloy", 1 ] ]
+    ]
+  },
+  {
     "result": "cuirass_lightplate_surv",
     "type": "recipe",
     "category": "CC_ARMOR",
@@ -1802,6 +1873,27 @@
     "using": [ [ "sewing_standard", 50 ], [ "welding_standard", 3 ] ],
     "components": [
       [ [ "cuirass_lightplate", 1 ] ],
+      [ [ "rag", 5 ] ],
+      [ [ "leather", 5 ], [ "tanned_hide", 1 ] ],
+      [ [ "coat_rain", 1 ], [ "jacket_windbreaker", 1 ], [ "jacket_evac", 1 ], [ "coat_gut", 1 ] ],
+      [ [ "duct_tape", 125 ] ],
+      [ [ "kevlar_plate", 10 ] ]
+    ]
+  },
+  {
+    "result": "cuirass_lightplate_surv_superalloy",
+    "type": "recipe",
+    "category": "CC_ARMOR",
+    "subcategory": "CSC_ARMOR_TORSO",
+    "skill_used": "fabrication",
+    "difficulty": 7,
+    "skills_required": [ "tailor", 4 ],
+    "time": "2 h",
+    "autolearn": [ [ "fabrication", 8 ], [ "tailor", 5 ] ],
+    "book_learn": [ [ "textbook_armwest", 7 ], [ "recipe_surv", 6 ] ],
+    "using": [ [ "sewing_standard", 50 ], [ "welding_standard", 3 ] ],
+    "components": [
+      [ [ "cuirass_lightplate_superalloy", 1 ] ],
       [ [ "rag", 5 ] ],
       [ [ "leather", 5 ], [ "tanned_hide", 1 ] ],
       [ [ "coat_rain", 1 ], [ "jacket_windbreaker", 1 ], [ "jacket_evac", 1 ], [ "coat_gut", 1 ] ],
@@ -1830,6 +1922,26 @@
     ]
   },
   {
+    "result": "armguard_lightplate_surv_superalloy",
+    "type": "recipe",
+    "category": "CC_ARMOR",
+    "subcategory": "CSC_ARMOR_ARMS",
+    "skill_used": "fabrication",
+    "difficulty": 7,
+    "skills_required": [ "tailor", 4 ],
+    "time": "1 h",
+    "autolearn": [ [ "fabrication", 8 ], [ "tailor", 5 ] ],
+    "book_learn": [ [ "textbook_armwest", 7 ], [ "recipe_surv", 6 ] ],
+    "using": [ [ "sewing_standard", 30 ], [ "welding_standard", 2 ] ],
+    "components": [
+      [ [ "armguard_lightplate_superalloy", 1 ] ],
+      [ [ "rag", 2 ] ],
+      [ [ "leather", 2 ] ],
+      [ [ "duct_tape", 75 ] ],
+      [ [ "kevlar_plate", 6 ] ]
+    ]
+  },
+  {
     "result": "legguard_lightplate_surv",
     "type": "recipe",
     "category": "CC_ARMOR",
@@ -1843,6 +1955,26 @@
     "using": [ [ "sewing_standard", 40 ], [ "welding_standard", 2 ] ],
     "components": [
       [ [ "legguard_lightplate", 1 ] ],
+      [ [ "rag", 3 ] ],
+      [ [ "leather", 3 ] ],
+      [ [ "duct_tape", 100 ] ],
+      [ [ "kevlar_plate", 8 ] ]
+    ]
+  },
+  {
+    "result": "legguard_lightplate_surv_superalloy",
+    "type": "recipe",
+    "category": "CC_ARMOR",
+    "subcategory": "CSC_ARMOR_LEGS",
+    "skill_used": "fabrication",
+    "difficulty": 7,
+    "skills_required": [ "tailor", 4 ],
+    "time": "1 h",
+    "autolearn": [ [ "fabrication", 8 ], [ "tailor", 5 ] ],
+    "book_learn": [ [ "textbook_armwest", 7 ], [ "recipe_surv", 6 ] ],
+    "using": [ [ "sewing_standard", 40 ], [ "welding_standard", 2 ] ],
+    "components": [
+      [ [ "legguard_lightplate_superalloy", 1 ] ],
       [ [ "rag", 3 ] ],
       [ [ "leather", 3 ] ],
       [ [ "duct_tape", 100 ] ],
@@ -1872,6 +2004,28 @@
     ]
   },
   {
+    "result": "helmet_plate_surv_superalloy",
+    "type": "recipe",
+    "category": "CC_ARMOR",
+    "subcategory": "CSC_ARMOR_HEAD",
+    "skill_used": "fabrication",
+    "difficulty": 7,
+    "skills_required": [ "tailor", 4 ],
+    "time": "45 m",
+    "autolearn": [ [ "fabrication", 8 ], [ "tailor", 5 ] ],
+    "book_learn": [ [ "textbook_armwest", 7 ], [ "recipe_surv", 6 ] ],
+    "using": [ [ "sewing_standard", 10 ], [ "welding_standard", 1 ] ],
+    "qualities": [ { "id": "SAW_M_FINE", "level": 1 } ],
+    "components": [
+      [ [ "helmet_plate_superalloy", 1 ] ],
+      [ [ "leather", 5 ], [ "tanned_hide", 1 ] ],
+      [ [ "tac_helmet", 1 ], [ "tac_fullhelmet", 1 ], [ "helmet_army", 1 ], [ "kevlar_plate", 6 ] ],
+      [ [ "rag", 2 ], [ "bandana", 1 ] ],
+      [ [ "glasses_safety", 2 ], [ "glasses_bal", 1 ] ],
+      [ [ "duct_tape", 75 ] ]
+    ]
+  },
+  {
     "result": "gloves_plate_surv",
     "type": "recipe",
     "category": "CC_ARMOR",
@@ -1891,6 +2045,25 @@
     ]
   },
   {
+    "result": "gloves_plate_surv_superalloy",
+    "type": "recipe",
+    "category": "CC_ARMOR",
+    "subcategory": "CSC_ARMOR_HANDS",
+    "skill_used": "fabrication",
+    "difficulty": 7,
+    "skills_required": [ "tailor", 4 ],
+    "time": "45 m",
+    "autolearn": [ [ "fabrication", 8 ], [ "tailor", 5 ] ],
+    "book_learn": [ [ "textbook_armwest", 7 ], [ "recipe_surv", 6 ] ],
+    "using": [ [ "sewing_standard", 40 ], [ "welding_standard", 2 ] ],
+    "components": [
+      [ [ "gloves_plate_superalloy", 1 ] ],
+      [ [ "leather", 2 ] ],
+      [ [ "duct_tape", 50 ] ],
+      [ [ "gloves_tactical", 1 ], [ "kevlar_plate", 4 ] ]
+    ]
+  },
+  {
     "result": "boots_plate_surv",
     "type": "recipe",
     "category": "CC_ARMOR",
@@ -1903,6 +2076,20 @@
     "book_learn": [ [ "textbook_armwest", 5 ], [ "recipe_surv", 4 ] ],
     "using": [ [ "sewing_standard", 60 ], [ "welding_standard", 3 ] ],
     "components": [ [ [ "boots_plate", 1 ] ], [ [ "leather", 4 ] ], [ [ "kevlar_plate", 4 ] ], [ [ "duct_tape", 100 ] ] ]
+  },
+  {
+    "result": "boots_plate_surv_superalloy",
+    "type": "recipe",
+    "category": "CC_ARMOR",
+    "subcategory": "CSC_ARMOR_FEET",
+    "skill_used": "fabrication",
+    "difficulty": 7,
+    "skills_required": [ "tailor", 4 ],
+    "time": "45 m",
+    "autolearn": [ [ "fabrication", 8 ], [ "tailor", 5 ] ],
+    "book_learn": [ [ "textbook_armwest", 7 ], [ "recipe_surv", 6 ] ],
+    "using": [ [ "sewing_standard", 60 ], [ "welding_standard", 3 ] ],
+    "components": [ [ [ "boots_plate_superalloy", 1 ] ], [ [ "leather", 4 ] ], [ [ "kevlar_plate", 4 ] ], [ [ "duct_tape", 100 ] ] ]
   },
   {
     "type": "recipe",
@@ -2723,6 +2910,43 @@
     ]
   },
   {
+    "result": "c_power_armor_surv_superalloy",
+    "type": "recipe",
+    "category": "CC_ARMOR",
+    "subcategory": "CSC_ARMOR_SUIT",
+    "skill_used": "fabrication",
+    "difficulty": 8,
+    "skills_required": [ [ "mechanics", 4 ], [ "electronics", 2 ] ],
+    "time": "5 h",
+    "autolearn": [ [ "fabrication", 9 ], [ "mechanics", 5 ], [ "electronics", 3 ] ],
+    "book_learn": [
+      [ "recipe_surv", 6 ],
+      [ "textbook_robots", 7 ],
+      [ "book_icef", 7 ],
+      [ "recipe_melee", 8 ],
+      [ "textbook_biodiesel", 8 ]
+    ],
+    "using": [ [ "welding_standard", 200 ] ],
+    "qualities": [ { "id": "SAW_M", "level": 1 }, { "id": "SCREW", "level": 1 }, { "id": "WRENCH", "level": 1 } ],
+    "//": "Swapping out both the main armor plating and the call to steel_standard, hence two superalloy components",
+    "components": [
+      [ [ "drivebelt", 2 ], [ "drivebelt_makeshift", 2 ] ],
+      [ [ "filter_air", 1 ], [ "filter_air_makeshift", 1 ] ],
+      [ [ "filter_liquid", 1 ], [ "filter_liquid_makeshift", 1 ] ],
+      [ [ "motor_small", 1 ], [ "motor_tiny", 2 ] ],
+      [ [ "well_pump", 1 ], [ "pump_complex", 1 ] ],
+      [ [ "power_supply", 1 ] ],
+      [ [ "hand_crank_charger", 1 ], [ "alternator_bicycle", 1 ], [ "alternator_motorbike", 1 ] ],
+      [ [ "hose", 4 ], [ "makeshift_hose", 4 ] ],
+      [ [ "metal_tank_little", 1 ] ],
+      [ [ "motor_oil", 1600 ], [ "lamp_oil", 1600 ] ],
+      [ [ "foldframe", 2 ] ],
+      [ [ "alloy_plate", 3 ], [ "alloy_sheet", 36 ] ],
+      [ [ "alloy_sheet", 10 ] ],
+      [ [ "kevlar", 1 ], [ "swat_armor", 1 ], [ "kevlar_plate", 24 ] ]
+    ]
+  },
+  {
     "result": "hydrogen_convertor",
     "type": "recipe",
     "category": "CC_WEAPON",
@@ -2856,5 +3080,21 @@
     "using": [ [ "welding_standard", 30 ] ],
     "qualities": [ { "id": "HAMMER", "level": 2 }, { "id": "SAW_M", "level": 1 } ],
     "components": [ [ [ "frame", 1 ] ], [ [ "steel_plate", 1 ] ], [ [ "kevlar_plate", 15 ] ] ]
+  },
+  {
+    "type": "recipe",
+    "result": "shield_welded_surv_superalloy",
+    "//": "Still uses a steel frame, but could still get some weight saving from better plating",
+    "byproducts": [ [ "steel_chunk", 40 ] ],
+    "category": "CC_ARMOR",
+    "subcategory": "CSC_ARMOR_OTHER",
+    "skill_used": "fabrication",
+    "difficulty": 8,
+    "time": "75 m",
+    "autolearn": true,
+    "book_learn": [ [ "recipe_surv", 7 ], [ "recipe_melee", 7 ] ],
+    "using": [ [ "welding_standard", 30 ] ],
+    "qualities": [ { "id": "HAMMER", "level": 2 }, { "id": "SAW_M", "level": 1 } ],
+    "components": [ [ [ "frame", 1 ] ], [ [ "alloy_plate", 1 ] ], [ [ "kevlar_plate", 15 ] ] ]
   }
 ]

--- a/nocts_cata_mod_BN/Surv_help/c_armor.json
+++ b/nocts_cata_mod_BN/Surv_help/c_armor.json
@@ -128,6 +128,18 @@
     ]
   },
   {
+    "id": "surv_armor_suit_superalloy",
+    "copy-from": "surv_armor_suit",
+    "type": "ARMOR",
+    "name": { "str": "survivor's superalloy scout suit" },
+    "description": "A home-made suit built to live off the land.  Comes with ample storage, warm fur lining, environmental and physical protection, a built in watch, and a makeshift sheath ring.  The suit is carefully crafted of Kevlar fabric and reinforced with superalloy.  It requires a separate gas mask for full protection.",
+    "material": [ "kevlar", "superalloy" ],
+    "color": "light_cyan",
+    "//": "Superalloy armor uses 5 less encumbrance than base item",
+    "encumbrance": 40,
+    "proportional": { "weight": 0.6, "price": 2, "price_postapoc": 2 }
+  },
+  {
     "id": "armor_lightplate_surv",
     "copy-from": "armor_lightplate",
     "//": "No storage or other amenities, but a modest increase in protection relative to the added encumbrance.",
@@ -144,6 +156,17 @@
     "environmental_protection": 3,
     "material_thickness": 5,
     "extend": { "flags": [ "WATERPROOF" ] }
+  },
+  {
+    "id": "armor_lightplate_surv_superalloy",
+    "copy-from": "armor_lightplate_surv",
+    "type": "ARMOR",
+    "name": { "str": "survivor superalloy plate armor" },
+    "description": "A suit of Gothic plate armor, made from superalloy plates further modified with kevlar and leather, altered to better protect the gaps between plates and provide better protection from the elements.",
+    "material": [ "superalloy", "kevlar", "leather" ],
+    "color": "light_cyan",
+    "encumbrance": 20,
+    "proportional": { "weight": 0.6, "price": 2, "price_postapoc": 2 }
   },
   {
     "id": "cuirass_lightplate_surv",
@@ -163,6 +186,17 @@
     "extend": { "flags": [ "WATERPROOF" ] }
   },
   {
+    "id": "cuirass_lightplate_surv_superalloy",
+    "copy-from": "cuirass_lightplate_surv",
+    "type": "ARMOR",
+    "name": { "str": "survivor superalloy cuirass", "str_pl": "survivor superalloy cuirasses" },
+    "description": "A medieval breastplate remade in cutting-edge superalloy, modified with kevlar and leather to better protect from the elements.",
+    "material": [ "superalloy", "kevlar", "leather" ],
+    "color": "light_cyan",
+    "encumbrance": 20,
+    "proportional": { "weight": 0.6, "price": 2, "price_postapoc": 2 }
+  },
+  {
     "id": "armguard_lightplate_surv",
     "copy-from": "armguard_lightplate",
     "type": "ARMOR",
@@ -178,6 +212,17 @@
     "environmental_protection": 3,
     "material_thickness": 5,
     "extend": { "flags": [ "WATERPROOF" ] }
+  },
+  {
+    "id": "armguard_lightplate_surv_superalloy",
+    "copy-from": "armguard_lightplate_surv",
+    "type": "ARMOR",
+    "name": { "str": "survivor superalloy arm guards", "str_pl": "survivor superalloy arm guards" },
+    "description": "A full assembly of medieval arm protection, made from modern superalloy.  Rerebraces, couters, and vambraces, subsequently modified with kevlar and leather to better protect the joints.",
+    "material": [ "superalloy", "kevlar", "leather" ],
+    "color": "light_cyan",
+    "encumbrance": 20,
+    "proportional": { "weight": 0.6, "price": 2, "price_postapoc": 2 }
   },
   {
     "id": "legguard_lightplate_surv",
@@ -197,6 +242,17 @@
     "extend": { "flags": [ "WATERPROOF" ] }
   },
   {
+    "id": "legguard_lightplate_surv_superalloy",
+    "copy-from": "legguard_lightplate_surv",
+    "type": "ARMOR",
+    "name": { "str": "survivor superalloy leg guards", "str_pl": "survivor superalloy leg guards" },
+    "description": "A full assembly of medieval leg protection, made from modern superalloy.  Cuisses, poleyns, and greaves, subsequently modified with kevlar and leather to better protect the joints.",
+    "material": [ "superalloy", "kevlar", "leather" ],
+    "color": "light_cyan",
+    "encumbrance": 20,
+    "proportional": { "weight": 0.6, "price": 2, "price_postapoc": 2 }
+  },
+  {
     "id": "helmet_plate_surv",
     "copy-from": "helmet_plate",
     "type": "ARMOR",
@@ -212,6 +268,17 @@
     "material_thickness": 6,
     "qualities": [ [ "GLARE", 1 ] ],
     "extend": { "flags": [ "WATERPROOF", "SUN_GLASSES" ] }
+  },
+  {
+    "id": "helmet_plate_surv_superalloy",
+    "copy-from": "helmet_plate_surv",
+    "type": "ARMOR",
+    "name": { "str": "survivor superalloy great helm" },
+    "description": "A modernized medieval helmet that has been further modified, widening the eye slits and breaths, with ballistic lenses and a kevlar aventail helping make up for the increased vulnerability.",
+    "material": [ "superalloy", "kevlar", "leather" ],
+    "color": "light_cyan",
+    "encumbrance": 30,
+    "proportional": { "weight": 0.6, "price": 2, "price_postapoc": 2 }
   },
   {
     "id": "gloves_plate_surv",
@@ -230,6 +297,17 @@
     "extend": { "flags": [ "WATERPROOF" ] }
   },
   {
+    "id": "gloves_plate_surv_superalloy",
+    "copy-from": "gloves_plate_surv",
+    "type": "ARMOR",
+    "name": { "str": "pair of survivor superalloy armored gauntlets", "str_pl": "pairs of survivor superalloy armored gauntlets" },
+    "description": "A set of medieval gauntlets plated with superalloy, then further modified with kevlar reinforcements to increase protection from the elements.",
+    "material": [ "superalloy", "kevlar", "leather" ],
+    "color": "light_cyan",
+    "encumbrance": 20,
+    "proportional": { "weight": 0.6, "price": 2, "price_postapoc": 2 }
+  },
+  {
     "id": "boots_plate_surv",
     "copy-from": "boots_plate",
     "type": "ARMOR",
@@ -243,6 +321,17 @@
     "warmth": 25,
     "material_thickness": 5,
     "environmental_protection": 3
+  },
+  {
+    "id": "boots_plate_surv_superalloy",
+    "copy-from": "boots_plate_surv",
+    "type": "ARMOR",
+    "name": { "str": "pair of survivor superalloy armored boots", "str_pl": "pairs of survivor superalloy armored boots" },
+    "description": "A set of superalloy plated boots, modified with kevlar to better protect from the elements.",
+    "material": [ "superalloy", "kevlar", "leather" ],
+    "color": "light_cyan",
+    "encumbrance": 25,
+    "proportional": { "weight": 0.6, "price": 2, "price_postapoc": 2 }
   },
   {
     "id": "badge_bio_weapon",
@@ -986,6 +1075,53 @@
     "weight_capacity_modifier": 2
   },
   {
+    "id": "c_power_armor_surv_superalloy",
+    "copy-from": "c_power_armor_surv",
+    "type": "ARMOR",
+    "name": { "str": "makeshift superalloy power armor" },
+    "description": "A heavy suit of superalloy and kevlar plates covering a network of hydraulics, driven by pieces of a stripped-down diesel engine jury-rigged to assist the wearer's movements.  When running it will increase your strength and raw speed, allowing you to fire heavy weapons unsupported, plus make it less encumbering to wear, but the motors make things warm and make stealth harder.",
+    "material": [ "superalloy", "kevlar_rigid" ],
+    "color": "light_cyan",
+    "encumbrance": 40,
+    "proportional": { "weight": 0.6, "price": 2, "price_postapoc": 2 },
+    "use_action": {
+      "type": "fireweapon_off",
+      "target_id": "c_power_armor_surv_superalloy_on",
+      "moves": 100,
+      "noise": 60,
+      "success_chance": 2,
+      "success_message": "Your makeshift superalloy power armor roars to life, servos kicking into gear!",
+      "failure_message": "Your armor sputters but fails to start up.",
+      "lacks_fuel_message": "You work your armor's starter, but nothing happens."
+    }
+  },
+  {
+    "id": "c_power_armor_surv_superalloy_on",
+    "copy-from": "c_power_armor_surv_superalloy",
+    "repairs_like": "c_power_armor_surv_superalloy",
+    "type": "TOOL_ARMOR",
+    "name": { "str": "makeshift superalloy power armor (on)", "str_pl": "makeshift superalloy power armors (on)" },
+    "description": "A heavy suit of superalloy and kevlar plates covering a network of hydraulics, driven by pieces of a stripped-down diesel engine jury-rigged to assist the wearer's movements.  It's currently active, strengthening the wearer, allowing you to fire heavy weapons unsupported, increasing raw speed and making the armor less encumbering, but also being warmer and making stealth more difficult.",
+    "extend": { "effects": [ "TRADER_AVOID", "HEAVY_WEAPON_SUPPORT" ] },
+    "//": "turns_per_charge increased over standard version since lighter suit takes less effort to power.",
+    "turns_per_charge": 10,
+    "revert_to": "c_power_armor_surv_superalloy",
+    "use_action": [
+      {
+        "type": "fireweapon_on",
+        "noise": 30,
+        "noise_chance": 5,
+        "noise_message": "Your armor whirs with activity.",
+        "voluntary_extinguish_message": "You shut the makeshift power armor off.",
+        "charges_extinguish_message": "Your makeshift superalloy power armor sputters and dies!",
+        "water_extinguish_message": "Your armor's engine floods and cuts out!"
+      }
+    ],
+    "warmth": 45,
+    "encumbrance": 10,
+    "weight_capacity_modifier": 2
+  },
+  {
     "id": "shield_riot_surv",
     "copy-from": "shield_riot",
     "type": "ARMOR",
@@ -1020,5 +1156,17 @@
     "material_thickness": 8,
     "techniques": [ "WBLOCK_3" ],
     "flags": [ "OVERSIZE", "BELTED", "ONLY_ONE", "BLOCK_WHILE_WORN", "HEAVY_WEAPON_SUPPORT", "POWERARMOR_COMPATIBLE" ]
+  },
+  {
+    "id": "shield_welded_surv_superalloy",
+    "copy-from": "shield_welded_surv",
+    "type": "ARMOR",
+    "name": { "str": "makeshift superalloy ballistic pavise" },
+    "description": "A shield made from superalloy plates and kevlar lining, welded to a framework that helps distribute the weight.  It leaves you free to operate two-handed weapons, even letting you brace heavy weapons to fire without mounting terrain, but is still very heavy and encumbering.",
+    "material": [ "superalloy", "kevlar_rigid" ],
+    "color": "light_cyan",
+    "encumbrance": 40,
+    "//": "No pre-apoc price to modify since post-cata makeshift item",
+    "proportional": { "weight": 0.6, "price_postapoc": 2 }
   }
 ]

--- a/nocts_cata_mod_DDA/Recipe/c_recipes.json
+++ b/nocts_cata_mod_DDA/Recipe/c_recipes.json
@@ -553,7 +553,7 @@
     "skills_required": [ "fabrication", 8 ],
     "time": "500 m",
     "book_learn": [ [ "recipe_surv", 8 ] ],
-    "using": [ [ "sewing_standard", 100 ], [ "steel_tiny", 8 ] ],
+    "using": [ [ "sewing_standard", 100 ], [ "steel_standard", 2 ] ],
     "qualities": [ { "id": "HAMMER", "level": 2 }, { "id": "SAW_M", "level": 1 } ],
     "tools": [ [ [ "welder", 50 ], [ "welding_kit", 50 ], [ "welder_crude", 100 ], [ "soldering_iron", 100 ], [ "toolset", 100 ] ] ],
     "components": [


### PR DESCRIPTION
Set aside for when https://github.com/cataclysmbnteam/Cataclysm-BN/pull/3956 is merged. Depends on it since the superalloy plate armor items that survivor superalloy plate armor uses as a component is obviously important to have in the JSON.

Adds superalloy versions of the following items:
* Survivor's armored scout suit
* Survivor plate armor (including components)
* Survivor great helm
* Survivor armored gauntlets
* Survivor armored boots
* Makeshift power armor
* Makeshift ballistic pavise

Follows the same general conventions as the related BN PRs set: 60% the base item's weight, double the price/post-apoc price (when defined), 5 lower encumbrance (set explicitly for the time being due to bugs with relative and proportional); meanwhile the recipes use 2 higher fabrication skill (whether primary or secondary skill, maxing out at 10), 2 higher booklearn level, and call for 1 superalloy sheet per steel lump used in the recipe (or 1 alloy plate per steel plate, where relevant).

Could add DDA versions of some of this, but they already have wacky amounts of flavor variations on armor items by grades of steel alredy, and survivor superalloy plate armor wouldn't really would out well without having the superalloy plate armor as well.

MISC: Updated armored scout suit to use 2 doses of `steel_standard` instead of 8 doses of `steel_tiny` since that allows using steel lumps too.