### PR TITLE
Changes to match upstream updates

### DIFF
--- a/nocts_cata_mod_DDA/Mutations/c_bio_mutation.json
+++ b/nocts_cata_mod_DDA/Mutations/c_bio_mutation.json
@@ -129,7 +129,6 @@
     "cancels": [ "THIRST" ],
     "bodytemp_modifiers": [ 0, 2000 ],
     "enchantments": [ { "values": [ { "value": "METABOLISM", "multiply": 1.25 } ] }],
-    "thirst_modifier": 0.75,
     "vitamins_absorb_multi": [ [ "all", [ [ "mutant_toxin", 0.25 ] ] ] ]
   },
   {
@@ -241,9 +240,15 @@
     "purifiable": false,
     "profession": true,
     "types": [ "HEALING" ],
-    "healing_awake": 2.5,
-    "healing_multiplier": 2.0,
-    "mending_modifier": 10.0
+    "enchantments": [
+      {
+        "values": [
+          { "value": "REGEN_HP_AWAKE", "multiply": 2.5 },
+          { "value": "REGEN_HP", "multiply": 1.0 },
+          { "value": "MENDING_MODIFIER", "multiply": 9.0 }
+        ]
+      } 
+    ]
   },
   {
     "type": "mutation",
@@ -286,13 +291,12 @@
         "values": [
           { "value": "METABOLISM", "multiply": -0.25 },
           { "value": "FATIGUE", "multiply": -0.25 },
-          { "value": "STAMINA_REGEN_MOD", "add": -0.5 }
+          { "value": "STAMINA_REGEN_MOD", "add": -0.5 },
+          { "value": "REGEN_HP", "multiply": -0.5},
+          { "value": "MENDING_MODIFIER", "multiply": -0.75}
         ]
       }
-    ],
-    "thirst_modifier": -0.25,
-    "healing_multiplier": 0.5,
-    "mending_modifier": 0.25
+    ]
   },
   {
     "type": "mutation",

--- a/nocts_cata_mod_DDA/Mutations/c_bio_mutation_super_soldier.json
+++ b/nocts_cata_mod_DDA/Mutations/c_bio_mutation_super_soldier.json
@@ -20,15 +20,14 @@
         "values": [
           { "value": "CARDIO_MULTIPLIER", "multiply": 0.25 },
           { "value": "METABOLISM", "multiply": 0.25 },
-          { "value": "CARRY_WEIGHT", "multiply": 0.25 }
+          { "value": "CARRY_WEIGHT", "multiply": 0.25 },
+          { "value": "REGEN_HP_AWAKE", "multiply": 0.1 },
+          { "value": "REGEN_HP", "multiply": 0.25 },
+          { "value": "MENDING_MODIFIER", "multiply": 0.0 }
         ]
       }
     ],
-    "healing_awake": 0.1,
-    "healing_multiplier": 1.25,
-    "vitamin_rates": [ [ "blood", -1 ], [ "redcells", -1 ] ],
-    "mending_modifier": 1.0,
-    "thirst_modifier": 0.25
+    "vitamin_rates": [ [ "blood", -1 ], [ "redcells", -1 ] ]
   },
   {
     "type": "mutation",
@@ -51,15 +50,14 @@
         "values": [
           { "value": "CARDIO_MULTIPLIER", "multiply": 0.5 },
           { "value": "METABOLISM", "multiply": 0.5 },
-          { "value": "CARRY_WEIGHT", "multiply": 0.5}
+          { "value": "CARRY_WEIGHT", "multiply": 0.5 },
+          { "value": "REGEN_HP_AWAKE", "multiply": 0.2 },
+          { "value": "REGEN_HP", "multiply": 0.5 },
+          { "value": "MENDING_MODIFIER", "multiply": 1.0 }
         ]
       }
     ],
-    "healing_awake": 0.2,
-    "healing_multiplier": 1.5,
-    "mending_modifier": 2.0,
     "vitamin_rates": [ [ "blood", -2 ], [ "redcells", -2 ] ],
