### PR TITLE
Remove old edit to repeating crossbow

### DIFF
--- a/nocts_cata_mod_BN/Weapons/c_ranged_override.json
+++ b/nocts_cata_mod_BN/Weapons/c_ranged_override.json
@@ -1,13 +1,5 @@
 [
   {
-    "id": "rep_crossbow",
-    "copy-from": "rep_crossbow",
-    "type": "GUN",
-    "name": { "str": "repeating crossbow" },
-    "skill": "rifle",
-    "modes": [ [ "DEFAULT", "semi", 1 ], [ "BURST", "burst", 5 ] ]
-  },
-  {
     "id": "acr",
     "copy-from": "acr",
     "name": { "str": "Remington ACR" },

--- a/nocts_cata_mod_DDA/Weapons/c_ranged_override.json
+++ b/nocts_cata_mod_DDA/Weapons/c_ranged_override.json
@@ -1,14 +1,5 @@
 [
   {
-    "id": "rep_crossbow",
-    "copy-from": "rep_crossbow",
-    "type": "ITEM",
-    "subtypes": [ "GUN" ],
-    "name": { "str": "repeating crossbow" },
-    "skill": "rifle",
-    "modes": [ [ "DEFAULT", "semi", 1 ], [ "BURST", "burst", 5 ] ]
-  },
-  {
     "id": "laser_cannon",
     "//": "Preserved here because DDA removed it and Cata++ makes some use of it.",
     "looks_like": "ar15",


### PR DESCRIPTION
It wouldn't really make it suck any less in DDA and BN has balanced crossbows a bit differently, so might be reasonable to finally retire this old edit.