### PR TITLE
Plasma cutter updates

### DIFF
--- a/nocts_cata_mod_BN/Surv_help/c_bionics.json
+++ b/nocts_cata_mod_BN/Surv_help/c_bionics.json
@@ -257,7 +257,7 @@
     "bashing": 3,
     "flags": [ "NO_UNWIELD", "NO_DROP", "UNBREAKABLE_MELEE", "TRADER_AVOID", "USES_BIONIC_POWER" ],
     "max_charges": 1000,
-    "charges_per_use": 6,
+    "charges_per_use": 10,
     "use_action": [ "OXYTORCH" ],
     "qualities": [ [ "WELD", 2 ] ]
   },

--- a/nocts_cata_mod_BN/Surv_help/c_bionics.json
+++ b/nocts_cata_mod_BN/Surv_help/c_bionics.json
@@ -247,7 +247,7 @@
   },
   {
     "id": "bio_cutting_torch_item",
-    "sub": "oxy_torch",
+    "sub": "welder",
     "type": "TOOL",
     "name": { "str": "extended bionic cutting torch" },
     "description": "A bionic plasma cutter, deployed and taking up your hand.  Activate it to destroy metal barriers, as you would a cutting torch.",

--- a/nocts_cata_mod_DDA/Surv_help/c_bionics.json
+++ b/nocts_cata_mod_DDA/Surv_help/c_bionics.json
@@ -308,7 +308,7 @@
   },
   {
     "id": "bio_cutting_torch_item",
-    "sub": "oxy_torch",
+    "sub": "welder",
     "type": "TOOL",
     "name": { "str": "extended bionic cutting torch" },
     "description": "A bionic plasma cutter, deployed and taking up your hand.  Activate it to destroy metal barriers, as you would a cutting torch.",
@@ -318,7 +318,7 @@
     "melee_damage": { "bash": 3 },
     "flags": [ "NO_UNWIELD", "NO_DROP", "UNBREAKABLE_MELEE", "TRADER_AVOID", "USES_BIONIC_POWER" ],
     "ammo": "battery",
-    "charges_per_use": 6,
+    "charges_per_use": 20,
     "use_action": [ "OXYTORCH" ],
     "qualities": [ [ "WELD", 2 ] ]
   },


### PR DESCRIPTION
Updates BN version of plasma cutter to match the power usage of an arc welder when used to cut tools, consistent with https://github.com/cataclysmbnteam/Cataclysm-BN/pull/6206 having made 1 charge_per_use of the oxytorch worth the same 10:2 ratio seen in `welding_standard`.

Likewise tweaked DDA version a bit to match.