### PR TITLE
Assorted fixes

### DIFF
--- a/nocts_cata_mod_BN/Char_creation/c_classes_r.json
+++ b/nocts_cata_mod_BN/Char_creation/c_classes_r.json
@@ -69,7 +69,8 @@
       { "level": 4, "name": "tailor" },
       { "level": 3, "name": "cooking" },
       { "level": 3, "name": "fabrication" },
-      { "level": 2, "name": "survival" }
+      { "level": 2, "name": "survival" },
+      { "level": 1, "name": "mechanics" }
     ],
     "items": {
       "both": {
@@ -164,10 +165,9 @@
     ],
     "items": {
       "both": {
-        "ammo": 100,
-        "items": [ "loincloth", "footrags", "backpack", "waterskin", "flint_steel", "clay_pot" ],
+        "items": [ "loincloth", "footrags", "c_power_armor_surv", "backpack", "waterskin", "flint_steel", "clay_pot" ],
         "entries": [
-          { "item": "c_power_armor_surv", "ammo-item": "lamp_oil", "charges": 2000 },
+          { "item": "lamp_oil", "container-item": "metal_tank_little" },
           { "item": "greatsword_makeshift", "custom-flags": [ "auto_wield" ] },
           { "item": "makeshift_knife", "container-item": "sheath" }
         ]

--- a/nocts_cata_mod_BN/Recipe/c_recipes.json
+++ b/nocts_cata_mod_BN/Recipe/c_recipes.json
@@ -111,6 +111,8 @@
     "components": [
       [
         [ "metal_tank_little", 1 ],
+        [ "can_food_big_unsealed", 1 ],
+        [ "can_medium_unsealed", 3 ],
         [ "sheet_metal_small", 4 ],
         [ "can_food_unsealed", 6 ],
         [ "can_drink_unsealed", 6 ],
@@ -206,6 +208,9 @@
     "tools": [
       [ [ "surface_heat", 10, "LIST" ] ],
       [
+        [ "metal_tank_little", -1 ],
+        [ "can_food_big_unsealed", -1 ],
+        [ "can_medium_unsealed", -1 ],
         [ "can_food_unsealed", -1 ],
         [ "canister_empty", -1 ],
         [ "tinderbox", -1 ],

--- a/nocts_cata_mod_DDA/Char_creation/c_classes_r.json
+++ b/nocts_cata_mod_DDA/Char_creation/c_classes_r.json
@@ -77,7 +77,8 @@
       { "level": 4, "name": "tailor" },
       { "level": 3, "name": "cooking" },
       { "level": 3, "name": "fabrication" },
-      { "level": 2, "name": "survival" }
+      { "level": 2, "name": "survival" },
+      { "level": 1, "name": "mechanics" }
     ],
     "proficiencies": [
       "prof_handloading",
@@ -85,7 +86,8 @@
       "prof_leatherworking",
       "prof_millinery",
       "prof_furriery",
-      "prof_closures"
+      "prof_closures",
+      "prof_gun_cleaning"
     ],
     "items": {
       "both": {
@@ -183,9 +185,9 @@
     "items": {
       "both": {
         "ammo": 100,
-        "items": [ "loincloth", "footrags", "backpack", "waterskin", "flint_steel", "clay_pot" ],
+        "items": [ "loincloth", "footrags", "c_power_armor_surv", "backpack", "waterskin", "flint_steel", "clay_pot" ],
         "entries": [
-          { "item": "c_power_armor_surv", "contents-item": "lamp_oil", "charges": 2000 },
+          { "item": "lamp_oil", "container-item": "metal_tank_little" },
           { "item": "greatsword_makeshift", "custom-flags": [ "auto_wield" ] },
           { "item": "makeshift_knife", "container-item": "sheath" }
         ]
@@ -206,7 +208,6 @@
       "bio_alarm",
       "bio_cloak",
       "bio_atomic_battery",
-      "bio_cloak",
       "bio_fingerhack",
       "bio_lockpick",
       "bio_metabolics",

--- a/nocts_cata_mod_DDA/Recipe/c_recipes.json
+++ b/nocts_cata_mod_DDA/Recipe/c_recipes.json
@@ -116,7 +116,15 @@
     "using": [ [ "surface_heat", 50 ] ],
     "qualities": [ { "id": "CUT", "level": 1 }, { "id": "HAMMER", "level": 2 } ],
     "components": [
-      [ [ "metal_tank_little", 1 ], [ "sheet_metal_small", 4 ], [ "can_food", 6 ], [ "can_drink", 6 ], [ "scrap", 12 ] ],
+      [
+        [ "metal_tank_little", 1 ],
+        [ "can_food_big", 1 ],
+        [ "can_medium", 3 ],
+        [ "sheet_metal_small", 4 ],
+        [ "can_food", 6 ],
+        [ "can_drink", 6 ],
+        [ "scrap", 12 ]
+      ],
       [ [ "clay_lump", 2 ], [ "pebble", 20 ], [ "material_limestone", 100 ], [ "material_sand", 100 ] ],
       [ [ "cu_pipe", 1 ], [ "pipe", 1 ], [ "clay_lump", 1 ] ]
     ]
@@ -213,6 +221,9 @@
     "tools": [
       [ [ "surface_heat", 10, "LIST" ] ],
       [
+        [ "metal_tank_little", -1 ],
+        [ "can_food_big", -1 ],
+        [ "can_medium", -1 ],
         [ "can_food", -1 ],
         [ "canister_empty", -1 ],
         [ "tinderbox", -1 ],
@@ -1493,11 +1504,7 @@
     "book_learn": [ [ "recipe_surv", 5 ] ],
     "using": [ [ "welding_standard", 10 ] ],
     "qualities": [ { "id": "HAMMER", "level": 2 }, { "id": "SAW_M", "level": 1 }, { "id": "WRENCH", "level": 1 } ],
-    "components": [
-      [ [ "forgerig", 1 ] ],
-      [ [ "veh_tools_workshop", 1 ] ],
-      [ [ "veh_tools_kitchen", 1 ] ]
-    ]
+    "components": [ [ [ "forgerig", 1 ] ], [ [ "veh_tools_workshop", 1 ] ], [ [ "veh_tools_kitchen", 1 ] ] ]
   },
   {
     "result": "goggles_welding",


### PR DESCRIPTION
1. Gave the wasteland techno-barbarian a 2-liter metal tank to store spare fuel in and moved the lamp oil there, since starting the armor fueled up was forcing it to only spawn with the default fuel type of diesel despite being set to spawn with lamp oil.
2. Gave the wasteland drifter the baseline 1 mechanics skill needed to clean their guns.
3. Added medium and large tin cans to the recipes for can forge.
4. Added 2-liter tanks, medium cans, and large cans as tool options for making charcoal in small batches.
5. Fixed the bionic silencer profession having the cloaking CBM listed twice in the DDA version.