### PR TITLE
Pending BN Update: spawn receiver cases in `auto_sears` instead of `drugdealer`

### DIFF
--- a/nocts_cata_mod_BN/Surv_help/c_item_groups.json
+++ b/nocts_cata_mod_BN/Surv_help/c_item_groups.json
@@ -973,7 +973,7 @@
     "items": [ { "item": "flamethrower_surv", "prob": 15 } ]
   },
   {
-    "id": "drugdealer",
+    "id": "auto_sears",
     "type": "item_group",
     "items": [ [ "auto_case", 50 ] ]
   },


### PR DESCRIPTION
Set aside for when https://github.com/cataclysmbnteam/Cataclysm-BN/pull/5635 is merged, swaps out the old injection of full-auto receiver cases into `drugdealer` (now being overhauled into a collection itemgroup) in favor of injecting it into `auto_sears` (which is called by drug dealer spawns and elsewhere).