### PR TITLE
BN Update: Reference Books Actually Useful

### DIFF
--- a/nocts_cata_mod_BN/Recipe/c_recipes.json
+++ b/nocts_cata_mod_BN/Recipe/c_recipes.json
@@ -92,7 +92,7 @@
     "time": "30 m",
     "batch_time_factors": [ 80, 4 ],
     "autolearn": true,
-    "book_learn": [ [ "textbook_fabrication", 2 ], [ "recipe_surv", 2 ] ],
+    "book_learn": [ [ "textbook_fabrication", 2 ], [ "recipe_surv", 2 ], [ "reference_fabrication1", 2 ] ],
     "using": [ [ "c_metal_molding_standard", 1 ], [ "steel_tiny", 2 ], [ "forging_standard", 2 ] ],
     "tools": [ [ [ "bearing", -1 ], [ "marble", -1 ] ] ]
   },
@@ -133,7 +133,7 @@
     "time": "30 m",
     "batch_time_factors": [ 80, 4 ],
     "autolearn": true,
-    "book_learn": [ [ "recipe_surv", 3 ] ],
+    "book_learn": [ [ "recipe_surv", 3 ], [ "reference_fabrication1", 3 ] ],
     "using": [ [ "c_metal_molding_standard", 1 ], [ "steel_standard", 2 ], [ "forging_standard", 8 ] ],
     "tools": [ [ [ "primitive_hammer", -1 ], [ "makeshift_hammer", -1 ] ] ]
   },
@@ -147,7 +147,7 @@
     "skills_required": [ [ "survival", 1 ] ],
     "time": "100 m",
     "autolearn": true,
-    "book_learn": [ [ "recipe_surv", 5 ] ],
+    "book_learn": [ [ "recipe_surv", 5 ], [ "reference_fabrication1", 5 ] ],
     "using": [ [ "c_metal_molding_standard", 1 ], [ "steel_standard", 10 ], [ "forging_standard", 40 ] ],
     "tools": [ [ [ "primitive_axe", -1 ], [ "copper_ax", -1 ] ] ]
   },
@@ -161,7 +161,7 @@
     "skills_required": [ [ "survival", 1 ] ],
     "time": "30 m",
     "autolearn": true,
-    "book_learn": [ [ "recipe_surv", 3 ] ],
+    "book_learn": [ [ "recipe_surv", 3 ], [ "reference_fabrication1", 3 ] ],
     "using": [ [ "c_metal_molding_standard", 1 ], [ "steel_standard", 1 ], [ "forging_standard", 4 ] ],
     "tools": [ [ [ "primitive_knife", -1 ], [ "makeshift_knife", -1 ], [ "copper_knife", -1 ] ] ]
   },
@@ -175,7 +175,7 @@
     "skills_required": [ [ "survival", 1 ] ],
     "time": "140 m",
     "autolearn": true,
-    "book_learn": [ [ "recipe_surv", 3 ] ],
+    "book_learn": [ [ "recipe_surv", 3 ], [ "reference_fabrication1", 3 ] ],
     "using": [ [ "c_metal_molding_standard", 14 ], [ "steel_standard", 14 ], [ "forging_standard", 56 ] ],
     "tools": [ [ [ "primitive_shovel", -1 ] ] ]
   },
@@ -189,7 +189,7 @@
     "skills_required": [ [ "survival", 1 ] ],
     "time": "30 m",
     "autolearn": true,
-    "book_learn": [ [ "recipe_surv", 1 ] ],
+    "book_learn": [ [ "recipe_surv", 1 ], [ "reference_fabrication1", 1 ] ],
     "using": [ [ "c_metal_molding_standard", 1 ], [ "steel_standard", 2 ], [ "forging_standard", 8 ] ],
     "tools": [ [ [ "pot_makeshift", -1 ], [ "pot_makeshift_copper", -1 ] ] ]
   },
@@ -244,7 +244,13 @@
     "skills_required": [ [ "gun", 4 ], [ "fabrication", 5 ] ],
     "time": "55 m",
     "decomp_learn": 5,
