### PR TITLE
Update some field names and weight formats to work with DDA changes

### DIFF
--- a/nocts_cata_mod_DDA/Monsters/c_monstergroups.json
+++ b/nocts_cata_mod_DDA/Monsters/c_monstergroups.json
@@ -5,8 +5,8 @@
     "override": false,
     "auto_total": true,
     "monsters": [
-      { "monster": "mon_failed_weapon", "weight": 15, "cost_multiplier": 20, "starts": 72 },
-      { "monster": "mon_zombie_failed_weapon", "weight": 20, "cost_multiplier": 20, "starts": 336 }
+      { "monster": "mon_failed_weapon", "weight": 15, "cost_multiplier": 20, "starts": "72 hours" },
+      { "monster": "mon_zombie_failed_weapon", "weight": 20, "cost_multiplier": 20, "starts": "336 hours" }
     ]
   },
   {
@@ -15,8 +15,8 @@
     "override": false,
     "auto_total": true,
     "monsters": [
-      { "monster": "mon_failed_weapon", "weight": 20, "cost_multiplier": 20, "starts": 72 },
-      { "monster": "mon_zombie_failed_weapon", "weight": 25, "cost_multiplier": 20, "starts": 336 }
+      { "monster": "mon_failed_weapon", "weight": 20, "cost_multiplier": 20, "starts": "72 hours" },
+      { "monster": "mon_zombie_failed_weapon", "weight": 25, "cost_multiplier": 20, "starts": "336 hours" }
     ]
   },
   {
@@ -25,8 +25,8 @@
     "override": false,
     "auto_total": true,
     "monsters": [
-      { "monster": "mon_failed_weapon", "weight": 2, "cost_multiplier": 25, "starts": 168 },
-      { "monster": "mon_zombie_failed_weapon", "weight": 3, "cost_multiplier": 25, "starts": 720 }
+      { "monster": "mon_failed_weapon", "weight": 2, "cost_multiplier": 25, "starts": "168 hours" },
+      { "monster": "mon_zombie_failed_weapon", "weight": 3, "cost_multiplier": 25, "starts": "72 hours" }
     ]
   },
   {
@@ -35,8 +35,8 @@
     "override": false,
     "auto_total": true,
     "monsters": [
-      { "monster": "mon_failed_weapon", "weight": 4, "cost_multiplier": 25, "starts": 168 },
-      { "monster": "mon_zombie_failed_weapon", "weight": 6, "cost_multiplier": 25, "starts": 720 }
+      { "monster": "mon_failed_weapon", "weight": 4, "cost_multiplier": 25, "starts": "168 hours" },
+      { "monster": "mon_zombie_failed_weapon", "weight": 6, "cost_multiplier": 25, "starts": "72 hours" }
     ]
   },
   {
@@ -45,8 +45,8 @@
     "override": false,
     "auto_total": true,
     "monsters": [
-      { "monster": "mon_failed_weapon", "weight": 4, "cost_multiplier": 25, "starts": 168 },
-      { "monster": "mon_zombie_failed_weapon", "weight": 6, "cost_multiplier": 25, "starts": 720 }
+      { "monster": "mon_failed_weapon", "weight": 4, "cost_multiplier": 25, "starts": "168 hours" },
+      { "monster": "mon_zombie_failed_weapon", "weight": 6, "cost_multiplier": 25, "starts": "72 hours" }
     ]
   },
   {
@@ -55,10 +55,10 @@
     "override": false,
     "auto_total": true,
     "monsters": [
-      { "monster": "mon_failed_weapon", "weight": 2, "cost_multiplier": 50, "starts": 72 },
-      { "monster": "mon_zombie_failed_weapon", "weight": 3, "cost_multiplier": 30, "starts": 336 },
-      { "monster": "mon_zombie_bio_dormant_unarmed", "weight": 10, "cost_multiplier": 15, "starts": 336 },
-      { "monster": "mon_zombie_bio_dormant_armed", "weight": 5, "cost_multiplier": 15, "starts": 336 }
+      { "monster": "mon_failed_weapon", "weight": 2, "cost_multiplier": 50, "starts": "72 hours" },
+      { "monster": "mon_zombie_failed_weapon", "weight": 3, "cost_multiplier": 30, "starts": "336 hours" },
+      { "monster": "mon_zombie_bio_dormant_unarmed", "weight": 10, "cost_multiplier": 15, "starts": "336 hours" },
+      { "monster": "mon_zombie_bio_dormant_armed", "weight": 5, "cost_multiplier": 15, "starts": "336 hours" }
     ]
   },
   {
@@ -67,8 +67,8 @@
     "override": false,
     "auto_total": true,
     "monsters": [
-      { "monster": "mon_zombie_bio_dormant_unarmed", "weight": 20, "cost_multiplier": 15, "starts": 72 },
-      { "monster": "mon_zombie_bio_dormant_armed", "weight": 20, "cost_multiplier": 15, "starts": 72 }
+      { "monster": "mon_zombie_bio_dormant_unarmed", "weight": 20, "cost_multiplier": 15, "starts": "72 hours" },
+      { "monster": "mon_zombie_bio_dormant_armed", "weight": 20, "cost_multiplier": 15, "starts": "72 hours" }
     ]
   },
   {
@@ -77,8 +77,8 @@
     "override": false,
     "auto_total": true,
     "monsters": [
-      { "monster": "mon_zombie_bio_dormant_unarmed", "weight": 20, "cost_multiplier": 15, "starts": 168 },
-      { "monster": "mon_zombie_bio_dormant_armed", "weight": 20, "cost_multiplier": 15, "starts": 168 }
+      { "monster": "mon_zombie_bio_dormant_unarmed", "weight": 20, "cost_multiplier": 15, "starts": "168 hours" },
+      { "monster": "mon_zombie_bio_dormant_armed", "weight": 20, "cost_multiplier": 15, "starts": "168 hours" }
     ]
   },
   {
@@ -87,8 +87,8 @@
     "override": false,
     "auto_total": true,
     "monsters": [
-      { "monster": "mon_zombie_bio_dormant_unarmed", "weight": 15, "cost_multiplier": 15, "starts": 72 },
-      { "monster": "mon_zombie_bio_dormant_armed", "weight": 15, "cost_multiplier": 15, "starts": 72 }
+      { "monster": "mon_zombie_bio_dormant_unarmed", "weight": 15, "cost_multiplier": 15, "starts": "72 hours" },
+      { "monster": "mon_zombie_bio_dormant_armed", "weight": 15, "cost_multiplier": 15, "starts": "72 hours" }
     ]
   },
   {
@@ -107,8 +107,8 @@
     "override": false,
     "auto_total": true,
     "monsters": [
-      { "monster": "mon_zombie_bio_dormant_unarmed", "weight": 3, "cost_multiplier": 15, "starts": 168 },
-      { "monster": "mon_zombie_bio_dormant_armed", "weight": 2, "cost_multiplier": 15, "starts": 168 }
+      { "monster": "mon_zombie_bio_dormant_unarmed", "weight": 3, "cost_multiplier": 15, "starts": "168 hours" },
+      { "monster": "mon_zombie_bio_dormant_armed", "weight": 2, "cost_multiplier": 15, "starts": "168 hours" }
     ]
   },
   {
@@ -117,8 +117,8 @@
     "override": false,
     "auto_total": true,
     "monsters": [
-      { "monster": "mon_zombie_bio_dormant_unarmed", "weight": 3, "cost_multiplier": 15, "starts": 336 },
-      { "monster": "mon_zombie_bio_dormant_armed", "weight": 2, "cost_multiplier": 15, "starts": 336 }
+      { "monster": "mon_zombie_bio_dormant_unarmed", "weight": 3, "cost_multiplier": 15, "starts": "336 hours" },
+      { "monster": "mon_zombie_bio_dormant_armed", "weight": 2, "cost_multiplier": 15, "starts": "336 hours" }
     ]
   },
   {
@@ -127,8 +127,8 @@
     "override": false,
     "auto_total": true,
     "monsters": [
-      { "monster": "mon_zombie_bio_dormant_unarmed", "weight": 10, "cost_multiplier": 15, "starts": 336 },
-      { "monster": "mon_zombie_bio_dormant_armed", "weight": 15, "cost_multiplier": 15, "starts": 336 }
+      { "monster": "mon_zombie_bio_dormant_unarmed", "weight": 10, "cost_multiplier": 15, "starts": "336 hours" },
+      { "monster": "mon_zombie_bio_dormant_armed", "weight": 15, "cost_multiplier": 15, "starts": "336 hours" }
     ]
   },
   {
@@ -147,8 +147,8 @@
     "override": false,
     "auto_total": true,
     "monsters": [
-      { "monster": "mon_zombie_bio_dormant_unarmed", "weight": 15, "cost_multiplier": 15, "starts": 240 },
-      { "monster": "mon_zombie_bio_dormant_armed", "weight": 10, "cost_multiplier": 15, "starts": 240 }
+      { "monster": "mon_zombie_bio_dormant_unarmed", "weight": 15, "cost_multiplier": 15, "starts": "240 hours" },
+      { "monster": "mon_zombie_bio_dormant_armed", "weight": 10, "cost_multiplier": 15, "starts": "240 hours" }
     ]
   },
   {
@@ -157,8 +157,8 @@
     "override": false,
     "auto_total": true,
     "monsters": [
-      { "monster": "mon_zombie_bio_dormant_unarmed", "weight": 25, "cost_multiplier": 15, "starts": 240 },
-      { "monster": "mon_zombie_bio_dormant_armed", "weight": 25, "cost_multiplier": 15, "starts": 240 }
+      { "monster": "mon_zombie_bio_dormant_unarmed", "weight": 25, "cost_multiplier": 15, "starts": "240 hours" },
+      { "monster": "mon_zombie_bio_dormant_armed", "weight": 25, "cost_multiplier": 15, "starts": "240 hours" }
     ]
   },
   {
@@ -166,21 +166,21 @@
     "type": "monstergroup",
     "override": false,
     "auto_total": true,
-    "monsters": [ { "monster": "mon_fungus_failed_weapon", "weight": 25, "cost_multiplier": 20, "starts": 168 } ]
+    "monsters": [ { "monster": "mon_fungus_failed_weapon", "weight": 25, "cost_multiplier": 20, "starts": "168 hours" } ]
   },
   {
     "id": "GROUP_FUNGI_TOWER",
     "type": "monstergroup",
     "override": false,
     "auto_total": true,
-    "monsters": [ { "monster": "mon_fungus_failed_weapon", "weight": 25, "cost_multiplier": 20, "starts": 168 } ]
+    "monsters": [ { "monster": "mon_fungus_failed_weapon", "weight": 25, "cost_multiplier": 20, "starts": "168 hours" } ]
   },
   {
     "id": "GROUP_FUNGI_FLOWERS",
     "type": "monstergroup",
     "override": false,
     "auto_total": true,
-    "monsters": [ { "monster": "mon_fungus_failed_weapon", "weight": 25, "cost_multiplier": 20, "starts": 168 } ]
+    "monsters": [ { "monster": "mon_fungus_failed_weapon", "weight": 25, "cost_multiplier": 20, "starts": "168 hours" } ]
   },
   {
     "type": "monstergroup",

--- a/nocts_cata_mod_DDA/Surv_help/c_tools.json
+++ b/nocts_cata_mod_DDA/Surv_help/c_tools.json
@@ -562,7 +562,7 @@
     "material": [ "iron" ],
     "//": "Get a further discount in weight because we're already getting crazy poundage here.",
     "weight": "9800 g",
-    "volume": 14,
+    "volume": "1400 ml",
     "to_hit": 3,
     "melee_damage": { "bash": 16, "cut": 1 },
     "qualities": [ [ "DIG", 3 ], [ "COOK", 1 ], [ "BUTCHER", -70 ] ],

--- a/nocts_cata_mod_DDA/legacy.json
+++ b/nocts_cata_mod_DDA/legacy.json
@@ -135,8 +135,8 @@
     "description": "This is a makeshift mold made from plastic.  It could be shaped and used to craft items made of metal.",
     "price": "10 USD",
     "material": "plastic",
-    "weight": 4,
-    "volume": 15
+    "weight": "4g",
+    "volume": "15ml"
   },
   {
     "id": "encyclopedia_barter",
@@ -152,12 +152,12 @@
     "material": [ "paper" ],
     "symbol": "?",
     "color": "blue",
-    "skill": "speech",
+    "read_skill": "speech",
     "required_level": 0,
     "max_level": 10,
     "intelligence": 12,
     "time": "180 m",
-    "fun": -5
+    "read_fun": -5
   },
   {
     "id": "c_mutagen_super_soldier",
@@ -206,12 +206,12 @@
     "material": [ "paper" ],
     "symbol": "?",
     "color": "blue",
-    "skill": "mechanics",
+    "read_skill": "mechanics",
     "required_level": 0,
     "max_level": 10,
     "intelligence": 12,
     "time": "180 m",
-    "fun": -5
+    "read_fun": -5
   },
   {
     "id": "encyclopedia_fabrication_advance",
@@ -227,12 +227,12 @@
     "material": [ "paper" ],
     "symbol": "?",
     "color": "blue",
-    "skill": "fabrication",
+    "read_skill": "fabrication",
     "required_level": 0,
     "max_level": 10,
     "intelligence": 12,
     "time": "180 m",
-    "fun": -5
+    "read_fun": -5
   },
   {
     "id": "encyclopedia_archery_advance",
@@ -248,12 +248,12 @@
     "material": [ "paper" ],
     "symbol": "?",
     "color": "blue",
-    "skill": "archery",
+    "read_skill": "archery",
     "required_level": 0,
     "max_level": 10,
     "intelligence": 12,
     "time": "180 m",
-    "fun": -5
+    "read_fun": -5
   },
   {
     "id": "encyclopedia_barter_advance",
@@ -269,12 +269,12 @@
     "material": [ "paper" ],
     "symbol": "?",
     "color": "blue",
-    "skill": "speech",
+    "read_skill": "speech",
     "required_level": 0,
     "max_level": 10,
     "intelligence": 12,
     "time": "180 m",
-    "fun": -5
+    "read_fun": -5
   },
   {
     "id": "encyclopedia_bashing_advance",
@@ -290,12 +290,12 @@
     "material": [ "paper" ],
     "symbol": "?",
     "color": "blue",
-    "skill": "bashing",
+    "read_skill": "bashing",
     "required_level": 0,
     "max_level": 10,
     "intelligence": 12,
     "time": "180 m",
-    "fun": -5
+    "read_fun": -5
   },
   {
     "id": "encyclopedia_computer_advance",
@@ -311,12 +311,12 @@
     "material": [ "paper" ],
     "symbol": "?",
     "color": "blue",
-    "skill": "computer",
+    "read_skill": "computer",
     "required_level": 0,
     "max_level": 10,
     "intelligence": 12,
     "time": "180 m",
-    "fun": -5
+    "read_fun": -5
   },
   {
     "id": "encyclopedia_cooking_advance",
@@ -332,12 +332,12 @@
     "material": [ "paper" ],
     "symbol": "?",
     "color": "blue",
-    "skill": "cooking",
+    "read_skill": "cooking",
     "required_level": 0,
     "max_level": 10,
     "intelligence": 12,
     "time": "180 m",
-    "fun": -5
+    "read_fun": -5
   },
   {
     "id": "encyclopedia_cutting_advance",
@@ -353,12 +353,12 @@
     "material": [ "paper" ],
     "symbol": "?",
     "color": "blue",
-    "skill": "cutting",
+    "read_skill": "cutting",
     "required_level": 0,
     "max_level": 10,
     "intelligence": 12,
     "time": "180 m",
-    "fun": -5
+    "read_fun": -5
   },
   {
     "id": "encyclopedia_dodge_advance",
@@ -374,12 +374,12 @@
     "material": [ "paper" ],
     "symbol": "?",
     "color": "blue",
-    "skill": "dodge",
+    "read_skill": "dodge",
     "required_level": 0,
     "max_level": 10,
     "intelligence": 12,
     "time": "180 m",
-    "fun": -5
+    "read_fun": -5
   },
   {
     "id": "encyclopedia_driving_advance",
@@ -395,12 +395,12 @@
     "material": [ "paper" ],
     "symbol": "?",
     "color": "blue",
-    "skill": "driving",
+    "read_skill": "driving",
     "required_level": 0,
     "max_level": 10,
     "intelligence": 12,
     "time": "180 m",
-    "fun": -5
+    "read_fun": -5
   },
   {
     "id": "encyclopedia_electronics_advance",
@@ -416,12 +416,12 @@
     "material": [ "paper" ],
     "symbol": "?",
     "color": "blue",
-    "skill": "electronics",
+    "read_skill": "electronics",
     "required_level": 0,
     "max_level": 10,
     "intelligence": 12,
     "time": "180 m",
-    "fun": -5
+    "read_fun": -5
   },
   {
     "id": "encyclopedia_firstaid_advance",
@@ -437,12 +437,12 @@
     "material": [ "paper" ],
     "symbol": "?",
     "color": "blue",
-    "skill": "firstaid",
+    "read_skill": "firstaid",
     "required_level": 0,
     "max_level": 10,
     "intelligence": 12,
     "time": "180 m",
-    "fun": -5
+    "read_fun": -5
   },
   {
     "id": "encyclopedia_gun_advance",
@@ -458,12 +458,12 @@
     "material": [ "paper" ],
     "symbol": "?",
     "color": "blue",
-    "skill": "gun",
+    "read_skill": "gun",
     "required_level": 0,
     "max_level": 10,
     "intelligence": 12,
     "time": "180 m",
-    "fun": -5
+    "read_fun": -5
   },
   {
     "id": "encyclopedia_launcher_advance",
@@ -479,12 +479,12 @@
     "material": [ "paper" ],
     "symbol": "?",
     "color": "blue",
-    "skill": "launcher",
+    "read_skill": "launcher",
     "required_level": 0,
     "max_level": 10,
     "intelligence": 12,
     "time": "180 m",
-    "fun": -5
+    "read_fun": -5
   },
   {
     "id": "encyclopedia_melee_advance",
@@ -500,12 +500,12 @@
     "material": [ "paper" ],
     "symbol": "?",
     "color": "blue",
-    "skill": "melee",
+    "read_skill": "melee",
     "required_level": 0,
     "max_level": 10,
     "intelligence": 12,
     "time": "180 m",
-    "fun": -5
+    "read_fun": -5
   },
   {
     "id": "encyclopedia_pistol_advance",
@@ -521,12 +521,12 @@
     "material": [ "paper" ],
     "symbol": "?",
     "color": "blue",
-    "skill": "pistol",
+    "read_skill": "pistol",
     "required_level": 0,
     "max_level": 10,
     "intelligence": 12,
     "time": "180 m",
-    "fun": -5
+    "read_fun": -5
   },
   {
     "id": "encyclopedia_rifle_advance",
@@ -542,12 +542,12 @@
     "material": [ "paper" ],
     "symbol": "?",
     "color": "blue",
-    "skill": "rifle",
+    "read_skill": "rifle",
     "required_level": 0,
     "max_level": 10,
     "intelligence": 12,
     "time": "180 m",
-    "fun": -5
+    "read_fun": -5
   },
   {
     "id": "encyclopedia_shotgun_advance",
@@ -563,12 +563,12 @@
     "material": [ "paper" ],
     "symbol": "?",
     "color": "blue",
-    "skill": "shotgun",
+    "read_skill": "shotgun",
     "required_level": 0,
     "max_level": 10,
     "intelligence": 12,
     "time": "180 m",
-    "fun": -5
+    "read_fun": -5
   },
   {
     "id": "encyclopedia_smg_advance",
@@ -584,12 +584,12 @@
     "material": [ "paper" ],
     "symbol": "?",
     "color": "blue",
-    "skill": "smg",
+    "read_skill": "smg",
     "required_level": 0,
     "max_level": 10,
     "intelligence": 12,
     "time": "180 m",
-    "fun": -5
+    "read_fun": -5
   },
   {
     "id": "encyclopedia_speech_advance",
@@ -605,12 +605,12 @@
     "material": [ "paper" ],
     "symbol": "?",
     "color": "blue",
-    "skill": "speech",
+    "read_skill": "speech",
     "required_level": 0,
     "max_level": 10,
     "intelligence": 12,
     "time": "180 m",
-    "fun": -5
+    "read_fun": -5
   },
   {
     "id": "encyclopedia_stabbing_advance",
@@ -626,12 +626,12 @@
     "material": [ "paper" ],
     "symbol": "?",
     "color": "blue",
-    "skill": "stabbing",
+    "read_skill": "stabbing",
     "required_level": 0,
     "max_level": 10,
     "intelligence": 12,
     "time": "180 m",
-    "fun": -5
+    "read_fun": -5
   },
   {
     "id": "encyclopedia_survival_advance",
@@ -647,12 +647,12 @@
     "material": [ "paper" ],
     "symbol": "?",
     "color": "blue",
-    "skill": "survival",
+    "read_skill": "survival",
     "required_level": 0,
     "max_level": 10,
     "intelligence": 12,
     "time": "180 m",
-    "fun": -5
+    "read_fun": -5
   },
   {
     "id": "encyclopedia_swimming_advance",
@@ -668,12 +668,12 @@
     "material": [ "paper" ],
     "symbol": "?",
     "color": "blue",
-    "skill": "swimming",
+    "read_skill": "swimming",
     "required_level": 0,
     "max_level": 10,
     "intelligence": 12,
     "time": "180 m",
-    "fun": -5
+    "read_fun": -5
   },
   {
     "id": "encyclopedia_tailor_advance",
@@ -689,12 +689,12 @@
     "material": [ "paper" ],
     "symbol": "?",
     "color": "blue",
-    "skill": "tailor",
+    "read_skill": "tailor",
     "required_level": 0,
     "max_level": 10,
     "intelligence": 12,
     "time": "180 m",
-    "fun": -5
+    "read_fun": -5
   },
   {
     "id": "encyclopedia_throw_advance",
@@ -710,12 +710,12 @@
     "material": [ "paper" ],
     "symbol": "?",
     "color": "blue",
-    "skill": "throw",
+    "read_skill": "throw",
     "required_level": 0,
     "max_level": 10,
     "intelligence": 12,
     "time": "180 m",
-    "fun": -5
+    "read_fun": -5
   },
   {
     "id": "encyclopedia_traps_advance",
@@ -731,12 +731,12 @@
     "material": [ "paper" ],
     "symbol": "?",
     "color": "blue",
-    "skill": "traps",
+    "read_skill": "traps",
     "required_level": 0,
     "max_level": 10,
     "intelligence": 12,
     "time": "180 m",
-    "fun": -5
+    "read_fun": -5
   },
   {
     "id": "encyclopedia_unarmed_advance",
@@ -752,12 +752,12 @@
     "material": [ "paper" ],
     "symbol": "?",
     "color": "blue",
-    "skill": "unarmed",
+    "read_skill": "unarmed",
     "required_level": 0,
     "max_level": 10,
     "intelligence": 12,
     "time": "180 m",
-    "fun": -5
+    "read_fun": -5
   },
   {
     "id": "c_flesh_pistol_regen",


### PR DESCRIPTION
Hi,

This is my first time using git so please handle this with appropriate lack of respect for my competence.

Was installing the latest experimental and got a bunch of errors, I went into the files and changed the following and it stopped the errors:

The book fields "fun" and "skill" are now "read_fun" and "read_skill" as per https://github.com/CleverRaven/Cataclysm-DDA/pull/80490

The tool ammo field "ammo" is now "tool_ammo" as per https://github.com/CleverRaven/Cataclysm-DDA/pull/80490

"weight" and volume fields no longer accept int, added changed from eg 123 to "123g". I'm not 100% on what the bare numbers were supposed to represent in units, so please double check they make sense

"starts" field also no longer accepts int, I made similar changes assuming the numbers were hours.