### PR TITLE
Welding recipe update

### DIFF
--- a/nocts_cata_mod_BN/Recipe/c_recipes.json
+++ b/nocts_cata_mod_BN/Recipe/c_recipes.json
@@ -507,7 +507,7 @@
     "time": "500 m",
     "book_learn": [ [ "recipe_surv", 7 ] ],
     "using": [ [ "sewing_standard", 100 ] ],
-    "tools": [ [ [ "welder", 28 ], [ "welder_crude", 42 ], [ "soldering_iron", 42 ], [ "toolset", 42 ] ] ],
+    "tools": [ [ [ "welder", 28 ], [ "soldering_iron", 42 ], [ "toolset", 42 ] ] ],
     "components": [
       [ [ "survivor_suit", 1 ] ],
       [ [ "gloves_survivor", 1 ] ],
@@ -534,7 +534,7 @@
     "book_learn": [ [ "recipe_surv", 8 ] ],
     "using": [ [ "sewing_standard", 100 ], [ "steel_standard", 2 ] ],
     "qualities": [ { "id": "HAMMER", "level": 2 }, { "id": "SAW_M", "level": 1 } ],
-    "tools": [ [ [ "welder", 50 ], [ "welder_crude", 100 ], [ "soldering_iron", 100 ], [ "toolset", 100 ] ] ],
+    "tools": [ [ [ "welder", 50 ], [ "soldering_iron", 100 ], [ "toolset", 100 ] ] ],
     "components": [
       [ [ "hsurvivor_suit", 1 ] ],
       [ [ "gloves_hsurvivor", 1 ] ],
@@ -562,7 +562,7 @@
     "book_learn": [ [ "recipe_surv", 10 ] ],
     "using": [ [ "sewing_standard", 100 ] ],
     "qualities": [ { "id": "HAMMER", "level": 2 }, { "id": "SAW_M", "level": 1 } ],
-    "tools": [ [ [ "welder", 50 ], [ "welder_crude", 100 ], [ "soldering_iron", 100 ], [ "toolset", 100 ] ] ],
+    "tools": [ [ [ "welder", 50 ], [ "soldering_iron", 100 ], [ "toolset", 100 ] ] ],
     "components": [
       [ [ "sasurvivor_suit", 1 ] ],
       [ [ "gloves_sasurvivor", 1 ] ],
@@ -594,7 +594,7 @@
       { "id": "DRILL", "level": 2 }
     ],
     "tools": [
-      [ [ "welder", 10 ], [ "welder_crude", 20 ], [ "soldering_iron", 20 ], [ "toolset", 20 ] ],
+      [ [ "welder", 10 ], [ "soldering_iron", 20 ], [ "toolset", 20 ] ],
       [ [ "small_repairkit", 40 ], [ "large_repairkit", 40 ] ]
     ],
     "components": [ [ [ "sheet_metal_small", 1 ] ], [ [ "scrap", 2 ] ], [ [ "spring", 1 ] ] ]
@@ -616,7 +616,7 @@
       { "id": "DRILL", "level": 2 }
     ],
     "tools": [
-      [ [ "welder", 10 ], [ "welder_crude", 20 ], [ "soldering_iron", 20 ], [ "toolset", 20 ] ],
+      [ [ "welder", 10 ], [ "soldering_iron", 20 ], [ "toolset", 20 ] ],
       [ [ "small_repairkit", 40 ], [ "large_repairkit", 40 ] ]
     ],
     "components": [ [ [ "sheet_metal_small", 1 ] ], [ [ "scrap", 2 ] ], [ [ "spring", 1 ] ] ]
@@ -638,7 +638,7 @@
       { "id": "DRILL", "level": 2 }
     ],
     "tools": [
-      [ [ "welder", 10 ], [ "welder_crude", 20 ], [ "soldering_iron", 20 ], [ "toolset", 20 ] ],
+      [ [ "welder", 10 ], [ "soldering_iron", 20 ], [ "toolset", 20 ] ],
       [ [ "small_repairkit", 40 ], [ "large_repairkit", 40 ] ]
     ],
     "components": [ [ [ "sheet_metal_small", 1 ] ], [ [ "scrap", 2 ] ], [ [ "spring", 1 ] ] ]
@@ -660,7 +660,7 @@
       { "id": "DRILL", "level": 2 }
     ],
     "tools": [
-      [ [ "welder", 10 ], [ "welder_crude", 20 ], [ "soldering_iron", 20 ], [ "toolset", 20 ] ],
+      [ [ "welder", 10 ], [ "soldering_iron", 20 ], [ "toolset", 20 ] ],
       [ [ "small_repairkit", 40 ], [ "large_repairkit", 40 ] ]
     ],
     "components": [ [ [ "sheet_metal_small", 1 ] ], [ [ "scrap", 2 ] ], [ [ "spring", 1 ] ] ]
