### PR TITLE
Pending BN update: multi-installs and other bionic flags

### DIFF
--- a/nocts_cata_mod_BN/Surv_help/c_bionics.json
+++ b/nocts_cata_mod_BN/Surv_help/c_bionics.json
@@ -164,7 +164,7 @@
     "fuel_efficiency": 0.005,
     "time": 1,
     "occupied_bodyparts": [ [ "torso", 10 ] ],
-    "flags": [ "BIONIC_TOGGLED", "BIONIC_POWER_SOURCE", "BIONIC_NPC_USABLE", "BIONIC_SHOCKPROOF" ]
+    "flags": [ "BIONIC_TOGGLED", "BIONIC_POWER_SOURCE", "BIONIC_NPC_USABLE", "BIONIC_SHOCKPROOF", "INITIALLY_ACTIVATE" ]
   },
   {
     "id": "bio_atomic_battery",
@@ -317,7 +317,7 @@
     "name": { "str": "Sentinel Power Storage" },
     "capacity": "1000 kJ",
     "description": "An experimental and rare Compact Bionics Module that increases your power capacity by 1000 kJ.",
-    "flags": [ "BIONIC_NPC_USABLE" ]
+    "flags": [ "BIONIC_NPC_USABLE", "MULTIINSTALL" ]
   },
   {
     "id": "bio_power_storage_sentinel",

--- a/nocts_cata_mod_DDA/Surv_help/c_bionics.json
+++ b/nocts_cata_mod_DDA/Surv_help/c_bionics.json
@@ -401,6 +401,7 @@
     "type": "bionic",
     "name": { "str": "Sentinel Power Storage" },
     "capacity": "1000 kJ",
+    "dupes_allowed": true,
     "description": "An experimental and rare Compact Bionics Module that increases your power capacity by 1000 kJ.",
     "flags": [ "BIONIC_NPC_USABLE" ]
   },


### PR DESCRIPTION
Set aside for when https://github.com/cataclysmbnteam/Cataclysm-BN/pull/7369 is merged, sets atomic battery to auto-activate in BN version and lets you install multiple sentinel batteries in both versions.