### PR TITLE
Pending BN update: more use of `ALLOWS_X` flags for mutations

### DIFF
--- a/nocts_cata_mod_BN/Surv_help/c_armor.json
+++ b/nocts_cata_mod_BN/Surv_help/c_armor.json
@@ -27,7 +27,7 @@
     "material_thickness": 2,
     "use_action": { "type": "bandolier", "capacity": 50, "ammo": [ "arrow", "bolt" ], "draw_cost": 3 },
     "valid_mods": [ "resized_large" ],
-    "flags": [ "WATER_FRIENDLY", "STURDY", "BELTED" ]
+    "flags": [ "WATER_FRIENDLY", "STURDY", "BELTED", "ALLOWS_WINGS" ]
   },
   {
     "id": "surv_suit",
@@ -75,7 +75,8 @@
       "ALLOWS_NATURAL_ATTACKS",
       "WATCH",
       "NONCONDUCTIVE",
-      "ALARMCLOCK"
+      "ALARMCLOCK",
+      "ALLOWS_HOOVES"
     ]
   },
   {
@@ -124,7 +125,8 @@
       "ALLOWS_NATURAL_ATTACKS",
       "WATCH",
       "NONCONDUCTIVE",
-      "ALARMCLOCK"
+      "ALARMCLOCK",
+      "ALLOWS_HOOVES"
     ]
   },
   {
@@ -801,7 +803,17 @@
     "color": "green",
     "name": { "str": "salvaged carapace armor" },
     "description": "A second skin of alien sinew and steel support, covered in armor plates made of resin.  Salvaged using pre-cataclysm research into other living weaponry, it's been practically mutilated to fit a human (or mutant) wearer.  Activating it will reduce the suit's encumbrance, make your attacks faster, enhance strength and dexterity, protect the wearer from toxic gas, serve as a rebreather, enhance stamina and carry capacity, and provide some protection from outside temperature.  Recharges in sunlight, being active will also gradually fatigue the user and affect healthiness, plus render them more vulnerable to electric shocks.",
-    "flags": [ "OVERSIZE", "STURDY", "SKINTIGHT", "HELMET_COMPAT", "SWIM_GOGGLES", "SUN_GLASSES", "ONLY_ONE", "COMBAT_NPC_USE" ],
+    "flags": [
+      "OVERSIZE",
+      "STURDY",
+      "SKINTIGHT",
+      "HELMET_COMPAT",
+      "SWIM_GOGGLES",
+      "SUN_GLASSES",
+      "ONLY_ONE",
+      "COMBAT_NPC_USE",
+      "ALLOWS_HOOVES"
+    ],
     "price_postapoc": "80 USD",
     "material": [ "alien_resin", "flesh", "steel" ],
     "weight": "20 kg",
@@ -1032,7 +1044,7 @@
     "looks_like": "rm13_armor",
     "name": { "str": "makeshift hydraulic armor" },
     "description": "An incredibly heavy suit of steel and kevlar plates covering a network of hydraulics, driven by pieces of a stripped-down diesel engine jury-rigged to assist the wearer's movements.  When running it will increase your strength and raw speed, allowing you to fire heavy weapons unsupported, plus make it less encumbering to wear, but the motors make things warm and make stealth harder.",
-    "flags": [ "OVERSIZE", "STURDY", "OUTER", "ALLOWS_NATURAL_ATTACKS", "COMBAT_NPC_USE" ],
+    "flags": [ "OVERSIZE", "STURDY", "OUTER", "ALLOWS_NATURAL_ATTACKS", "COMBAT_NPC_USE", "ALLOWS_HOOVES" ],
     "price": "500 USD",
     "price_postapoc": "50 USD",
     "material": [ "steel", "kevlar_rigid" ],

--- a/nocts_cata_mod_BN/Surv_help/c_tools.json
+++ b/nocts_cata_mod_BN/Surv_help/c_tools.json
@@ -784,7 +784,7 @@
     "max_charges": 250,
     "use_action": { "type": "cast_spell", "spell_id": "c_topographical_scan", "no_fail": true, "level": 0 },
     "relic_data": { "recharge_scheme": [ { "type": "solar", "interval": "1 m", "rate": 1 } ] },
-    "flags": [ "BELTED", "COMPACT", "WATCH", "ALARMCLOCK", "RECHARGE", "NO_RELOAD", "NO_UNLOAD" ],
+    "flags": [ "BELTED", "COMPACT", "WATCH", "ALARMCLOCK", "RECHARGE", "NO_RELOAD", "NO_UNLOAD", "ALLOWS_NATURAL_ATTACKS", "ALLOWS_CLAWS" ],
     "covers": [ "hand_either" ],
     "encumbrance": 5,
     "coverage": 10,
@@ -1017,7 +1017,7 @@
       "ALLOWS_NATURAL_ATTACKS",
       "FIRESTARTER",
       "THERMOMETER",
-      "POWERARMOR_COMPATIBLE"
+      "POWERARMOR_COMPATIBLE", "ALLOWS_CLAWS"
     ]
   },
   {
@@ -1036,7 +1036,7 @@
     "covers": [ "hand_either" ],
     "encumbrance": 1,
     "coverage": 5,
-    "flags": [ "BELTED", "COMPACT", "FRAGILE", "ALLOWS_NATURAL_ATTACKS", "POWERARMOR_COMPATIBLE" ],
+    "flags": [ "BELTED", "COMPACT", "FRAGILE", "ALLOWS_NATURAL_ATTACKS", "POWERARMOR_COMPATIBLE", "ALLOWS_CLAWS" ],
     "use_action": "DISASSEMBLE"
   },
   {

--- a/nocts_cata_mod_BN/Weapons/c_ranged.json
+++ b/nocts_cata_mod_BN/Weapons/c_ranged.json
@@ -759,7 +759,7 @@
     "name": { "str": "makeshift greatbow" },
     "description": "A massive steel longbow made from part of a vehicle frame sawed and bent into shape.  While extremely powerful, its immense draw weight requires superhuman strength to use, plus it suffers in efficiency and accuracy.",
     "material": [ "steel" ],
-    "extend": { "flags": [ "STR_DRAW" ] },
+    "extend": { "flags": [ "STR_DRAW", "ALLOWS_WINGS" ] },
     "min_strength": 20,
     "weight": "7 kg",
     "volume": "5 L",


### PR DESCRIPTION
Set aside for when https://github.com/cataclysmbnteam/Cataclysm-BN/pull/7205 is merged, adds relevant use of new `ALLOWS_X` flags on items.