### PR TITLE
Fix DDA version of the mod due to batteries being broken

### DIFF
--- a/nocts_cata_mod_DDA/Monsters/c_monster_drops.json
+++ b/nocts_cata_mod_DDA/Monsters/c_monster_drops.json
@@ -93,8 +93,7 @@
       { "item": "gasoline", "charges": [ 1, 2000 ], "container-item": "metal_tank_little", "prob": 15 },
       { "item": "c_hydrogen_gas", "charges": [ 1, 20 ], "container-item": "metal_tank_little", "prob": 10 },
       { "item": "plasma", "charges": [ 1, 4 ], "prob": 5 },
-      { "group": "ammo_any_batteries", "prob": 25 },
-      { "group": "ammo_atomic_batteries", "prob": 15 }
+      { "group": "ammo_any_batteries", "prob": 25 }
     ]
   },
   {
@@ -124,10 +123,9 @@
             "collection": [
               { "item": "arc_laser_rifle", "damage": [ 0, 3 ], "charges": [ 0, 2500 ] },
               {
-                "distribution": [
-                  { "item": "medium_atomic_battery_cell_rechargeable", "damage": [ 0, 1 ], "charges": [ 0, 5000 ], "prob": 50 },
-                  { "item": "medium_atomic_battery_cell", "damage": [ 0, 1 ], "charges": [ 0, 5000 ], "prob": 50 }
-                ],
+                "item": "medium_atomic_battery_cell_rechargeable",
+                "damage": [ 0, 1 ],
+                "charges": [ 0, 5000 ],
                 "prob": 25
               }
             ],
@@ -171,10 +169,9 @@
             "collection": [
               { "item": "xarm_laser_shotgun", "damage": [ 0, 3 ], "charges": [ 0, 2500 ] },
               {
-                "distribution": [
-                  { "item": "medium_atomic_battery_cell_rechargeable", "damage": [ 0, 1 ], "charges": [ 0, 5000 ], "prob": 50 },
-                  { "item": "medium_atomic_battery_cell", "damage": [ 0, 1 ], "charges": [ 0, 5000 ], "prob": 50 }
-                ],
+                "item": "medium_atomic_battery_cell_rechargeable",
+                "damage": [ 0, 1 ],
+                "charges": [ 0, 5000 ],
                 "prob": 25
               }
             ],
@@ -222,10 +219,9 @@
             "collection": [
               { "item": "mx_laser_sniper", "damage": [ 0, 3 ], "charges": [ 0, 2500 ] },
               {
-                "distribution": [
-                  { "item": "medium_atomic_battery_cell_rechargeable", "damage": [ 0, 1 ], "charges": [ 0, 5000 ], "prob": 50 },
-                  { "item": "medium_atomic_battery_cell", "damage": [ 0, 1 ], "charges": [ 0, 5000 ], "prob": 50 }
-                ],
+                "item": "medium_atomic_battery_cell_rechargeable",
+                "damage": [ 0, 1 ],
+                "charges": [ 0, 5000 ],
                 "prob": 25
               }
             ],
@@ -273,10 +269,9 @@
             "collection": [
               { "item": "krx_laser_lmg", "damage": [ 0, 3 ], "charges": [ 0, 5000 ] },
               {
-                "distribution": [
-                  { "item": "heavy_atomic_battery_cell_rechargeable", "damage": [ 0, 1 ], "charges": [ 0, 10000 ], "prob": 50 },
-                  { "item": "heavy_atomic_battery_cell", "damage": [ 0, 1 ], "charges": [ 0, 10000 ], "prob": 50 }
-                ],
+                "item": "heavy_atomic_battery_cell_rechargeable",
+                "damage": [ 0, 1 ],
+                "charges": [ 0, 10000 ],
                 "prob": 25
               }
             ],
@@ -346,11 +341,9 @@
             "collection": [
               { "item": "neo_laser_pistol", "damage": [ 0, 3 ], "charges": [ 0, 250 ] },
               {
-                "distribution": [
-                  { "item": "light_atomic_battery_cell_rechargeable", "damage": [ 0, 1 ], "charges": [ 0, 1000 ], "prob": 50 },
-                  { "item": "light_atomic_battery_cell", "damage": [ 0, 1 ], "charges": [ 0, 1000 ], "prob": 25 },
-                  { "item": "light_minus_atomic_battery_cell", "damage": [ 0, 1 ], "charges": [ 0, 500 ], "prob": 25 }
-                ],
+                "item": "light_atomic_battery_cell_rechargeable",
+                "damage": [ 0, 1 ],
+                "charges": [ 0, 1000 ],
                 "prob": 25
               }
             ],
@@ -400,11 +393,9 @@
             "collection": [
               { "item": "akro_laser_smg", "damage": [ 0, 3 ], "charges": [ 0, 500 ] },
               {
-                "distribution": [
-                  { "item": "light_atomic_battery_cell_rechargeable", "damage": [ 0, 1 ], "charges": [ 0, 1000 ], "prob": 50 },
-                  { "item": "light_atomic_battery_cell", "damage": [ 0, 1 ], "charges": [ 0, 1000 ], "prob": 25 },
-                  { "item": "light_minus_atomic_battery_cell", "damage": [ 0, 1 ], "charges": [ 0, 500 ], "prob": 25 }
-                ],
+                "item": "light_atomic_battery_cell_rechargeable",
+                "damage": [ 0, 1 ],
+                "charges": [ 0, 1000 ],
                 "prob": 25
               }
             ],

--- a/nocts_cata_mod_DDA/Npc/NC_BIO_WEAPONS.json
+++ b/nocts_cata_mod_DDA/Npc/NC_BIO_WEAPONS.json
@@ -44,12 +44,7 @@
     "subtype": "collection",
     "ammo": 100,
     "entries": [
-      {
-        "distribution": [
-          { "item": "medium_atomic_battery_cell", "prob": 50 },
-          { "item": "medium_atomic_battery_cell_rechargeable", "prob": 50 }
-        ]
-      },
+      { "item": "medium_atomic_battery_cell_rechargeable", "prob": 50 },
       { "group": "mre_full_pack" },
       { "group": "everyday_gear" },
       { "group": "drugs_soldier", "prob": 50 },

--- a/nocts_cata_mod_DDA/Npc/NC_SUPER_SOLDIERS.json
+++ b/nocts_cata_mod_DDA/Npc/NC_SUPER_SOLDIERS.json
@@ -31,19 +31,8 @@
     "entries": [
       { "item": "protein_bar_evac", "count": [ 4, 8 ] },
       { "item": "id_military" },
-      {
-        "distribution": [
-          { "item": "medium_atomic_battery_cell", "prob": 50 },
-          { "item": "medium_atomic_battery_cell_rechargeable", "prob": 50 }
-        ]
-      },
-      {
-        "distribution": [
-          { "item": "medium_atomic_battery_cell", "prob": 50 },
-          { "item": "medium_atomic_battery_cell_rechargeable", "prob": 50 }
-        ],
-        "prob": 50
-      }
+      { "item": "medium_atomic_battery_cell_rechargeable" },
+      { "item": "medium_atomic_battery_cell_rechargeable", "prob": 50 }
     ]
   },
   {
@@ -100,7 +89,7 @@
     "type": "item_group",
     "subtype": "distribution",
     "entries": [
-      { "item": "light_atomic_battery_cell", "prob": 50 },
+      { "item": "light_atomic_battery_cell_rechargeable", "prob": 50 },
       { "item": "light_atomic_battery_cell_rechargeable", "prob": 50 }
     ]
   },

--- a/nocts_cata_mod_DDA/Recipe/c_recipes.json
+++ b/nocts_cata_mod_DDA/Recipe/c_recipes.json
@@ -1059,8 +1059,6 @@
     "tools": [ [ [ "welder", 10 ], [ "welding_kit", 10 ], [ "welder_crude", 10 ], [ "soldering_iron", 10 ], [ "toolset", 10 ] ] ],
     "components": [
       [
-        [ "medium_plus_battery_cell", 1 ],
-        [ "light_plus_battery_cell", 4 ],
         [ "light_battery_cell", 6 ],
         [ "light_minus_battery_cell", 12 ]
       ],
@@ -2537,11 +2535,9 @@
     "tools": [
       [
         [ "plut_cell", -1 ],
-        [ "light_minus_atomic_battery_cell", -1 ],
-        [ "light_atomic_battery_cell", -1 ],
-        [ "medium_atomic_battery_cell", -1 ],
-        [ "heavy_atomic_battery_cell", -1 ],
-        [ "huge_atomic_battery_cell", -1 ],
+        [ "light_atomic_battery_cell_rechargeable", -1 ],
+        [ "medium_atomic_battery_cell_rechargeable", -1 ],
+        [ "heavy_atomic_battery_cell_rechargeable", -1 ],
         [ "betavoltaic", -1 ],
         [ "RTG_coffee", -1 ]
       ]

--- a/nocts_cata_mod_DDA/Surv_help/c_armor.json
+++ b/nocts_cata_mod_DDA/Surv_help/c_armor.json
@@ -439,8 +439,7 @@
         "max_contains_volume": "525 ml",
         "max_contains_weight": "5 kg",
         "holster": true,
-        "flag_restriction": [ "MAG_COMPACT" ],
-        "item_restriction": [ "light_atomic_battery_cell", "medium_atomic_battery_cell" ]
+        "flag_restriction": [ "MAG_COMPACT" ]
       },
       {
         "moves": 40,
@@ -448,8 +447,7 @@
         "max_contains_volume": "525 ml",
         "max_contains_weight": "5 kg",
         "holster": true,
-        "flag_restriction": [ "MAG_COMPACT" ],
-        "item_restriction": [ "light_atomic_battery_cell", "medium_atomic_battery_cell" ]
+        "flag_restriction": [ "MAG_COMPACT" ]
       }
     ],
     "use_action": { "type": "holster", "holster_prompt": "Stash magazine", "holster_msg": "You stash your %s" },
@@ -489,8 +487,7 @@
         "max_contains_volume": "525 ml",
         "max_contains_weight": "5 kg",
         "holster": true,
-        "flag_restriction": [ "MAG_COMPACT" ],
-        "item_restriction": [ "light_atomic_battery_cell", "medium_atomic_battery_cell" ]
+        "flag_restriction": [ "MAG_COMPACT" ]
       },
       {
         "moves": 40,
@@ -498,8 +495,7 @@
         "max_contains_volume": "525 ml",
         "max_contains_weight": "5 kg",
         "holster": true,
-        "flag_restriction": [ "MAG_COMPACT" ],
-        "item_restriction": [ "light_atomic_battery_cell", "medium_atomic_battery_cell" ]
+        "flag_restriction": [ "MAG_COMPACT" ]
       }
     ],
     "use_action": { "type": "holster", "holster_prompt": "Stash magazine", "holster_msg": "You stash your %s" },
