### PR TITLE
BN UpdatE: adds "Exotic ammo types" mod to dependencies

### DIFF
--- a/nocts_cata_mod_BN/modinfo.json
+++ b/nocts_cata_mod_BN/modinfo.json
@@ -6,6 +6,6 @@
     "authors": [ "Noctifer" ],
     "description": "The unofficial expansion mod for Cataclysm: Bright Nights.\n\nThe gigantic jabberwock of a mod that adds a lot of content to the game: new items, buildings, scenarios, monsters, etc. It also reworks and adds alternatives to many things from recipes to scenarios. It also adds a pseudo-story and lore on the works.\n\nThe Bio-Weapon, Super Soldier, Commandeers, Slave Fighters and the Old World Prepper NPC factions join the world.\n\nSeek the Bio-weapons, find loot, take down new monsters and invest in skills for new craftable items.",
     "category": "content",
-    "dependencies": [ "bn" ]
+    "dependencies": [ "bn", "exotic_ammo" ]
   }
 ]


### PR DESCRIPTION
https://github.com/cataclysmbnteam/Cataclysm-BN/pull/6761 starts the process of mod-shifting some ammo types deemed too obscure for mainline, since some stuff in Cata++ spawns them plus the survivor's cowboy hat can stash some of those types the simple fix for now is to set this mod as needed by Cata++.