### PR TITLE
Pending BN Update: "Yeah, They Fly Now."

### DIFF
--- a/nocts_cata_mod_BN/Surv_help/c_armor.json
+++ b/nocts_cata_mod_BN/Surv_help/c_armor.json
@@ -866,12 +866,22 @@
     "extend": { "flags": [ "WATERPROOF", "RAINPROOF", "CLIMATE_CONTROL", "GAS_PROOF", "REBREATHER", "NO_TAKEOFF" ] }
   },
   {
+    "type": "mutation",
+    "id": "C_EXO_WING_FLIGHT",
+    "name": { "str": "Artificial Wings" },
+    "points": 99,
+    "valid": false,
+    "description": "Your equipment currently grants you the ability to fly.",
+    "player_display": false,
+    "flags": [ "MUTATION_FLIGHT" ]
+  },
+  {
     "id": "c_mi_go_wings_salvaged",
     "type": "TOOL_ARMOR",
     "symbol": "[",
     "color": "green",
     "name": { "str": "set of salvaged exo-wings", "str_pl": "sets of salvaged exo-wings" },
-    "description": "A harness from which jut thin, green iridescent wings, steel wires and joints meshed with thick alien nervous cords.  Salvaged using pre-cataclysm research into other living weaponry, it's been heavily altered to fit a human (or mutant) wearer.  Activating it will grant immunity to falling damage and vastly speed up movement.  It seems to recharge from sunlight, and being active will also gradually fatigue the user.",
+    "description": "A harness from which jut thin, green iridescent wings, steel wires and joints meshed with thick alien nervous cords.  Salvaged using pre-cataclysm research into other living weaponry, it's been heavily altered to fit a human (or mutant) wearer.  Activating it will grant limited flight and vastly speed up movement.  It seems to recharge from sunlight, and being active will also gradually fatigue the user.",
     "flags": [ "OVERSIZE", "STURDY", "WAIST", "COMPACT", "ONLY_ONE" ],
     "price_postapoc": "40 USD",
     "material": [ "alien_resin", "flesh", "steel" ],
@@ -894,7 +904,8 @@
           "has": "WORN",
           "condition": "ACTIVE",
           "values": [ { "value": "MOVE_COST", "multiply": -0.5 }, { "value": "BONUS_DODGE", "add": 5 } ],
-          "ench_effects": [ { "effect": "c_mi_go_wings_immunity", "intensity": 1 } ]
+          "ench_effects": [ { "effect": "c_mi_go_wings_immunity", "intensity": 1 } ],
+          "mutations": [ "C_EXO_WING_FLIGHT" ]
         }
       ],
       "recharge_scheme": [ { "type": "solar", "interval": "1 m", "rate": 1 } ]
@@ -909,7 +920,7 @@
     "copy-from": "c_mi_go_wings_salvaged",
     "type": "TOOL_ARMOR",
     "name": { "str": "set of salvaged exo-wings (on)", "str_pl": "sets of salvaged exo-wings (on)" },
-    "description": "A set of thin, green iridescent wings, steel wires and joints meshed with thick alien nervous cords.  They are currently buzzing with life, greatly speeding up movement and enhancing dodge as well as granting immunity to falling damage, in exchange for increased fatigue gain.",
+    "description": "A set of thin, green iridescent wings, steel wires and joints meshed with thick alien nervous cords.  They are currently buzzing with life, greatly speeding up movement and enhancing dodge as well as allowing you to fly, in exchange for increased fatigue gain.",
     "turns_per_charge": 75,
     "revert_to": "c_mi_go_wings_salvaged",
     "use_action": { "target": "c_mi_go_wings_salvaged", "msg": "The exo-wings go limp as they shut down.", "type": "transform" },

--- a/nocts_cata_mod_BN/Surv_help/c_armor.json
+++ b/nocts_cata_mod_BN/Surv_help/c_armor.json
@@ -866,16 +866,6 @@
     "extend": { "flags": [ "WATERPROOF", "RAINPROOF", "CLIMATE_CONTROL", "GAS_PROOF", "REBREATHER", "NO_TAKEOFF" ] }
   },
   {
-    "type": "mutation",
-    "id": "C_EXO_WING_FLIGHT",
-    "name": { "str": "Artificial Wings" },
-    "points": 99,
-    "valid": false,
-    "description": "Your equipment currently grants you the ability to fly.",
-    "player_display": false,
-    "flags": [ "MUTATION_FLIGHT" ]
-  },
-  {
     "id": "c_mi_go_wings_salvaged",
     "type": "TOOL_ARMOR",
     "symbol": "[",
@@ -904,8 +894,7 @@
           "has": "WORN",
           "condition": "ACTIVE",
           "values": [ { "value": "MOVE_COST", "multiply": -0.5 }, { "value": "BONUS_DODGE", "add": 5 } ],
-          "ench_effects": [ { "effect": "c_mi_go_wings_immunity", "intensity": 1 } ],
-          "mutations": [ "C_EXO_WING_FLIGHT" ]
+          "ench_effects": [ { "effect": "c_mi_go_wings_immunity", "intensity": 1 } ]
         }
       ],
       "recharge_scheme": [ { "type": "solar", "interval": "1 m", "rate": 1 } ]