@@ -539,8 +535,7 @@
         "max_contains_volume": "1500 ml",
         "max_contains_weight": "5 kg",
         "holster": true,
-        "flag_restriction": [ "MAG_COMPACT", "MAG_BULKY" ],
-        "item_restriction": [ "medium_atomic_battery_cell", "heavy_atomic_battery_cell" ]
+        "flag_restriction": [ "MAG_COMPACT", "MAG_BULKY" ]
       },
       {
         "moves": 40,
@@ -548,8 +543,7 @@
         "max_contains_volume": "1500 ml",
         "max_contains_weight": "5 kg",
         "holster": true,
-        "flag_restriction": [ "MAG_COMPACT", "MAG_BULKY" ],
-        "item_restriction": [ "medium_atomic_battery_cell", "heavy_atomic_battery_cell" ]
+        "flag_restriction": [ "MAG_COMPACT", "MAG_BULKY" ]
       }
     ],
     "use_action": { "type": "holster", "holster_prompt": "Stash magazine", "holster_msg": "You stash your %s" },

--- a/nocts_cata_mod_DDA/Surv_help/c_item_groups.json
+++ b/nocts_cata_mod_DDA/Surv_help/c_item_groups.json
@@ -314,28 +314,6 @@
     ]
   },
   {
-    "id": "ammo_atomic_batteries",
-    "type": "item_group",
-    "//": "This is vanilla in BN, added to DDA version so DDA will have a consistent experience.",
-    "items": [
-      { "item": "light_atomic_battery_cell", "prob": 4, "charges": [ 500, 1000 ] },
-      { "item": "light_minus_atomic_battery_cell", "prob": 3, "charges": [ 250, 500 ] },
-      { "item": "medium_atomic_battery_cell", "prob": 2, "charges": [ 2500, 5000 ] },
-      { "item": "heavy_atomic_battery_cell", "prob": 1, "charges": [ 5000, 10000 ] }
-    ]
-  },
-  {
-    "id": "ammo_atomic_batteries_full",
-    "type": "item_group",
-    "//": "This is vanilla in BN, added to DDA version so DDA will have a consistent experience.",
-    "items": [
-      { "item": "light_atomic_battery_cell", "prob": 4, "charges": 1000 },
-      { "item": "light_minus_atomic_battery_cell", "prob": 3, "charges": 500 },
-      { "item": "medium_atomic_battery_cell", "prob": 2, "charges": 5000 },
-      { "item": "heavy_atomic_battery_cell", "prob": 1, "charges": 10000 }
-    ]
-  },
-  {
     "id": "tachanka_loot",
     "type": "item_group",
     "subtype": "collection",
@@ -437,22 +415,6 @@
       { "group": "lmil_armor_collection", "prob": 20 },
       { "group": "mil_armor_collection", "prob": 10 },
       { "group": "hmil_armor_collection", "prob": 10 },
-      {
-        "item": "light_minus_atomic_battery_cell",
-        "prob": 5,
-        "charges": [ 0, 500 ],
-        "container-item": "neo_laser_pistol"
-      },
-      { "item": "light_atomic_battery_cell", "prob": 5, "charges": [ 0, 1000 ], "container-item": "akro_laser_smg" },
-      { "item": "medium_atomic_battery_cell", "prob": 5, "charges": [ 0, 5000 ], "container-item": "arc_laser_rifle" },
-      { "item": "medium_atomic_battery_cell", "prob": 5, "charges": [ 0, 5000 ], "container-item": "mx_laser_sniper" },
-      { "item": "heavy_atomic_battery_cell", "prob": 5, "charges": [ 0, 10000 ], "container-item": "krx_laser_lmg" },
-      {
-        "item": "medium_atomic_battery_cell",
-        "prob": 5,
-        "charges": [ 0, 5000 ],
-        "container-item": "xarm_laser_shotgun"
-      },
       { "item": "mk_ionic_cannon", "prob": 4, "charges": [ 0, 5 ] },
       { "item": "br_bolt_rifle_elec", "prob": 3, "charges": [ 0, 12 ] },
       { "item": "omnitech_plasma_pistol", "prob": 3, "charges": [ 0, 15 ] },

--- a/nocts_cata_mod_DDA/Surv_help/c_item_groups_vanilla.json
+++ b/nocts_cata_mod_DDA/Surv_help/c_item_groups_vanilla.json
@@ -81,8 +81,7 @@
         [ "45aux", 1 ],
         { "group": "lmil_armor_collection", "prob": 1 },
         { "group": "mil_armor_collection", "prob": 1 },
-        { "group": "hmil_armor_collection", "prob": 1 },
-        { "group": "ammo_atomic_batteries", "prob": 10 }
+        { "group": "hmil_armor_collection", "prob": 1 }
       ]
     }
   },