-    "book_learn": [ [ "recipe_surv", 4 ], [ "manual_luty", 5 ], [ "manual_rifle", 8 ], [ "textbook_anarch", 6 ] ],
+    "book_learn": [
+      [ "recipe_surv", 4 ],
+      [ "manual_luty", 5 ],
+      [ "manual_rifle", 8 ],
+      [ "textbook_anarch", 6 ],
+      [ "reference_fabrication1", 7 ]
+    ],
     "qualities": [
       { "id": "CUT", "level": 1 },
       { "id": "WRENCH_FINE", "level": 1 },
@@ -453,8 +459,6 @@
     ],
     "components": [ [ [ "auto_case", 1 ] ], [ [ "scrap", 2 ] ] ]
   },
-
-
   {
     "result": "fr_3006",
     "type": "recipe",
@@ -479,7 +483,6 @@
     ],
     "components": [ [ [ "auto_case", 1 ] ], [ [ "scrap", 2 ] ] ]
   },
-
   {
     "result": "fr_50",
     "type": "recipe",
@@ -1625,7 +1628,7 @@
     "skills_required": [ [ "mechanics", 4 ], [ "fabrication", 5 ] ],
     "time": "60 m",
     "decomp_learn": 3,
-    "book_learn": [ [ "recipe_surv", 5 ] ],
+    "book_learn": [ [ "recipe_surv", 5 ], [ "reference_fabrication1", 6 ] ],
     "using": [ [ "welding_standard", 10 ] ],
     "qualities": [ { "id": "HAMMER", "level": 2 }, { "id": "SAW_M", "level": 1 }, { "id": "WRENCH", "level": 1 } ],
     "components": [ [ [ "kitchen_unit", 1 ] ], [ [ "forgerig", 1 ] ], [ [ "weldrig", 1 ] ], [ [ "craftrig", 1 ] ], [ [ "chemlab", 1 ] ] ]
@@ -2321,7 +2324,9 @@
       [ "textbook_chemistry", 3 ],
       [ "recipe_labchem", 3 ],
       [ "textbook_gaswarfare", 4 ],
-      [ "atomic_survival", 4 ]
+      [ "atomic_survival", 4 ],
+      [ "reference_fabrication1", 3 ],
+      [ "reference_cooking", 4 ]
     ],
     "qualities": [ { "id": "CHEM", "level": 2 }, { "id": "PRESSURIZATION", "level": 1 } ],
     "tools": [ [ [ "electrolysis_kit", 1750 ] ] ],
@@ -2375,7 +2380,8 @@
       [ "textbook_chemistry", 3 ],
       [ "adv_chemistry", 3 ],
       [ "textbook_mechanics", 2 ],
-      [ "welding_book", 1 ]
+      [ "welding_book", 1 ],
+      [ "reference_fabrication1", 3 ]
     ],
     "qualities": [ { "id": "SCREW", "level": 1 } ],
     "tools": [ [ [ "smoxygen_tank", 12 ], [ "oxygen_tank", 12 ], [ "oxygen_cylinder", 100 ] ] ],
@@ -2498,7 +2504,7 @@
     "time": "30 m",
     "batch_time_factors": [ 80, 4 ],
     "autolearn": true,
-    "book_learn": [ [ "textbook_fabrication", 2 ], [ "recipe_surv", 2 ] ],
+    "book_learn": [ [ "textbook_fabrication", 2 ], [ "recipe_surv", 2 ], [ "reference_fabrication1", 2 ] ],
     "using": [ [ "c_metal_molding_standard", 1 ], [ "steel_tiny", 1 ], [ "forging_standard", 4 ] ],
     "tools": [ [ [ "rebar", -1 ], [ "pipe", -1 ] ] ]
   },
@@ -2513,7 +2519,7 @@
     "time": "30 m",
     "batch_time_factors": [ 80, 4 ],
     "autolearn": true,
-    "book_learn": [ [ "textbook_fabrication", 1 ], [ "recipe_surv", 1 ] ],
+    "book_learn": [ [ "textbook_fabrication", 1 ], [ "recipe_surv", 1 ], [ "reference_fabrication1", 1 ] ],
     "using": [ [ "c_metal_molding_standard", 1 ], [ "steel_tiny", 1 ], [ "forging_standard", 4 ] ],
     "tools": [ [ [ "nail", -1 ] ] ]
   },
