### PR TITLE
Remove FILTHY tag from BN

### DIFF
--- a/nocts_cata_mod_BN/Char_creation/c_scenarios.json
+++ b/nocts_cata_mod_BN/Char_creation/c_scenarios.json
@@ -11,7 +11,7 @@
     "allowed_locs": [ "Bio_Weapon_Lab_l" ],
     "professions": [ "bio_weapon_a", "bio_weapon_b", "bio_weapon_g", "bio_weapon_d", "failed_weapon_scen" ],
     "traits": [ "MARTIAL_ARTS_MUT_COM", "MARTIAL_ARTS_BIOJUTSU" ],
-    "forbidden_traits": [ "GOURMAND", "PARKOUR", "SPIRITUAL", "STYLISH", "HOARDER", "NOMAD", "PACIFIST", "SQUEAMISH", "WAYFARER" ]
+    "forbidden_traits": [ "GOURMAND", "PARKOUR", "SPIRITUAL", "STYLISH", "HOARDER", "NOMAD", "PACIFIST", "WAYFARER" ]
   },
   {
     "type": "scenario",
@@ -34,7 +34,6 @@
       "NOMAD",
       "PACIFIST",
       "TABLEMANNERS",
-      "SQUEAMISH",
       "WAYFARER"
     ]
   },

--- a/nocts_cata_mod_BN/Monsters/c_monsters.json
+++ b/nocts_cata_mod_BN/Monsters/c_monsters.json
@@ -53,8 +53,7 @@
       "NO_BREATHE",
       "REVIVES",
       "PUSH_MON",