@@ -280,9 +279,7 @@
         [ "omnitech_weapon_ups_manual", 2 ],
         [ "blood_m", 2 ],
         [ "blood_p", 2 ],
-        [ "anesthetic_kit", 2 ],
-        { "group": "ammo_atomic_batteries", "prob": 10 },
-        { "group": "ammo_atomic_batteries_full", "prob": 5 }
+        [ "anesthetic_kit", 2 ]
       ]
     }
   },
@@ -326,8 +323,7 @@
         [ "goggles_nv_clairvoyance", 2 ],
         [ "blood_m", 1 ],
         [ "blood_p", 1 ],
-        [ "cbm_rtg_inductor", 1 ],
-        { "group": "ammo_atomic_batteries", "prob": 10 }
+        [ "cbm_rtg_inductor", 1 ]
       ]
     }
   },
@@ -642,27 +638,6 @@
     "copy-from": "cyborg_harvest",
     "subtype": "distribution",
     "extend": { "entries": [ { "group": "bionics_experimental_cataplus", "prob": 1 } ] }
-  },
-  {
-    "id": "robofac_basic_trade",
-    "copy-from": "robofac_basic_trade",
-    "type": "item_group",
-    "subtype": "distribution",
-    "extend": { "items": [ { "group": "ammo_atomic_batteries_full", "prob": 100 } ] }
-  },
-  {
-    "id": "spider",
-    "copy-from": "spider",
-    "type": "item_group",
-    "subtype": "distribution",
-    "extend": { "items": [ { "group": "ammo_atomic_batteries", "prob": 5 } ] }
-  },
-  {
-    "id": "teleport",
-    "copy-from": "teleport",
-    "type": "item_group",
-    "subtype": "distribution",
-    "extend": { "items": [ { "group": "ammo_atomic_batteries", "prob": 10 }, { "group": "ammo_atomic_batteries_full", "prob": 10 } ] }
   },
   {
     "id": "sewer",

--- a/nocts_cata_mod_DDA/Surv_help/c_tools.json
+++ b/nocts_cata_mod_DDA/Surv_help/c_tools.json
@@ -407,7 +407,8 @@
         "rigid": true,
         "max_contains_volume": "20 L",
         "max_contains_weight": "20 kg",
-        "item_restriction": [ "medium_battery_cell", "medium_plus_battery_cell", "medium_atomic_battery_cell", "medium_disposable_cell" ]
+        "flag_restriction": [ "BATTERY_MEDIUM" ],
+        "default_magazine": "medium_battery_cell"
       }
     ]
   },
