### PR TITLE
Add use of resized_large to BN version

### DIFF
--- a/nocts_cata_mod_BN/Surv_help/c_armor.json
+++ b/nocts_cata_mod_BN/Surv_help/c_armor.json
@@ -27,6 +27,7 @@
     "warmth": 10,
     "material_thickness": 2,
     "use_action": { "type": "bandolier", "capacity": 50, "ammo": [ "arrow", "bolt" ], "draw_cost": 3 },
+    "valid_mods": [ "resized_large" ],
     "flags": [ "WATER_FRIENDLY", "STURDY", "BELTED" ]
   },
   {
@@ -507,6 +508,7 @@
       "draw_cost": 40,
       "flags": [ "MAG_COMPACT" ]
     },
+    "valid_mods": [ "resized_large" ],
     "flags": [ "STURDY", "NO_SALVAGE" ]
   },
   {
@@ -541,6 +543,7 @@
       "draw_cost": 40,
       "flags": [ "MAG_COMPACT" ]
     },
+    "valid_mods": [ "resized_large" ],
     "flags": [ "STURDY", "NO_SALVAGE" ]
   },
   {
@@ -575,6 +578,7 @@
       "draw_cost": 40,
       "flags": [ "MAG_COMPACT", "MAG_BULKY" ]
     },
+    "valid_mods": [ "resized_large" ],
     "flags": [ "STURDY", "NONCONDUCTIVE", "NO_SALVAGE" ]
   },
   {
@@ -598,6 +602,7 @@
     "warmth": 30,
     "material_thickness": 1,
     "environmental_protection": 5,
+    "valid_mods": [ "resized_large" ],
     "flags": [ "STURDY", "NO_SALVAGE" ]
   },
   {
@@ -621,6 +626,7 @@
     "warmth": 30,
     "material_thickness": 1,
     "environmental_protection": 5,
+    "valid_mods": [ "resized_large" ],
     "flags": [ "STURDY", "NO_SALVAGE" ]
   },
   {
@@ -644,6 +650,7 @@
     "warmth": 30,
     "material_thickness": 1,
     "environmental_protection": 5,
+    "valid_mods": [ "resized_large" ],
     "flags": [ "STURDY", "NO_SALVAGE" ]
   },
   {


### PR DESCRIPTION
Lil update to BN version in the wake of https://github.com/cataclysmbnteam/Cataclysm-BN/pull/4004

Adds compatibility with the `resized_large` clothing mod to the following items:
1. Survivor's archer backpack
2. Light military armor
3. Military armor
4. Heavy military armor
5. Light military helm
6. Military helm
7. Heavy military helm

Survivor scout suits already had `OVERSIZE`+`VARSIZE` explicitly so no need for for it, carapace armor and makeshift power armor natively had `OVERSIZE`, meanwhile all the flavor items as well as survivor plate armor and survivor cowboy hats inherit from `VARSIZE` stuff and thus would automatically get access to the clothing mod already too.