@@ -682,7 +682,7 @@
       { "id": "DRILL", "level": 2 }
     ],
     "tools": [
-      [ [ "welder", 10 ], [ "welder_crude", 20 ], [ "soldering_iron", 20 ], [ "toolset", 20 ] ],
+      [ [ "welder", 10 ], [ "soldering_iron", 20 ], [ "toolset", 20 ] ],
       [ [ "small_repairkit", 40 ], [ "large_repairkit", 40 ] ]
     ],
     "components": [ [ [ "sheet_metal", 1 ], [ "sheet_metal_small", 2 ] ], [ [ "scrap", 4 ] ], [ [ "spring", 1 ] ] ]
@@ -704,7 +704,7 @@
       { "id": "DRILL", "level": 2 }
     ],
     "tools": [
-      [ [ "welder", 10 ], [ "welder_crude", 20 ], [ "soldering_iron", 20 ], [ "toolset", 20 ] ],
+      [ [ "welder", 10 ], [ "soldering_iron", 20 ], [ "toolset", 20 ] ],
       [ [ "small_repairkit", 40 ], [ "large_repairkit", 40 ] ]
     ],
     "components": [ [ [ "sheet_metal_small", 1 ] ], [ [ "scrap", 2 ] ], [ [ "spring", 1 ] ] ]
@@ -726,7 +726,7 @@
       { "id": "DRILL", "level": 2 }
     ],
     "tools": [
-      [ [ "welder", 10 ], [ "welder_crude", 20 ], [ "soldering_iron", 20 ], [ "toolset", 20 ] ],
+      [ [ "welder", 10 ], [ "soldering_iron", 20 ], [ "toolset", 20 ] ],
       [ [ "small_repairkit", 40 ], [ "large_repairkit", 40 ] ]
     ],
     "components": [ [ [ "sheet_metal_small", 1 ] ], [ [ "scrap", 2 ] ], [ [ "spring", 1 ] ] ]
@@ -748,7 +748,7 @@
       { "id": "DRILL", "level": 2 }
     ],
     "tools": [
-      [ [ "welder", 10 ], [ "welder_crude", 20 ], [ "soldering_iron", 20 ], [ "toolset", 20 ] ],
+      [ [ "welder", 10 ], [ "soldering_iron", 20 ], [ "toolset", 20 ] ],
       [ [ "small_repairkit", 40 ], [ "large_repairkit", 40 ] ]
     ],
     "components": [ [ [ "sheet_metal_small", 1 ] ], [ [ "scrap", 2 ] ], [ [ "spring", 1 ] ] ]