@@ -439,7 +440,8 @@
         "rigid": true,
         "max_contains_volume": "20 L",
         "max_contains_weight": "20 kg",
-        "item_restriction": [ "medium_battery_cell", "medium_plus_battery_cell", "medium_atomic_battery_cell", "medium_disposable_cell" ]
+        "flag_restriction": [ "BATTERY_MEDIUM" ],
+        "default_magazine": "medium_battery_cell"
       }
     ]
   },

--- a/nocts_cata_mod_DDA/Terrain/Mapgen_Variants.json
+++ b/nocts_cata_mod_DDA/Terrain/Mapgen_Variants.json
@@ -124,7 +124,7 @@
         { "group": "lmil_armor_collection", "x": 10, "y": 9, "chance": 75, "repeat": 1 },
         { "item": "UPS_off", "x": 10, "y": 10, "chance": 75, "repeat": 1 },
         { "item": "plut_cell", "x": 10, "y": 10, "chance": 75, "repeat": 5 },
-        { "item": "medium_atomic_battery_cell", "x": 10, "y": 11, "chance": 75, "repeat": 10 },
+        { "item": "medium_atomic_battery_cell_rechargeable", "x": 10, "y": 11, "chance": 75, "repeat": 10 },
         { "item": "plasma", "x": 10, "y": 12, "chance": 75, "repeat": 2 },
         { "item": "modular_m4_carbine", "variant": "modular_m4a1", "x": 12, "y": [ 9, 11 ], "magazine": 100, "chance": 75, "repeat": 30 },
         { "item": "modular_m16_auto_rifle", "variant": "acr", "x": 12, "y": 9, "magazine": 100, "chance": 75, "repeat": 8 },

