### PR TITLE
Adjustment to survivor gun carts

### DIFF
--- a/nocts_cata_mod_BN/Surv_help/c_item_groups.json
+++ b/nocts_cata_mod_BN/Surv_help/c_item_groups.json
@@ -942,8 +942,20 @@
     "type": "item_group",
     "subtype": "collection",
     "items": [
-      { "item": "surv_belt_762R", "prob": 60, "ammo-item": "reloaded_762_54R", "charges": [ 5, 75 ] },
-      { "item": "reloaded_762_54R", "prob": 30, "charges": [ 10, 20 ] }
+      {
+        "distribution": [
+          { "item": "surv_belt_762R", "prob": 50, "ammo-item": "762_54R", "charges": [ 5, 75 ] },
+          { "item": "surv_belt_762R", "prob": 50, "ammo-item": "bp_762_54R", "charges": [ 5, 75 ] }
+        ],
+        "prob": 60
+      },
+      {
+        "distribution": [
+          { "item": "762_54R", "prob": 50, "charges": [ 10, 20 ] },
+          { "item": "bp_762_54R", "prob": 50, "charges": [ 10, 20 ] }
+        ],
+        "prob": 30
+      }
     ]
   },
   {

--- a/nocts_cata_mod_BN/Vehicles/c_vehicles.json
+++ b/nocts_cata_mod_BN/Vehicles/c_vehicles.json
@@ -377,7 +377,7 @@
           "frame_wood_cross",
           "seat_wood",
           "turret_mount",
-          { "ammo_types": [ "reloaded_762_54R" ], "part": "surv_lmg_762R_t", "ammo": 60, "ammo_qty": [ 5, 75 ] }
+          { "ammo_types": [ "762_54R", "bp_762_54R" ], "part": "surv_lmg_762R_t", "ammo": 60, "ammo_qty": [ 5, 75 ] }
         ]
       },
       { "x": -2, "y": 1, "parts": [ "frame_wood_cross", "wheel_wood_b", "wooden_aisle_vertical" ] },

--- a/nocts_cata_mod_DDA/Surv_help/c_item_groups.json
+++ b/nocts_cata_mod_DDA/Surv_help/c_item_groups.json
@@ -340,8 +340,20 @@
     "type": "item_group",
     "subtype": "collection",
     "items": [
-      { "item": "surv_belt_762R", "prob": 60, "ammo-item": "reloaded_762_54R", "charges": [ 5, 75 ] },
-      { "item": "reloaded_762_54R", "prob": 30, "charges": [ 10, 20 ] }
+      {
+        "distribution": [
+          { "item": "surv_belt_762R", "prob": 50, "ammo-item": "reloaded_762_54R", "charges": [ 5, 75 ] },
+          { "item": "surv_belt_762R", "prob": 50, "ammo-item": "bp_762_54R", "charges": [ 5, 75 ] }
+        ],
+        "prob": 60
+      },
+      {
+        "distribution": [
+          { "item": "reloaded_762_54R", "prob": 50, "charges": [ 10, 20 ] },
+          { "item": "bp_762_54R", "prob": 50, "charges": [ 10, 20 ] }
+        ],
+        "prob": 30
+      }
     ]
   },
   {

--- a/nocts_cata_mod_DDA/Vehicles/c_vehicles.json
+++ b/nocts_cata_mod_DDA/Vehicles/c_vehicles.json
@@ -377,7 +377,7 @@
           "frame_wood#cross",
           "seat_wood",
           "turret_mount",
-          { "ammo_types": [ "reloaded_762_54R" ], "part": "turret_surv_lmg_762R", "ammo": 60, "ammo_qty": [ 5, 75 ] }
+          { "ammo_types": [ "reloaded_762_54R", "bp_762_54R" ], "part": "turret_surv_lmg_762R", "ammo": 60, "ammo_qty": [ 5, 75 ] }
         ]
       },
       {


### PR DESCRIPTION
Small update since reloaded ammo was obsoleted in BN, adding in a random choice between standard and black powder 7.62 for the survivor gun cart spawns, while also updating the DDA version accordingly.