@@ -2527,7 +2533,7 @@
     "difficulty": 3,
     "time": "30 h",
     "autolearn": true,
-    "book_learn": [ [ "textbook_fabrication", 1 ], [ "recipe_surv", 1 ] ],
+    "book_learn": [ [ "textbook_fabrication", 1 ], [ "recipe_surv", 1 ], [ "reference_fabrication1", 1 ] ],
     "using": [ [ "c_metal_molding_standard", 1 ], [ "steel_tiny", 1 ], [ "forging_standard", 4 ] ],
     "qualities": [ { "id": "CUT", "level": 1 } ]
   },
@@ -2541,7 +2547,7 @@
     "time": "120 m",
     "batch_time_factors": [ 80, 4 ],
     "autolearn": true,
-    "book_learn": [ [ "textbook_fabrication", 1 ], [ "recipe_surv", 1 ] ],
+    "book_learn": [ [ "textbook_fabrication", 1 ], [ "recipe_surv", 1 ], [ "reference_fabrication1", 1 ] ],
     "using": [ [ "c_metal_molding_standard", 1 ], [ "steel_standard", 12 ], [ "forging_standard", 48 ] ],
     "tools": [ [ [ "makeshift_crowbar", -1 ] ] ]
   },
@@ -2615,7 +2621,13 @@
     "difficulty": 5,
     "time": "30 m",
     "batch_time_factors": [ 20, 5 ],
-    "book_learn": [ [ "textbook_fabrication", 6 ], [ "recipe_augs", 5 ], [ "recipe_mil_augs", 5 ], [ "recipe_lab_elec", 4 ] ],
+    "book_learn": [
+      [ "textbook_fabrication", 6 ],
+      [ "recipe_augs", 5 ],
+      [ "recipe_mil_augs", 5 ],
+      [ "recipe_lab_elec", 4 ],
+      [ "reference_firstaid1", 6 ]
+    ],
     "tools": [ [ [ "vac_sealer", 15 ], [ "makeshift_sealer", 30 ] ] ],
     "components": [ [ [ "bag_plastic", 1 ] ], [ [ "paper", 2 ] ] ]
   },
@@ -2656,7 +2668,13 @@
     "difficulty": 6,
     "skills_required": [ [ "firstaid", 4 ], [ "cooking", 5 ], [ "melee", 2 ] ],
     "time": "15 m",
-    "book_learn": [ [ "evil_invitation", 5 ], [ "recipe_lab_elec", 6 ], [ "recipe_creepy", 6 ], [ "recipe_labchem", 7 ] ],
+    "book_learn": [
+      [ "evil_invitation", 5 ],
+      [ "recipe_lab_elec", 6 ],
+      [ "recipe_creepy", 6 ],
+      [ "recipe_labchem", 7 ],
+      [ "reference_cooking", 7 ]
+    ],
     "using": [ [ "c_resin_molding_standard", 1 ], [ "welding_standard", 10 ], [ "steel_standard", 1 ] ],
     "qualities": [ { "id": "CUT_FINE", "level": 2 } ],
     "components": [ [ [ "c_mi_go_claw_broken", 1 ] ] ]
@@ -2671,7 +2689,13 @@
     "skills_required": [ [ "cooking", 5 ], [ "gun", 2 ] ],
     "time": "5 m",
     "batch_time_factors": [ 80, 4 ],
-    "book_learn": [ [ "evil_invitation", 5 ], [ "recipe_lab_elec", 6 ], [ "recipe_creepy", 6 ], [ "recipe_labchem", 7 ] ],
+    "book_learn": [
+      [ "evil_invitation", 5 ],
+      [ "recipe_lab_elec", 6 ],
+      [ "recipe_creepy", 6 ],
+      [ "recipe_labchem", 7 ],
+      [ "reference_cooking", 7 ]
+    ],
     "using": [ [ "c_resin_molding_standard", 1 ] ],
     "tools": [ [ [ "press", -1 ] ] ]
   },