--- a/nocts_cata_mod_DDA/Terrain/Survivor_Encampments.json
+++ b/nocts_cata_mod_DDA/Terrain/Survivor_Encampments.json
@@ -296,7 +296,6 @@
       },
       "place_loot": [
         { "group": "tools_gunsmith", "x": 20, "y": [ 12, 13 ], "chance": 90, "repeat": 2 },
-        { "group": "ammo_atomic_batteries", "x": 20, "y": [ 12, 13 ], "chance": 50, "repeat": 2 },
         { "group": "tools_robotics", "x": 20, "y": [ 18, 20 ], "chance": 90, "repeat": 2 },
         { "group": "supplies_electronics", "x": 20, "y": [ 18, 20 ], "chance": 75, "repeat": 3 },
         { "item": "recipe_surv", "x": 5, "y": 11 }
@@ -816,7 +815,6 @@
         { "group": "drugs_heal_simple", "x": [ 16, 17 ], "y": 14, "chance": 50, "repeat": 6 },
         { "group": "survivor_weapons", "x": [ 16, 18 ], "y": 16, "chance": 75, "repeat": 3 },
         { "group": "ammo_reloaded", "x": [ 16, 18 ], "y": 16, "chance": 50, "repeat": 6 },
-        { "group": "mags_makeshift", "x": [ 16, 18 ], "y": 16, "chance": 50, "repeat": 6 },
         { "group": "tools_electronics", "x": 20, "y": [ 14, 16 ], "chance": 75, "repeat": 3 },
         { "group": "supplies_electronics", "x": 20, "y": [ 14, 16 ], "chance": 50, "repeat": 6 },
         { "group": "bionics_failed_bio", "x": 20, "y": [ 14, 16 ], "chance": 50, "repeat": 2 },

--- a/nocts_cata_mod_DDA/Weapons/c_magazines.json
+++ b/nocts_cata_mod_DDA/Weapons/c_magazines.json
@@ -287,28 +287,67 @@
     "looks_like": "battery",
     "flags": [ "NO_SALVAGE", "NO_UNLOAD", "RECHARGE", "MAG_COMPACT" ]
   },
