### PR TITLE
Some updates to Post-Human Combatives

### DIFF
--- a/nocts_cata_mod_BN/Surv_help/c_martialarts.json
+++ b/nocts_cata_mod_BN/Surv_help/c_martialarts.json
@@ -129,7 +129,6 @@
         "name": "Bull Rush",
         "description": "When you get enough momentum going, they're going to feel it.\n\nMovement speed increased by 45% of strength, damage increased by 15% of strength.  Enables \"Battering Ram\" technique.\nLasts 3 turns, stacks 3 times.",
         "skill_requirements": [ { "name": "melee", "level": 4 } ],
-        "unarmed_allowed": true,
         "melee_allowed": true,
         "buff_duration": 3,
         "max_stacks": 3,
@@ -138,6 +137,21 @@
           { "stat": "damage", "type": "bash", "scaling-stat": "str", "scale": 0.15 },
           { "stat": "damage", "type": "cut", "scaling-stat": "str", "scale": 0.15 },
           { "stat": "damage", "type": "stab", "scaling-stat": "str", "scale": 0.15 }
+        ]
+      },
+      {
+        "id": "buff_mut_com_onmove2",
+        "name": "Hit and Run",
+        "description": "Get in, hit hard, get back out.\n\nMovement speed increased by 30% of strength, armor penetration increased by 20% of strength.  Enables \"Foe-Tossing Charge\" technique.\nLasts 3 turns, stacks 3 times.",
+        "skill_requirements": [ { "name": "unarmed", "level": 4 } ],
+        "unarmed_allowed": true,
+        "buff_duration": 3,
+        "max_stacks": 3,
+        "flat_bonuses": [
+          { "stat": "speed", "scaling-stat": "str", "scale": 0.45 },
+          { "stat": "arpen", "type": "bash", "scaling-stat": "str", "scale": 0.2 },
+          { "stat": "arpen", "type": "cut", "scaling-stat": "str", "scale": 0.2 },
+          { "stat": "arpen", "type": "stab", "scaling-stat": "str", "scale": 0.2 }
         ]
       }
     ],
@@ -159,7 +173,14 @@
         ]
       }
     ],
