### PR TITLE
Updates to minie ball ammo

### DIFF
--- a/nocts_cata_mod_BN/Recipe/c_recipes.json
+++ b/nocts_cata_mod_BN/Recipe/c_recipes.json
@@ -1546,7 +1546,9 @@
     "time": "90 s",
     "batch_time_factors": [ 60, 5 ],
     "book_learn": [ [ "manual_rifle", 3 ], [ "manual_pistol", 3 ], [ "recipe_bullets", 3 ], [ "recipe_surv", 3 ] ],
+    "autolearn": true,
     "charges": 1,
+    "reversible": true,
     "using": [ [ "bullet_forming", 20 ], [ "ammo_bullet", 15 ] ],
     "qualities": [ { "id": "CUT", "level": 1 } ],
     "components": [ [ [ "gunpowder", 5 ], [ "chem_black_powder", 8 ], [ "chem_match_head_powder", 8 ] ], [ [ "paper", 1 ] ] ]

--- a/nocts_cata_mod_BN/Weapons/c_ammo.json
+++ b/nocts_cata_mod_BN/Weapons/c_ammo.json
@@ -9,7 +9,7 @@
     "weight": "55 g",
     "price": "25 USD",
     "price_postapoc": "15 USD",
-    "proportional": { "damage": { "damage_type": "bullet", "armor_penetration": 1.25 }, "range": 4.0, "dispersion": 0.89, "recoil": 2.0 },
+    "proportional": { "damage": { "damage_type": "bullet", "armor_penetration": 1.25 }, "range": 2.0, "dispersion": 0.89, "recoil": 2.0 },
     "extend": { "effects": [ "RECYCLED" ] }
   },
   {

--- a/nocts_cata_mod_DDA/Recipe/c_recipes.json
+++ b/nocts_cata_mod_DDA/Recipe/c_recipes.json
@@ -1059,10 +1059,7 @@
     "qualities": [ { "id": "SCREW_FINE", "level": 1 }, { "id": "GLARE", "level": 1 } ],
     "tools": [ [ [ "welder", 10 ], [ "welding_kit", 10 ], [ "welder_crude", 10 ], [ "soldering_iron", 10 ], [ "toolset", 10 ] ] ],
     "components": [
-      [
-        [ "light_battery_cell", 6 ],
-        [ "light_minus_battery_cell", 12 ]
-      ],
+      [ [ "light_battery_cell", 6 ], [ "light_minus_battery_cell", 12 ] ],
       [ [ "amplifier", 2 ] ],
       [ [ "e_scrap", 1 ] ],
       [ [ "cable", 10 ] ],
@@ -1581,7 +1578,9 @@
     "time": "90 s",
     "batch_time_factors": [ 60, 5 ],
     "book_learn": [ [ "manual_rifle", 3 ], [ "manual_pistol", 3 ], [ "recipe_bullets", 3 ], [ "recipe_surv", 3 ] ],
+    "autolearn": true,
     "charges": 1,
+    "reversible": true,
     "using": [ [ "bullet_forming", 20 ], [ "ammo_bullet", 15 ] ],
     "qualities": [ { "id": "CUT", "level": 1 } ],
     "components": [ [ [ "gunpowder", 5 ], [ "chem_black_powder", 8 ] ], [ [ "paper", 1 ] ] ]

--- a/nocts_cata_mod_DDA/Weapons/c_ammo.json
+++ b/nocts_cata_mod_DDA/Weapons/c_ammo.json
@@ -10,7 +10,7 @@
     "price": "25 USD",
     "price_postapoc": "15 USD",
     "damage": { "damage_type": "bullet", "armor_penetration": 12 },
-    "proportional": { "range": 4.0, "dispersion": 0.89, "recoil": 2.0 },
+    "proportional": { "range": 2.0, "dispersion": 0.89, "recoil": 2.0 },
     "extend": { "effects": [ "RECYCLED" ] }
   },
   {


### PR DESCRIPTION
Makes minie ball recipe autolearn since unlike .36 and .44 ammo the baseline vanilla recipes for paper cartridges autolearn. Also makes it reversible.

In exchange however, toned down the range multiplier of minie ball down from 4x to 2x, since when combined with a rifled flintlock it had more range than the reality bubble.