+
+
   {
     "id": "light_atomic_battery_cell_rechargeable",
-    "copy-from": "light_atomic_battery_cell",
+    "//": "Can no longer streamline these with copy-from because DDA is not allowed to have nice things, they deleted the item this and medium cells used to inherit from.",
     "type": "MAGAZINE",
+    "category": "tool_magazine",
     "name": { "str": "light rechargeable plutonium cell" },
     "description": "This battery uses a thin plutonium-244 rod to stabilize multiple proprietary exotic compounds.  Designed by Omnitech for a military contract, this modified plutonium battery is rechargeable, but as it made for military purposes there is very little this is compatible with.",
-    "extend": { "flags": [ "RECHARGE", "MAG_COMPACT" ] }
+    "weight": "160 g",
+    "volume": "35 ml",
+    "price": "500 USD",
+    "price_postapoc": "4 USD",
+    "material": [ "iron", "plastic" ],
+    "symbol": "=",
+    "color": "green",
+    "ammo_type": [ "battery" ],
+    "count": 1000,
+    "capacity": 1000,
+    "looks_like": "battery",
+    "flags": [ "NO_SALVAGE", "NO_UNLOAD", "NO_RELOAD", "LEAK_DAM", "RADIOACTIVE", "BATTERY_LIGHT", "RECHARGE", "MAG_COMPACT" ],
+    "pocket_data": [ { "pocket_type": "MAGAZINE", "rigid": true, "ammo_restriction": { "battery": 1000 } } ]
   },
   {
     "id": "medium_atomic_battery_cell_rechargeable",
-    "copy-from": "medium_atomic_battery_cell",
     "type": "MAGAZINE",
-    "name": { "str": "medium rechargeable plutonium cell" },
+    "category": "tool_magazine",
+    "name": { "str": "light rechargeable plutonium cell" },
     "description": "This battery uses a thin plutonium-244 rod to stabilize multiple proprietary exotic compounds.  Designed by Omnitech for a military contract, this modified plutonium battery is rechargeable, but as it made for military purposes there is very little this is compatible with.",
-    "extend": { "flags": [ "RECHARGE", "MAG_COMPACT" ] }
+    "weight": "1000 g",
+    "volume": "525 ml",
+    "price": "1 kUSD",
+    "price_postapoc": "10 USD",
+    "material": [ "iron", "plastic" ],
+    "symbol": "=",
+    "color": "green",
+    "ammo_type": [ "battery" ],
+    "count": 5000,
+    "capacity": 5000,
+    "looks_like": "battery",
+    "flags": [ "NO_SALVAGE", "NO_UNLOAD", "NO_RELOAD", "LEAK_DAM", "RADIOACTIVE", "BATTERY_MEDIUM", "RECHARGE", "MAG_COMPACT" ],
+    "pocket_data": [ { "pocket_type": "MAGAZINE", "rigid": true, "ammo_restriction": { "battery": 5000 } } ]
   },
   {
     "id": "heavy_atomic_battery_cell_rechargeable",
-    "copy-from": "heavy_atomic_battery_cell",
     "type": "MAGAZINE",
+    "category": "tool_magazine",
     "name": { "str": "heavy rechargeable plutonium cell" },
     "description": "This battery uses a thin plutonium-244 rod to stabilize multiple proprietary exotic compounds.  Designed by Omnitech for a military contract, this modified plutonium battery is rechargeable, but as it made for military purposes there is very little this is compatible with.",
-    "extend": { "flags": [ "RECHARGE", "MAG_BULKY" ] }
+    "weight": "1600 g",
+    "volume": "1500 ml",
+    "price": "1 kUSD",
+    "price_postapoc": "15 USD",
+    "material": [ "iron", "plastic" ],
+    "symbol": "=",
+    "color": "green",
+    "ammo_type": [ "battery" ],
+    "count": 10000,
+    "capacity": 10000,
+    "looks_like": "battery",
+    "flags": [ "NO_SALVAGE", "NO_UNLOAD", "NO_RELOAD", "LEAK_DAM", "RADIOACTIVE", "BATTERY_HEAVY", "RECHARGE", "MAG_BULKY" ],
+    "pocket_data": [ { "pocket_type": "MAGAZINE", "rigid": true, "ammo_restriction": { "battery": 10000 } } ]
   }
 ]

