### PR TITLE
Pending BN Update: reload rate fixes

### DIFF
--- a/nocts_cata_mod_BN/Weapons/c_mods.json
+++ b/nocts_cata_mod_BN/Weapons/c_mods.json
@@ -32,7 +32,7 @@
       "dispersion": 600,
       "range": 2,
       "durability": 7,
-      "reload": 4,
+      "reload": 150,
       "clip_size": 250
     },
     "min_skills": [ [ "weapon", 2 ], [ "launcher", 1 ] ],

--- a/nocts_cata_mod_BN/Weapons/c_ranged.json
+++ b/nocts_cata_mod_BN/Weapons/c_ranged.json
@@ -308,7 +308,7 @@
     "durability": 6,
     "modes": [ [ "DEFAULT", "semi", 1 ], [ "BURST", "burst", 3 ], [ "auto", "auto", 10 ] ],
     "clip_size": 100,
-    "reload": 6000,
+    "reload": 2000,
     "loudness": 20,
     "valid_mod_locations": [
       [ "accessories", 3 ],
@@ -1435,7 +1435,7 @@
     "dispersion": 450,
     "durability": 7,
     "clip_size": 1500,
-    "reload": 4,
+    "reload": 1000,
     "valid_mod_locations": [
       [ "accessories", 1 ],
       [ "grip", 1 ],

--- a/nocts_cata_mod_DDA/Weapons/c_mods.json
+++ b/nocts_cata_mod_DDA/Weapons/c_mods.json
@@ -21,7 +21,7 @@
       "dispersion": 600,
       "range": 2,
       "durability": 7,
-      "reload": 4,
+      "reload": 150,
       "clip_size": 250,
       "ammo_to_fire": 50
     },

--- a/nocts_cata_mod_DDA/Weapons/c_ranged.json
+++ b/nocts_cata_mod_DDA/Weapons/c_ranged.json
@@ -301,7 +301,7 @@
     "modes": [ [ "DEFAULT", "semi", 1 ], [ "BURST", "burst", 3 ], [ "auto", "auto", 10 ] ],
     "clip_size": 100,
     "pocket_data": [ { "pocket_type": "MAGAZINE", "ammo_restriction": { "pebble": 100 } } ],
-    "reload": 6000,
+    "reload": 2000,
     "loudness": 20,
     "valid_mod_locations": [
       [ "accessories", 3 ],
@@ -1631,7 +1631,7 @@
         }
       }
     ],
-    "reload": 4,
+    "reload": 1000,
     "valid_mod_locations": [
       [ "accessories", 1 ],
       [ "grip", 1 ],


### PR DESCRIPTION
Set aside for when https://github.com/cataclysmbnteam/Cataclysm-BN/pull/5769 is merged, updats reload rate of pneumatic LMG to be twice that of pnuematic assault rifle, and gave survivor flamethrower a fixed reload time now that reload rate won't be multiplied by number of rounds loaded.