-      "PUSH_VEH",
-      "FILTHY"
+      "PUSH_VEH"
     ]
   },
   {
@@ -231,7 +230,7 @@
     "placate_triggers": [ "PLAYER_WEAK" ],
     "death_drops": "mon_fungus_failed_weapon_death_drops",
     "death_function": [ "ACID", "FUNGUS", "NORMAL" ],
-    "flags": [ "SEES", "HEARS", "SMELLS", "STUMBLES", "ELECTRIC", "ATTACKMON", "BASHES", "PUSH_MON", "PUSH_VEH", "FILTHY" ]
+    "flags": [ "SEES", "HEARS", "SMELLS", "STUMBLES", "ELECTRIC", "ATTACKMON", "BASHES", "PUSH_MON", "PUSH_VEH" ]
   },
   {
     "id": "mon_zombie_bio_dormant_unarmed",
@@ -276,7 +275,7 @@
     "death_function": [ "NORMAL" ],
     "upgrades": { "half_life": 28, "into": "mon_zombie_bio_knife" },
     "zombify_into": "mon_zombie_bio_reanimated",
-    "flags": [ "SEES", "HEARS", "SMELLS", "POISON", "NO_BREATHE", "FILTHY", "STUMBLES", "BASHES" ]
+    "flags": [ "SEES", "HEARS", "SMELLS", "POISON", "NO_BREATHE",  "STUMBLES", "BASHES" ]
   },
   {
     "id": "mon_zombie_bio_dormant_armed",
@@ -321,7 +320,7 @@
     "death_function": [ "NORMAL" ],
     "upgrades": { "half_life": 28, "into_group": "GROUP_ZOMBIE_SUPER_SOLDIER_UPGRADE" },
     "zombify_into": "mon_zombie_bio_reanimated",
-    "flags": [ "SEES", "HEARS", "SMELLS", "POISON", "NO_BREATHE", "FILTHY", "STUMBLES", "BASHES" ]
+    "flags": [ "SEES", "HEARS", "SMELLS", "POISON", "NO_BREATHE",  "STUMBLES", "BASHES" ]
   },
   {
     "id": "mon_zombie_bio_knife",
@@ -339,7 +338,7 @@
     "special_attacks": [ [ "GRAB", 10 ], [ "BIO_OP_TAKEDOWN", 30 ], [ "LUNGE", 20 ] ],
     "death_drops": "mon_zombie_bio_knife_death_drops",
     "zombify_into": "mon_zombie_bio_reanimated",
-    "flags": [ "HARDTOSHOOT", "SEES", "HEARS", "SMELLS", "POISON", "NO_BREATHE", "FILTHY", "PATH_AVOID_DANGER_1", "BLEED" ],
+    "flags": [ "HARDTOSHOOT", "SEES", "HEARS", "SMELLS", "POISON", "NO_BREATHE",  "PATH_AVOID_DANGER_1", "BLEED" ],
     "delete": { "upgrades": { "half_life": 28, "into": "mon_zombie_bio_knife" } }
   },
   {
@@ -412,7 +411,7 @@
     "death_drops": "wild_bio_infantry_rifle",
     "death_function": [ "NORMAL" ],
     "zombify_into": "mon_zombie_bio_reanimated",
-    "flags": [ "SEES", "HEARS", "SMELLS", "POISON", "NO_BREATHE", "FILTHY", "PATH_AVOID_DANGER_1" ]
+    "flags": [ "SEES", "HEARS", "SMELLS", "POISON", "NO_BREATHE",  "PATH_AVOID_DANGER_1" ]
   },
   {
     "id": "mon_zombie_bio_infantry_shotgun",
@@ -484,7 +483,7 @@
     "death_drops": "wild_bio_infantry_shotgun",
     "death_function": [ "NORMAL" ],
     "zombify_into": "mon_zombie_bio_reanimated",
-    "flags": [ "SEES", "HEARS", "SMELLS", "POISON", "NO_BREATHE", "FILTHY", "PATH_AVOID_DANGER_1" ]
+    "flags": [ "SEES", "HEARS", "SMELLS", "POISON", "NO_BREATHE",  "PATH_AVOID_DANGER_1" ]
   },
   {
     "id": "mon_zombie_bio_knight_lmg",
@@ -554,7 +553,7 @@
     "death_drops": "wild_bio_knight_lmg",
     "death_function": [ "NORMAL" ],
     "zombify_into": "mon_zombie_bio_reanimated",
-    "flags": [ "SEES", "HEARS", "SMELLS", "POISON", "NO_BREATHE", "FILTHY", "BASHES", "PUSH_MON", "PUSH_VEH", "PATH_AVOID_FIRE" ]
+    "flags": [ "SEES", "HEARS", "SMELLS", "POISON", "NO_BREATHE",  "BASHES", "PUSH_MON", "PUSH_VEH", "PATH_AVOID_FIRE" ]
   },
   {
     "id": "mon_zombie_bio_knight_lauhcher",
@@ -625,7 +624,7 @@
     "death_drops": "wild_bio_knight_launcher",
     "death_function": [ "NORMAL" ],
     "zombify_into": "mon_zombie_bio_reanimated",
-    "flags": [ "SEES", "HEARS", "SMELLS", "POISON", "NO_BREATHE", "FILTHY", "BASHES", "PUSH_MON", "PUSH_VEH", "PATH_AVOID_FIRE" ]
+    "flags": [ "SEES", "HEARS", "SMELLS", "POISON", "NO_BREATHE",  "BASHES", "PUSH_MON", "PUSH_VEH", "PATH_AVOID_FIRE" ]
   },
   {
     "id": "mon_zombie_bio_scout_sniper",
@@ -698,7 +697,7 @@
     "death_drops": "wild_bio_scout_sniper",
     "death_function": [ "NORMAL" ],
     "zombify_into": "mon_zombie_bio_reanimated",
-    "flags": [ "SEES", "HEARS", "SMELLS", "POISON", "NO_BREATHE", "FILTHY", "PATH_AVOID_DANGER_1" ]
+    "flags": [ "SEES", "HEARS", "SMELLS", "POISON", "NO_BREATHE",  "PATH_AVOID_DANGER_1" ]
   },
   {
     "id": "mon_zombie_bio_tool_pistol",
@@ -769,7 +768,7 @@
     "death_drops": "wild_bio_tool_pistol",
     "death_function": [ "NORMAL" ],
     "zombify_into": "mon_zombie_bio_reanimated",
-    "flags": [ "SEES", "HEARS", "SMELLS", "POISON", "NO_BREATHE", "FILTHY", "PATH_AVOID_DANGER_2" ]
+    "flags": [ "SEES", "HEARS", "SMELLS", "POISON", "NO_BREATHE",  "PATH_AVOID_DANGER_2" ]
   },
   {
     "id": "mon_zombie_bio_tool_smg",
@@ -840,7 +839,7 @@
     "death_drops": "wild_bio_tool_smg",
     "death_function": [ "NORMAL" ],
     "zombify_into": "mon_zombie_bio_reanimated",
-    "flags": [ "SEES", "HEARS", "SMELLS", "POISON", "NO_BREATHE", "FILTHY", "PATH_AVOID_DANGER_2" ]
+    "flags": [ "SEES", "HEARS", "SMELLS", "POISON", "NO_BREATHE",  "PATH_AVOID_DANGER_2" ]
   },
   {
     "id": "mon_zombie_bio_reanimated",
@@ -896,7 +895,6 @@
       "SMELLS",
       "POISON",
       "NO_BREATHE",
-      "FILTHY",
       "STUMBLES",
       "BASHES",
       "PATH_AVOID_DANGER_1"


### PR DESCRIPTION
See: https://github.com/cataclysmbnteam/Cataclysm-BN/pull/6363

As of the 2025-04-29 nightly, this change prevents the game from loading with nocts_cata_mod enabled