--- a/nocts_cata_mod_DDA/Weapons/c_ranged.json
+++ b/nocts_cata_mod_DDA/Weapons/c_ranged.json
@@ -423,15 +423,7 @@
         "holster": true,
         "max_contains_volume": "20 L",
         "max_contains_weight": "20 kg",
-        "item_restriction": [
-          "light_plus_battery_cell",
-          "light_minus_battery_cell",
-          "light_battery_cell",
-          "light_atomic_battery_cell",
-          "light_minus_atomic_battery_cell",
-          "light_minus_disposable_cell",
-          "light_disposable_cell"
-        ]
+        "item_restriction": [ "light_minus_battery_cell", "light_minus_disposable_cell", "light_battery_cell", "light_cell_rechargeable" ]
       }
     ],
     "skill": "pistol",
@@ -470,7 +462,7 @@
         "holster": true,
         "max_contains_volume": "20 L",
         "max_contains_weight": "20 kg",
-        "item_restriction": [ "medium_battery_cell", "medium_plus_battery_cell", "medium_atomic_battery_cell", "medium_disposable_cell" ]
+        "item_restriction": [ "medium_battery_cell" ]
       }
     ],
     "skill": "rifle",
@@ -1023,7 +1015,7 @@
         "holster": true,
         "max_contains_volume": "20 L",
         "max_contains_weight": "20 kg",
-        "item_restriction": [ "light_minus_atomic_battery_cell", "light_atomic_battery_cell", "light_atomic_battery_cell_rechargeable" ]
+        "item_restriction": [ "light_atomic_battery_cell_rechargeable" ]
       }
     ]
   },
@@ -1109,7 +1101,7 @@
         "holster": true,
         "max_contains_volume": "20 L",
         "max_contains_weight": "20 kg",
-        "item_restriction": [ "light_atomic_battery_cell", "light_minus_atomic_battery_cell", "light_atomic_battery_cell_rechargeable" ]
+        "item_restriction": [ "light_atomic_battery_cell_rechargeable" ]
       }
     ]
   },
@@ -1197,7 +1189,7 @@
         "holster": true,
         "max_contains_volume": "20 L",
         "max_contains_weight": "20 kg",
-        "item_restriction": [ "medium_atomic_battery_cell", "medium_atomic_battery_cell_rechargeable" ]
+        "item_restriction": [ "medium_atomic_battery_cell_rechargeable" ]
       }
     ]
   },
@@ -1284,7 +1276,7 @@
         "holster": true,
         "max_contains_volume": "20 L",
         "max_contains_weight": "20 kg",
-        "item_restriction": [ "heavy_atomic_battery_cell", "heavy_atomic_battery_cell_rechargeable" ]
+        "item_restriction": [ "heavy_atomic_battery_cell_rechargeable" ]
       }
     ]
   },
@@ -1369,12 +1361,7 @@
         "holster": true,
         "max_contains_volume": "20 L",
         "max_contains_weight": "20 kg",
-        "item_restriction": [
-          "medium_atomic_battery_cell",
-          "heavy_atomic_battery_cell",
-          "medium_atomic_battery_cell_rechargeable",
-          "heavy_atomic_battery_cell_rechargeable"
-        ]
+        "item_restriction": [ "medium_atomic_battery_cell_rechargeable", "heavy_atomic_battery_cell_rechargeable" ]
       }
     ]
   },
@@ -1462,7 +1449,7 @@
         "holster": true,
         "max_contains_volume": "20 L",
         "max_contains_weight": "20 kg",
-        "item_restriction": [ "medium_atomic_battery_cell", "medium_atomic_battery_cell_rechargeable" ]
+        "item_restriction": [ "medium_atomic_battery_cell_rechargeable" ]
       }
     ]
   },


### PR DESCRIPTION
Fixes DDA version due to https://github.com/CleverRaven/Cataclysm-DDA/pull/75865 having removed nice things from DDA yet again.

Not only do Omnitech batteries have to be standalone and no longer streamlined by copy-from, but now have to fully replace the standard atomic batteries for Omnitech stuff.

Did all this for heavy ones too even though those are still in DDA because zero ability to trust those will stay.

Fixes https://github.com/Noctifer-de-Mortem/nocts_cata_mod/issues/645