### PR TITLE
Pending BN Update: new post-apoc profession

### DIFF
--- a/nocts_cata_mod_BN/Char_creation/c_scenarios.json
+++ b/nocts_cata_mod_BN/Char_creation/c_scenarios.json
@@ -68,6 +68,7 @@
       "hardened_survivor",
       "road_warrior",
       "waste_ranger",
+      "monster_hunter",
       "bionic_silencer",
       "surv_drifter",
       "surv_knight_errant",


### PR DESCRIPTION
Set aside for when https://github.com/cataclysmbnteam/Cataclysm-BN/pull/5644 is merged, adds the new post-apoc profession to the prepper household scenario since post-apoc professions in general are currently permitted in it.