@@ -2685,7 +2709,13 @@
     "difficulty": 5,
     "skills_required": [ [ "gun", 2 ] ],
     "time": "180 m",
-    "book_learn": [ [ "evil_invitation", 4 ], [ "recipe_lab_elec", 5 ], [ "recipe_creepy", 5 ], [ "recipe_labchem", 6 ] ],
+    "book_learn": [
+      [ "evil_invitation", 4 ],
+      [ "recipe_lab_elec", 5 ],
+      [ "recipe_creepy", 5 ],
+      [ "recipe_labchem", 6 ],
+      [ "reference_cooking", 8 ]
+    ],
     "charges": 800,
     "tools": [ [ [ "press", -1 ] ] ],
     "components": [ [ [ "alien_pod_resin", 1 ] ] ]
@@ -2701,7 +2731,13 @@
     "time": "30 m",
     "batch_time_factors": [ 80, 4 ],
     "charges": 10,
-    "book_learn": [ [ "evil_invitation", 3 ], [ "recipe_lab_elec", 4 ], [ "recipe_creepy", 4 ], [ "recipe_labchem", 5 ] ],
+    "book_learn": [
+      [ "evil_invitation", 3 ],
+      [ "recipe_lab_elec", 4 ],
+      [ "recipe_creepy", 4 ],
+      [ "recipe_labchem", 5 ],
+      [ "reference_fabrication1", 5 ]
+    ],
     "using": [ [ "c_metal_molding_standard", 1 ], [ "forging_standard", 1 ] ],
     "components": [ [ [ "scrap", 1 ], [ "weights", 4, "LIST" ] ] ]
   },
@@ -2714,7 +2750,13 @@
     "difficulty": 7,
     "skills_required": [ [ "firstaid", 4 ], [ "electronics", 3 ], [ "cooking", 5 ] ],
     "time": "30 m",
-    "book_learn": [ [ "evil_invitation", 6 ], [ "recipe_lab_elec", 7 ], [ "recipe_creepy", 7 ], [ "recipe_labchem", 8 ] ],
+    "book_learn": [
+      [ "evil_invitation", 6 ],
+      [ "recipe_lab_elec", 7 ],
+      [ "recipe_creepy", 7 ],
+      [ "recipe_labchem", 8 ],
+      [ "reference_cooking", 8 ]
+    ],
     "using": [ [ "c_resin_molding_standard", 2 ], [ "soldering_standard", 20 ], [ "steel_tiny", 1 ] ],
     "qualities": [ { "id": "CUT_FINE", "level": 2 } ],
     "components": [ [ [ "c_mi_go_beam_broken", 1 ] ], [ [ "power_supply", 1 ] ], [ [ "amplifier", 1 ] ], [ [ "cable", 20 ] ] ]
@@ -2728,7 +2770,13 @@
     "difficulty": 7,
     "skills_required": [ [ "firstaid", 4 ], [ "mechanics", 3 ], [ "cooking", 5 ] ],
     "time": "60 m",
-    "book_learn": [ [ "evil_invitation", 6 ], [ "recipe_lab_elec", 7 ], [ "recipe_creepy", 7 ], [ "recipe_labchem", 8 ] ],
+    "book_learn": [
+      [ "evil_invitation", 6 ],
+      [ "recipe_lab_elec", 7 ],
+      [ "recipe_creepy", 7 ],
+      [ "recipe_labchem", 8 ],
+      [ "reference_cooking", 8 ]
+    ],
     "using": [ [ "c_resin_molding_standard", 4 ], [ "welding_standard", 40 ], [ "steel_tiny", 4 ] ],
     "qualities": [ { "id": "CUT_FINE", "level": 2 } ],
     "components": [ [ [ "c_mi_go_rifle_broken", 1 ] ], [ [ "metal_tank_little", 1 ] ], [ [ "cu_pipe", 2 ] ], [ [ "pump_complex", 1 ] ] ]
@@ -2742,7 +2790,13 @@
     "difficulty": 8,
     "skills_required": [ [ "firstaid", 4 ], [ "electronics", 3 ], [ "mechanics", 3 ], [ "cooking", 5 ] ],
     "time": "120 m",
