### PR TITLE
Update .22 aux pistol recipe and mag use

### DIFF
--- a/nocts_cata_mod_DDA/Recipe/c_recipes.json
+++ b/nocts_cata_mod_DDA/Recipe/c_recipes.json
@@ -2196,7 +2196,7 @@
       { "id": "DRILL", "level": 2 }
     ],
     "tools": [ [ [ "small_repairkit", 50 ], [ "large_repairkit", 50 ] ], [ [ "22_casing", -1 ] ] ],
-    "components": [ [ [ "sig_mosquito", 1 ], [ "sw_22", 1 ], [ "walther_p22", 1 ] ], [ [ "plastic_chunk", 1 ] ] ]
+    "components": [ [ [ "sig_mosquito", 1 ], [ "ruger_mk4", 1 ], [ "walther_p22", 1 ] ], [ [ "plastic_chunk", 1 ] ] ]
   },
   {
     "type": "recipe",

--- a/nocts_cata_mod_DDA/Weapons/c_mods.json
+++ b/nocts_cata_mod_DDA/Weapons/c_mods.json
@@ -82,7 +82,7 @@
         "holster": true,
         "max_contains_volume": "20 L",
         "max_contains_weight": "20 kg",
-        "item_restriction": [ "mosquitomag", "sw22mag", "wp22mag", "surv_22_mag" ]
+        "item_restriction": [ "mosquitomag", "ruger_mk4_mag", "wp22mag", "surv_22_mag" ]
       }
     ]
   },


### PR DESCRIPTION
Done due to https://github.com/CleverRaven/Cataclysm-DDA/pull/74417 obsoleting one of the pistols and magazines used in it, replaced with the Ruger pistol.

Side note, tempted to port that to BN someday...

Fixes https://github.com/Noctifer-de-Mortem/nocts_cata_mod/issues/627