@@ -925,7 +914,7 @@
     "revert_to": "c_mi_go_wings_salvaged",
     "use_action": { "target": "c_mi_go_wings_salvaged", "msg": "The exo-wings go limp as they shut down.", "type": "transform" },
     "encumbrance": 0,
-    "extend": { "flags": [ "NO_TAKEOFF" ] }
+    "extend": { "flags": [ "NO_TAKEOFF", "ALWAYS_ALLOWS_FLIGHT" ] }
   },
   {
     "id": "cowboy_hat_surv",

--- a/nocts_cata_mod_DDA/Surv_help/c_armor.json
+++ b/nocts_cata_mod_DDA/Surv_help/c_armor.json
@@ -814,13 +814,23 @@
     ]
   },
   {
+    "type": "mutation",
+    "id": "C_EXO_WING_FLIGHT",
+    "name": { "str": "Artificial Wings" },
+    "points": 99,
+    "valid": false,
+    "description": "Your equipment currently grants you the ability to fly.",
+    "player_display": false,
+    "flags": [ "WINGS_2", "WING_GLIDE" ]
+  },
+  {
     "id": "c_mi_go_wings_salvaged",
     "type": "ITEM",
     "subtypes": [ "TOOL", "ARMOR", "ARTIFACT" ],
     "symbol": "[",
     "color": "green",
     "name": { "str": "set of salvaged exo-wings", "str_pl": "sets of salvaged exo-wings" },
-    "description": "A harness from which jut thin, green iridescent wings, steel wires and joints meshed with thick alien nervous cords.  Salvaged using pre-cataclysm research into other living weaponry, it's been heavily altered to fit a human (or mutant) wearer.  Activating it will grant immunity to falling damage and vastly speed up movement.  It seems to recharge from sunlight, and being active will also gradually fatigue the user.",
+    "description": "A harness from which jut thin, green iridescent wings, steel wires and joints meshed with thick alien nervous cords.  Salvaged using pre-cataclysm research into other living weaponry, it's been heavily altered to fit a human (or mutant) wearer.  Activating it will grant immunity to falling damage, ability to glide, and vastly speed up movement.  It seems to recharge from sunlight, and being active will also gradually fatigue the user.",
     "flags": [ "OVERSIZE", "STURDY", "BELTED", "PADDED" ],
     "max_worn": 1,
     "price_postapoc": "40 USD",
@@ -845,7 +855,8 @@
         "has": "WORN",
         "condition": "ACTIVE",
         "values": [ { "value": "MOVE_COST", "multiply": -0.5 }, { "value": "BONUS_DODGE", "add": 5 } ],
-        "ench_effects": [ { "effect": "c_mi_go_wings_immunity", "intensity": 1 } ]
+        "ench_effects": [ { "effect": "c_mi_go_wings_immunity", "intensity": 1 } ],
+          "mutations": [ "C_EXO_WING_FLIGHT" ]
       }
     ],
     "material_thickness": 2,
@@ -857,7 +868,7 @@
     "type": "ITEM",
     "subtypes": [ "TOOL", "ARMOR" ],
     "name": { "str": "set of salvaged exo-wings (on)", "str_pl": "sets of salvaged exo-wings (on)" },
-    "description": "A set of thin, green iridescent wings, steel wires and joints meshed with thick alien nervous cords.  They are currently buzzing with life, greatly speeding up movement and enhancing dodge as well as granting immunity to falling damage, in exchange for increased fatigue gain.",
+    "description": "A set of thin, green iridescent wings, steel wires and joints meshed with thick alien nervous cords.  They are currently buzzing with life, greatly speeding up movement and enhancing dodge as well as letting you glide through the air, in exchange for increased fatigue gain.",
     "turns_per_charge": 75,
     "revert_to": "c_mi_go_wings_salvaged",
     "use_action": {


### PR DESCRIPTION
Set aside for when https://github.com/cataclysmbnteam/Cataclysm-BN/pull/6731 is merged, gives the new flight ability to a trait granted by active exo-wings. Need to figure out if it works as a static mutation or if it can only ever be activated, though.