-    "book_learn": [ [ "evil_invitation", 7 ], [ "recipe_lab_elec", 8 ], [ "recipe_creepy", 8 ], [ "recipe_labchem", 9 ] ],
+    "book_learn": [
+      [ "evil_invitation", 7 ],
+      [ "recipe_lab_elec", 8 ],
+      [ "recipe_creepy", 8 ],
+      [ "recipe_labchem", 9 ],
+      [ "reference_cooking", 9 ]
+    ],
     "using": [ [ "c_resin_molding_standard", 8 ], [ "welding_standard", 40 ], [ "steel_standard", 5 ] ],
     "qualities": [ { "id": "CUT_FINE", "level": 2 } ],
     "components": [
@@ -2765,7 +2819,13 @@
     "difficulty": 5,
     "skills_required": [ [ "firstaid", 4 ], [ "mechanics", 3 ], [ "cooking", 5 ] ],
     "time": "25 m",
-    "book_learn": [ [ "evil_invitation", 4 ], [ "recipe_lab_elec", 5 ], [ "recipe_creepy", 5 ], [ "recipe_labchem", 6 ] ],
+    "book_learn": [
+      [ "evil_invitation", 4 ],
+      [ "recipe_lab_elec", 5 ],
+      [ "recipe_creepy", 5 ],
+      [ "recipe_labchem", 6 ],
+      [ "reference_cooking", 6 ]
+    ],
     "using": [ [ "c_resin_molding_standard", 1 ], [ "welding_standard", 10 ], [ "steel_tiny", 1 ] ],
     "qualities": [ { "id": "CUT_FINE", "level": 2 } ],
     "components": [ [ [ "c_mi_go_extruder_broken", 1 ] ], [ [ "canister_empty", 1 ] ], [ [ "meat_tainted", 5 ], [ "slime_scrap", 1 ] ] ]
@@ -2779,7 +2839,13 @@
     "difficulty": 7,
     "skills_required": [ [ "firstaid", 4 ], [ "electronics", 3 ], [ "mechanics", 3 ], [ "cooking", 5 ] ],
     "time": "80 m",
-    "book_learn": [ [ "evil_invitation", 6 ], [ "recipe_lab_elec", 7 ], [ "recipe_creepy", 7 ], [ "recipe_labchem", 8 ] ],
+    "book_learn": [
+      [ "evil_invitation", 6 ],
+      [ "recipe_lab_elec", 7 ],
+      [ "recipe_creepy", 7 ],
+      [ "recipe_labchem", 8 ],
+      [ "reference_cooking", 8 ]
+    ],
     "using": [ [ "c_resin_molding_standard", 4 ], [ "welding_standard", 20 ], [ "steel_standard", 1 ] ],
     "qualities": [ { "id": "CUT_FINE", "level": 2 } ],
     "components": [
@@ -2958,7 +3024,8 @@
       [ "textbook_robots", 5 ],
       [ "book_icef", 5 ],
       [ "recipe_melee", 6 ],
-      [ "textbook_biodiesel", 6 ]
+      [ "textbook_biodiesel", 6 ],
+      [ "reference_fabrication1", 6 ]
     ],
     "using": [ [ "welding_standard", 200 ], [ "steel_standard", 10 ] ],
     "qualities": [ { "id": "SAW_M", "level": 1 }, { "id": "SCREW", "level": 1 }, { "id": "WRENCH", "level": 1 } ],
@@ -2994,7 +3061,8 @@
       [ "textbook_robots", 7 ],
       [ "book_icef", 7 ],
       [ "recipe_melee", 8 ],
-      [ "textbook_biodiesel", 8 ]
+      [ "textbook_biodiesel", 8 ],
+      [ "reference_fabrication1", 8 ]
     ],
     "using": [ [ "welding_standard", 200 ] ],
     "qualities": [ { "id": "SAW_M", "level": 1 }, { "id": "SCREW", "level": 1 }, { "id": "WRENCH", "level": 1 } ],


### PR DESCRIPTION
A lil update now that https://github.com/cataclysmbnteam/Cataclysm-BN/pull/4954 has been merged, setting the newly-updated reference books as potential booklearns for several relevant recipes in the BN version of the mod.