-    "techniques": [ "tec_mut_com_battering_ram", "tec_mut_com_overrun", "tec_mut_com_stampeding_strike", "tec_mut_com_feint" ],
+    "techniques": [
+      "tec_mut_com_battering_ram",
+      "tec_mut_com_foe_tossing_charge",
+      "tec_mut_com_overrun",
+      "tec_mut_com_stampeding_strike",
+      "tec_mut_com_taste_the_ground",
+      "tec_mut_com_feint"
+    ],
     "weapon_category": [
       "2H_SWORDS",
       "CLUBS",
@@ -168,7 +189,6 @@
       "FLAILS",
       "1H_HAMMERS",
       "2H_HAMMERS",
-      "1H_AXES",
       "2H_AXES",
       "HOOKED_POLES",
       "PIKES",

--- a/nocts_cata_mod_BN/Surv_help/c_techniques.json
+++ b/nocts_cata_mod_BN/Surv_help/c_techniques.json
@@ -84,6 +84,19 @@
   },
   {
     "type": "technique",
+    "id": "tec_mut_com_foe_tossing_charge",
+    "name": "Foe-Tossing Charge",
+    "messages": [ "You toss %s aside using your momentum", "<npcname>'s tosses %s aside" ],
+    "skill_requirements": [ { "name": "unarmed", "level": 6 } ],
+    "unarmed_allowed": true,
+    "melee_allowed": true,
+    "req_buffs": [ "buff_mut_com_onmove2" ],
+    "crit_tec": true,
+    "stun_dur": 3,
+    "side_switch": true
+  },
+  {
+    "type": "technique",
     "id": "tec_mut_com_overrun",
     "name": "Overrun",
     "messages": [ "You swiftly slam into and bowl over %s", "<npcname> swiftly slams into and bowls over %s" ],
@@ -100,7 +113,6 @@
     "name": "Stampeding Strike",
     "messages": [ "You bear down on %s with terrible force", "<npcname> bears down on %s with terrible force" ],
     "skill_requirements": [ { "name": "melee", "level": 7 } ],
-    "unarmed_allowed": true,
     "melee_allowed": true,
     "crit_tec": true,
     "downed_target": true,
@@ -114,6 +126,28 @@
       { "stat": "damage", "type": "bash", "scale": 1.15 },
       { "stat": "damage", "type": "cut", "scale": 1.15 },
       { "stat": "damage", "type": "stab", "scale": 1.15 }
+    ]
+  },
+  {
+    "type": "technique",
+    "id": "tec_mut_com_taste_the_ground",
+    "name": "Taste The Ground",
+    "messages": [ "You heft %s and slam them into the ground", "<npcname> hefts and slams %s" ],
+    "skill_requirements": [ { "name": "unarmed", "level": 7 } ],
+    "unarmed_allowed": true,
+    "crit_tec": true,
+    "stunned_target": true,
+    "down_dur": 3,
+    "flat_bonuses": [
+      { "stat": "arpen", "type": "bash", "scaling-stat": "str", "scale": 0.75 },
+      { "stat": "arpen", "type": "cut", "scaling-stat": "str", "scale": 0.75 },
+      { "stat": "arpen", "type": "stab", "scaling-stat": "str", "scale": 0.75 }
+    ],
+    "mult_bonuses": [
+      { "stat": "movecost", "scale": 1.25 },
+      { "stat": "damage", "type": "bash", "scale": 1.1 },
+      { "stat": "damage", "type": "cut", "scale": 1.1 },
+      { "stat": "damage", "type": "stab", "scale": 1.1 }
     ]
   },
   {

--- a/nocts_cata_mod_DDA/Surv_help/c_martialarts.json
+++ b/nocts_cata_mod_DDA/Surv_help/c_martialarts.json
@@ -139,6 +139,21 @@
           { "stat": "damage", "type": "cut", "scaling-stat": "str", "scale": 0.15 },
           { "stat": "damage", "type": "stab", "scaling-stat": "str", "scale": 0.15 }
         ]
+      },
+      {
+        "id": "buff_mut_com_onmove2",
+        "name": "Hit and Run",
+        "description": "Get in, hit hard, get back out.\n\nMovement speed increased by 30% of strength, armor penetration increased by 20% of strength.  Enables \"Foe-Tossing Charge\" technique.\nLasts 3 turns, stacks 3 times.",
+        "skill_requirements": [ { "name": "unarmed", "level": 4 } ],
+        "unarmed_allowed": true,
+        "buff_duration": 3,
+        "max_stacks": 3,
+        "flat_bonuses": [
+          { "stat": "speed", "scaling-stat": "str", "scale": 0.45 },
+          { "stat": "arpen", "type": "bash", "scaling-stat": "str", "scale": 0.2 },
+          { "stat": "arpen", "type": "cut", "scaling-stat": "str", "scale": 0.2 },
+          { "stat": "arpen", "type": "stab", "scaling-stat": "str", "scale": 0.2 }
+        ]
       }
     ],
     "onhit_buffs": [
@@ -159,7 +174,14 @@
         ]
       }
     ],
