### PR TITLE
Allow disassembling certain CBMs in BN version

### DIFF
--- a/nocts_cata_mod_BN/Recipe/c_uncraft.json
+++ b/nocts_cata_mod_BN/Recipe/c_uncraft.json
@@ -253,5 +253,91 @@
     "qualities": [ { "id": "CUT", "level": 1 } ],
     "components": [ [ [ "rag", 1 ] ] ],
     "flags": [ "BLIND_EASY" ]
+  },
+  {
+    "type": "uncraft",
+    "result": "bio_laser_armgun",
+    "skill_used": "electronics",
+    "difficulty": 8,
+    "time": "50 m",
+    "qualities": [ { "id": "SCREW_FINE", "level": 1 }, { "id": "SAW_M_FINE", "level": 1 }, { "id": "WRENCH_FINE", "level": 1 } ],
+    "components": [
+      [ [ "lens_small", 6 ] ],
+      [ [ "power_supply", 2 ] ],
+      [ [ "amplifier", 2 ] ],
+      [ [ "processor", 1 ] ],
+      [ [ "targeting_module", 1 ] ],
+      [ [ "alloy_sheet", 1 ] ],
+      [ [ "cable", 16 ] ],
+      [ [ "burnt_out_bionic", 1 ] ]
+    ]
+  },
+  {
+    "type": "uncraft",
+    "result": "bio_flamethrower",
+    "skill_used": "electronics",
+    "difficulty": 7,
+    "time": "50 m",
+    "qualities": [ { "id": "SCREW_FINE", "level": 1 }, { "id": "SAW_M_FINE", "level": 1 }, { "id": "WRENCH_FINE", "level": 1 } ],
+    "components": [
+      [ [ "element", 4 ] ],
+      [ [ "amplifier", 4 ] ],
+      [ [ "circuit", 1 ] ],
+      [ [ "motor_micro", 2 ] ],
+      [ [ "pump_complex", 2 ] ],
+      [ [ "targeting_module", 1 ] ],
+      [ [ "cable", 12 ] ],
+      [ [ "burnt_out_bionic", 1 ] ]
+    ]
+  },
+  {
+    "type": "uncraft",
+    "result": "bio_hazard_shield",
+    "skill_used": "electronics",
+    "difficulty": 9,
+    "time": "50 m",
+    "qualities": [ { "id": "SCREW_FINE", "level": 1 }, { "id": "SAW_M_FINE", "level": 1 }, { "id": "WRENCH_FINE", "level": 1 } ],
+    "components": [
+      [ [ "hose", 1 ] ],
+      [ [ "nanomaterial", 10 ] ],
+      [ [ "self_monitoring_module", 1 ] ],
+      [ [ "processor", 2 ] ],
+      [ [ "cable", 8 ] ],
+      [ [ "plastic_chunk", 2 ] ],
+      [ [ "plut_cell", 3 ] ],
+      [ [ "burnt_out_bionic", 1 ] ]
+    ]
+  },
+  {
+    "type": "uncraft",
+    "result": "bio_cutting_torch",
+    "skill_used": "electronics",
+    "difficulty": 8,
+    "time": "50 m",
+    "qualities": [ { "id": "SCREW_FINE", "level": 1 }, { "id": "SAW_M_FINE", "level": 1 }, { "id": "WRENCH_FINE", "level": 1 } ],
+    "components": [
+      [ [ "power_supply", 4 ] ],
+      [ [ "amplifier", 2 ] ],
+      [ [ "motor_micro", 1 ] ],
+      [ [ "pump_complex", 1 ] ],
+      [ [ "alloy_sheet", 1 ] ],
+      [ [ "cable", 12 ] ],
+      [ [ "burnt_out_bionic", 1 ] ]
+    ]
+  },
+  {
+    "type": "uncraft",
+    "result": "bio_power_storage_sentinel",
+    "skill_used": "electronics",
+    "difficulty": 10,
+    "time": "50 m",
+    "qualities": [ { "id": "SCREW_FINE", "level": 1 }, { "id": "SAW_M_FINE", "level": 1 }, { "id": "WRENCH_FINE", "level": 1 } ],
+    "components": [
+      [ [ "light_atomic_battery_cell_rechargeable", 1 ] ],
+      [ [ "circuit", 4 ] ],
+      [ [ "cable", 4 ] ],
+      [ [ "plut_cell", 3 ] ],
+      [ [ "burnt_out_bionic", 1 ] ]
+    ]
   }
 ]


### PR DESCRIPTION
Now that BN has craftable CBMs in addition to being able to uncraft several of them, this adds uncrafts to some of the CBMs in the BN version of Cata++, based mainly on which CBMs in vanilla can be taken apart.

Adds uncrafts for the following:
1. Laser Gatling Arm CBM. Uncraft mostly based off the vanilla uncraft for finger laser, but swaps in more of the smaller lenses in place of standard ones and adds an alloy sheet for housing of the lasers.
2. Dual-Hand Flamethrower CBM. Took the basic components of the vanilla finger lighter, doubled them up, then added a few components from the Omnitech plasma pistol's recipe, along with the standard targeting module common to ranged attack CBMs.
3. Hazard Stabilizer System CBM. Mostly blended components from the uncrafts for Climate Control and Repair Nanobots.
4. Integrated Cutting Torch CBM. Took the basic finger laser uncraft and swapped in bits from the arc welder's recipe, along with an alloy sheet for housing as common for deployable tools and the like.
5. Sentinel Power Storage CBM. Scaled up the uncrafts for power storage CBMs but swapped in a light Omnitech battery since the capacity lines up perfectly.

If I ever getting around to fleshing out the face mask CBM's uncraft to be more than a placeholder, and if fuel cell CBMs or melee bionics get recipes/uncrafts defined later on, related Cata++ bionics will likely get uncrafts specified for them later on too.