-    "thirst_modifier": 0.5,
     "flags": [ "C_SENTINEL_MARKER_1" ]
   },
   {
@@ -83,15 +81,14 @@
         "values": [
           { "value": "CARDIO_MULTIPLIER", "multiply": 1.0 },
           { "value": "METABOLISM", "multiply": 1.0 },
-          { "value": "CARRY_WEIGHT", "multiply": 1.0 }
+          { "value": "CARRY_WEIGHT", "multiply": 1.0 },
+          { "value": "REGEN_HP_AWAKE", "multiply": 0.4 },
+          { "value": "REGEN_HP", "multiply": 1.0 },
+          { "value": "MENDING_MODIFIER", "multiply": 3.0 }
         ]
       }
     ],
-    "healing_awake": 0.4,
-    "healing_multiplier": 2.0,
-    "mending_modifier": 4.0,
-    "vitamin_rates": [ [ "blood", -4 ], [ "redcells", -4 ] ],
-    "thirst_modifier": 1.0
+    "vitamin_rates": [ [ "blood", -4 ], [ "redcells", -4 ] ]
   },
   {
     "type": "mutation",

--- a/nocts_cata_mod_DDA/Surv_help/c_armor.json
+++ b/nocts_cata_mod_DDA/Surv_help/c_armor.json
@@ -938,8 +938,7 @@
           "flintlock": 12,
           "36paper": 12,
           "44paper": 12,
-          "blunderbuss": 12,
-          "shotpaper": 12
+          "blunderbuss": 12
         },
         "moves": 30
       }

--- a/nocts_cata_mod_DDA/Surv_help/c_bionics.json
+++ b/nocts_cata_mod_DDA/Surv_help/c_bionics.json
@@ -212,7 +212,7 @@
     "name": { "str": "Atomic Battery" },
     "description": "Your body has been implanted with a compact, advanced plutonium-cell generator for military use.  A true atomic battery, using advanced materials to create a practical alphavoltaic power source.  While its power output is still very low, it's also consistent with negligible waste heat, making it a useful backup to another power generation method.",
     "occupied_bodyparts": [ [ "torso", 10 ] ],
-    "power_trickle": "5 J",
+    "enchantments": [ { "values": [ { "value": "POWER_TRICKLE", "add": 6 } ] } ],
     "flags": [ "BIONIC_POWER_SOURCE", "BIONIC_NPC_USABLE", "BIONIC_SHOCKPROOF" ]
   },
   {

--- a/nocts_cata_mod_DDA/Vehicles/c_vehicles.json
+++ b/nocts_cata_mod_DDA/Vehicles/c_vehicles.json
@@ -267,7 +267,7 @@
     ],
     "parts": [
       { "x": 0, "y": 1, "parts": [ "hdframe#vertical", "door_opaque" ] },
-      { "x": 0, "y": 0, "parts": [ "hdframe#vertical_2", "reaper_advanced", "hdroof" ] },
+      { "x": 0, "y": 0, "parts": [ "reaper_advanced", "hdroof" ] },
       { "x": 0, "y": -1, "parts": [ "hdframe#vertical", "hdboard#vertical" ] },
       { "x": 1, "y": 1, "parts": [ "hdframe#vertical", "reinforced_windshield" ] },
       { "x": 1, "y": 0, "parts": [ "hdframe#vertical_2", "controls", "seat", "seatbelt_heavyduty", "hdroof" ] },
@@ -288,7 +288,7 @@
         "y": 1,
         "parts": [ "hdframe#cross", "storage_battery_mount", "storage_battery_removable", "hdboard#se" ]
       },
-      { "x": -1, "y": 0, "parts": [ "hdframe#horizontal", "plow", "hdboard#horizontal" ] },
+      { "x": -1, "y": 0, "parts": [ "plow", "hdboard#horizontal" ] },
       {
         "x": -1,
         "y": -1,


### PR DESCRIPTION
More things moved to enchantments. Notably "thirst_modifier" was completely removed without replacement since it wasn't in use in the upstream repo, so that would require a PR there to put back in. Please take a look at the MENDING_MODIFIER values to see if that's working as intended to, some weirdness there since the only upstream examples were mending_modifier: 16 -> MENDING_MODIFIER: 15. Shotpaper was removed. Reapers and plows were made structural so the associated frames were removed from the tractor.