-    "techniques": [ "tec_mut_com_battering_ram", "tec_mut_com_overrun", "tec_mut_com_stampeding_strike", "tec_mut_com_feint" ],
+    "techniques": [
+      "tec_mut_com_battering_ram",
+      "tec_mut_com_foe_tossing_charge",
+      "tec_mut_com_overrun",
+      "tec_mut_com_stampeding_strike",
+      "tec_mut_com_taste_the_ground",
+      "tec_mut_com_feint"
+    ],
     "weapon_category": [ "FLAILS", "MACES", "LONG_SWORDS", "HOOKING_WEAPONRY", "POLEARMS", "GREAT_SWORDS", "GREAT_HAMMERS", "GREAT_AXES" ],
     "weapons": [
       "chainsaw_off",

--- a/nocts_cata_mod_DDA/Surv_help/c_techniques.json
+++ b/nocts_cata_mod_DDA/Surv_help/c_techniques.json
@@ -87,6 +87,19 @@
   },
   {
     "type": "technique",
+    "id": "tec_mut_com_foe_tossing_charge",
+    "name": "Foe-Tossing Charge",
+    "messages": [ "You toss %s aside using your momentum", "<npcname>'s tosses %s aside" ],
+    "skill_requirements": [ { "name": "unarmed", "level": 6 } ],
+    "unarmed_allowed": true,
+    "required_buffs_all": [ "buff_mut_com_onmove2" ],
+    "crit_tec": true,
+    "stun_dur": 3,
+    "side_switch": true,
+    "attack_vectors": [ "vector_null", "vector_punch" ]
+  },
+  {
+    "type": "technique",
     "id": "tec_mut_com_overrun",
     "name": "Overrun",
     "messages": [ "You swiftly slam into and bowl over %s", "<npcname> swiftly slams into and bowls over %s" ],
@@ -104,7 +117,6 @@
     "name": "Stampeding Strike",
     "messages": [ "You bear down on %s with terrible force", "<npcname> bears down on %s with terrible force" ],
     "skill_requirements": [ { "name": "melee", "level": 7 } ],
-    "unarmed_allowed": true,
     "melee_allowed": true,
     "crit_tec": true,
     "condition": { "npc_has_effect": "downed" },
@@ -119,6 +131,30 @@
       { "stat": "damage", "type": "bash", "scale": 1.15 },
       { "stat": "damage", "type": "cut", "scale": 1.15 },
       { "stat": "damage", "type": "stab", "scale": 1.15 }
+    ],
+    "attack_vectors": [ "vector_punch" ]
+  },
+  {
+    "type": "technique",
+    "id": "tec_mut_com_taste_the_ground",
+    "name": "Taste The Ground",
+    "messages": [ "You heft %s and slam them into the ground", "<npcname> hefts and slams %s" ],
+    "skill_requirements": [ { "name": "unarmed", "level": 7 } ],
+    "unarmed_allowed": true,
+    "crit_tec": true,
+    "condition": { "npc_has_effect": "stunned" },
+    "condition_desc": "* Only works on a <info>stunned</info> target",
+    "down_dur": 3,
+    "flat_bonuses": [
+      { "stat": "arpen", "type": "bash", "scaling-stat": "str", "scale": 0.75 },
+      { "stat": "arpen", "type": "cut", "scaling-stat": "str", "scale": 0.75 },
+      { "stat": "arpen", "type": "stab", "scaling-stat": "str", "scale": 0.75 }
+    ],
+    "mult_bonuses": [
+      { "stat": "movecost", "scale": 1.25 },
+      { "stat": "damage", "type": "bash", "scale": 1.1 },
+      { "stat": "damage", "type": "cut", "scale": 1.1 },
+      { "stat": "damage", "type": "stab", "scale": 1.1 }
     ],
     "attack_vectors": [ "vector_punch" ]
   },


### PR DESCRIPTION
Per feedback, split some of the high-damage bonuses for Post-Human Combatives so that they only apply with weapons, since unarmed weapons can often get wacky DPS when combined with these effects. Unarmed-focused counterparts focus on stunning and displacing your target instead of knockback+knockdown, and the follow-up move likewise involves piledriving a stunned target instead of squishing a downed target.

Lastly, removed one-handed axes since it's now only used by hatchets and the like. One-handed hammers stay for now since warhammers use it, though I worry that warhammers, maces, and the like may still end up being the optimal weapons for this style.