@@ -766,7 +766,7 @@
     "using": [ [ "sewing_standard", 120 ], [ "fabric_standard", 6 ] ],
     "qualities": [ { "id": "SAW_M_FINE", "level": 1 }, { "id": "HAMMER_FINE", "level": 1 } ],
     "tools": [
-      [ [ "welder", 20 ], [ "welder_crude", 40 ], [ "soldering_iron", 40 ], [ "toolset", 40 ] ],
+      [ [ "welder", 20 ], [ "soldering_iron", 40 ], [ "toolset", 40 ] ],
       [ [ "small_repairkit", 60 ], [ "large_repairkit", 60 ] ],
       [ [ "swage", -1 ] ],
       [ [ "223_casing", -1 ] ]
@@ -786,7 +786,7 @@
     "using": [ [ "sewing_standard", 120 ], [ "fabric_standard", 6 ] ],
     "qualities": [ { "id": "SAW_M_FINE", "level": 1 }, { "id": "HAMMER_FINE", "level": 1 } ],
     "tools": [
-      [ [ "welder", 20 ], [ "welder_crude", 40 ], [ "soldering_iron", 40 ], [ "toolset", 40 ] ],
+      [ [ "welder", 20 ], [ "soldering_iron", 40 ], [ "toolset", 40 ] ],
       [ [ "small_repairkit", 60 ], [ "large_repairkit", 60 ] ],
       [ [ "swage", -1 ] ],
       [ [ "308_casing", -1 ] ]
@@ -806,7 +806,7 @@
     "using": [ [ "sewing_standard", 120 ], [ "fabric_standard", 6 ] ],
     "qualities": [ { "id": "SAW_M_FINE", "level": 1 }, { "id": "HAMMER_FINE", "level": 1 } ],
     "tools": [
-      [ [ "welder", 20 ], [ "welder_crude", 40 ], [ "soldering_iron", 40 ], [ "toolset", 40 ] ],
+      [ [ "welder", 20 ], [ "soldering_iron", 40 ], [ "toolset", 40 ] ],
       [ [ "small_repairkit", 60 ], [ "large_repairkit", 60 ] ],
       [ [ "swage", -1 ] ],
       [ [ "762_casing", -1 ] ]
@@ -826,7 +826,7 @@
     "using": [ [ "sewing_standard", 120 ], [ "fabric_standard", 6 ] ],
     "qualities": [ { "id": "SAW_M_FINE", "level": 1 }, { "id": "HAMMER_FINE", "level": 1 } ],
     "tools": [
-      [ [ "welder", 20 ], [ "welder_crude", 40 ], [ "soldering_iron", 40 ], [ "toolset", 40 ] ],
+      [ [ "welder", 20 ], [ "soldering_iron", 40 ], [ "toolset", 40 ] ],
       [ [ "small_repairkit", 60 ], [ "large_repairkit", 60 ] ],
       [ [ "swage", -1 ] ],
       [ [ "762R_casing", -1 ] ]
@@ -850,7 +850,7 @@
       { "id": "DRILL", "level": 2 }
     ],
     "tools": [
-      [ [ "welder", 10 ], [ "welder_crude", 20 ], [ "soldering_iron", 20 ], [ "toolset", 20 ] ],
+      [ [ "welder", 10 ], [ "soldering_iron", 20 ], [ "toolset", 20 ] ],
       [ [ "small_repairkit", 40 ], [ "large_repairkit", 40 ] ]
     ],
     "components": [ [ [ "sheet_metal", 1 ], [ "sheet_metal_small", 2 ] ], [ [ "scrap", 4 ] ], [ [ "spring", 1 ] ] ]
@@ -904,7 +904,7 @@
     "decomp_learn": 2,
     "book_learn": [ [ "advanced_electronics", 6 ], [ "textbook_electronics", 6 ], [ "manual_electronics", 6 ], [ "recipe_surv", 5 ] ],
     "qualities": [ { "id": "SAW_M_FINE", "level": 1 }, { "id": "SCREW", "level": 1 }, { "id": "WRENCH_FINE", "level": 1 } ],
-    "tools": [ [ [ "welder", 30 ], [ "welder_crude", 60 ], [ "soldering_iron", 60 ], [ "toolset", 60 ] ] ],
+    "tools": [ [ [ "welder", 30 ], [ "soldering_iron", 60 ], [ "toolset", 60 ] ] ],
     "components": [
       [ [ "battery_ups", 1 ] ],
       [ [ "amplifier", 4 ] ],
@@ -932,7 +932,7 @@
       { "id": "SCREW_FINE", "level": 1 },
       { "id": "GLARE", "level": 2 }
     ],
-    "tools": [ [ [ "welder", 30 ], [ "welder_crude", 60 ], [ "soldering_iron", 60 ], [ "toolset", 60 ] ] ],
+    "tools": [ [ [ "welder", 30 ], [ "soldering_iron", 60 ], [ "toolset", 60 ] ] ],
     "components": [
       [ [ "ups_rifle", 1 ] ],
       [ [ "hand_crank_charger", 1 ] ],
@@ -954,7 +954,7 @@
     "time": "25 m",
     "book_learn": [ [ "advanced_electronics", 7 ], [ "textbook_electronics", 7 ], [ "manual_electronics", 7 ], [ "recipe_surv", 6 ] ],
     "qualities": [ { "id": "SCREW_FINE", "level": 1 }, { "id": "GLARE", "level": 2 } ],
-    "tools": [ [ [ "welder", 10 ], [ "welder_crude", 10 ], [ "soldering_iron", 10 ], [ "toolset", 10 ] ] ],
+    "tools": [ [ [ "welder", 10 ], [ "soldering_iron", 10 ], [ "toolset", 10 ] ] ],
     "components": [
       [ [ "light_plus_battery_cell", 4 ], [ "light_battery_cell", 6 ], [ "light_minus_battery_cell", 12 ] ],
       [ [ "amplifier", 2 ] ],
@@ -2701,7 +2701,7 @@
     "autolearn": true,
     "book_learn": [ [ "recipe_surv", 3 ] ],
     "using": [ [ "sewing_standard", 40 ] ],
-    "tools": [ [ [ "welder", 16 ], [ "welder_crude", 24 ], [ "soldering_iron", 24 ], [ "toolset", 24 ] ] ],
+    "tools": [ [ [ "welder", 16 ], [ "soldering_iron", 24 ], [ "toolset", 24 ] ] ],
     "components": [
       [ [ "cowboy_hat", 1 ], [ "hat_boonie", 1 ], [ "straw_hat", 1 ] ],
       [ [ "kevlar_plate", 3 ] ],
@@ -2884,7 +2884,7 @@
     "autolearn": true,
     "book_learn": [ [ "recipe_surv", 4 ], [ "recipe_melee", 4 ] ],
     "tools": [
-      [ [ "welder", 14 ], [ "welder_crude", 21 ], [ "soldering_iron", 21 ], [ "toolset", 21 ] ],
+      [ [ "welder", 14 ], [ "soldering_iron", 21 ], [ "toolset", 21 ] ],
       [ [ "mold_plastic", -1 ] ],
       [ [ "surface_heat", 15, "LIST" ] ]
     ],


### PR DESCRIPTION
https://github.com/cataclysmbnteam/Cataclysm-BN/pull/4264 phased out the makeshift arc welder in BN, in favor of just being able to craft regular welders like we already can with soldering irons, so this updates recipes accordingly.