### PR TITLE
[DDA] Convert martial arts technique attack_vectors to new format

### DIFF
--- a/nocts_cata_mod_DDA/Surv_help/c_techniques.json
+++ b/nocts_cata_mod_DDA/Surv_help/c_techniques.json
@@ -27,7 +27,7 @@
       { "stat": "damage", "type": "stab", "scale": 0.5 }
     ],
     "down_dur": 1,
-    "attack_vectors": [ "WEAPON", "HAND" ]
+    "attack_vectors": [ "vector_null", "vector_punch" ]
   },
   {
     "type": "technique",
@@ -47,7 +47,7 @@
     ],
     "knockback_dist": 1,
     "stun_dur": 1,
-    "attack_vectors": [ "WEAPON", "HAND" ]
+    "attack_vectors": [ "vector_null", "vector_punch" ]
   },
   {
     "type": "technique",
@@ -69,7 +69,7 @@
     "unarmed_allowed": true,
     "melee_allowed": true,
     "disarms": true,
-    "attack_vectors": [ "WEAPON", "HAND" ]
+    "attack_vectors": [ "vector_null", "vector_punch" ]
   },
   {
     "type": "technique",
@@ -83,7 +83,7 @@
     "crit_tec": true,
     "stun_dur": 2,
     "knockback_dist": 4,
-    "attack_vectors": [ "WEAPON", "HAND" ]
+    "attack_vectors": [ "vector_null", "vector_punch" ]
   },
   {
     "type": "technique",
@@ -96,7 +96,7 @@
     "crit_tec": true,
     "down_dur": 2,
     "mult_bonuses": [ { "stat": "movecost", "scale": 0.9 } ],
-    "attack_vectors": [ "WEAPON", "HAND" ]
+    "attack_vectors": [ "vector_null", "vector_punch" ]
   },
   {
     "type": "technique",
@@ -120,7 +120,7 @@
       { "stat": "damage", "type": "cut", "scale": 1.15 },
       { "stat": "damage", "type": "stab", "scale": 1.15 }
     ],
-    "attack_vectors": [ "HAND" ]
+    "attack_vectors": [ "vector_punch" ]
   },
   {
     "type": "technique",


### PR DESCRIPTION
In https://github.com/CleverRaven/Cataclysm-DDA/pull/73064 the format for attack_vector definitions changed to allow for extra specificity/unhardcoding/etc.  This PR converts the old attack vector definitions to the new ones based on the linked PR's example with the DDA techniques.

Note: The current attack_vector definitions do not throw a startup error but will fail when actually trying to use them.

Fixes #620