### PR TITLE
Update c_vehicle_parts.json

### DIFF
--- a/nocts_cata_mod_BN/Vehicles/c_vehicle_parts.json
+++ b/nocts_cata_mod_BN/Vehicles/c_vehicle_parts.json
@@ -111,7 +111,7 @@
       "welder",
       "water_purifier"
     ],
-    "flags": [ "OBSTACLE", "WELDRIG", "WATER_PURIFIER", "FAUCET", "CRAFTER" ],
+    "flags": [ "OBSTACLE", "WATER_PURIFIER", "FAUCET", "CRAFTER" ],
     "breaks_into": [
       { "item": "steel_lump", "count": [ 30, 40 ] },
       { "item": "steel_chunk", "count": [ 30, 40 ] },


### PR DESCRIPTION
https://github.com/cataclysmbnteam/Cataclysm-BN/pull/7225 makes `WELDRIG` no longer needed.