### PR TITLE
Pending BN Update: chargen bionics

### DIFF
--- a/nocts_cata_mod_BN/Char_creation/c_scenarios.json
+++ b/nocts_cata_mod_BN/Char_creation/c_scenarios.json
@@ -11,7 +11,18 @@
     "allowed_locs": [ "Bio_Weapon_Lab_l" ],
     "professions": [ "bio_weapon_a", "bio_weapon_b", "bio_weapon_g", "bio_weapon_d", "failed_weapon_scen" ],
     "traits": [ "MARTIAL_ARTS_MUT_COM", "MARTIAL_ARTS_BIOJUTSU" ],
-    "forbidden_traits": [ "GOURMAND", "PARKOUR", "SPIRITUAL", "STYLISH", "HOARDER", "NOMAD", "PACIFIST", "WAYFARER" ]
+    "forbidden_traits": [ "GOURMAND", "PARKOUR", "SPIRITUAL", "STYLISH", "HOARDER", "NOMAD", "PACIFIST", "WAYFARER" ],
+    "bionics": [
+      "bio_laser_armgun",
+      "bio_sword",
+      "bio_flamethrower",
+      "bio_plasma_cell",
+      "bio_atomic_battery",
+      "bio_hazard_shield",
+      "bio_cutting_torch",
+      "bio_animal_empathy",
+      "bio_power_storage_sentinel"
+    ]
   },
   {
     "type": "scenario",
@@ -25,7 +36,18 @@
     "allowed_locs": [ "sloc_forest", "sloc_field" ],
     "professions": [ "mycus_weapon" ],
     "traits": [ "MARTIAL_ARTS_MUT_COM", "MARTIAL_ARTS_BIOJUTSU" ],
-    "forbidden_traits": [ "GOURMAND", "PARKOUR", "SPIRITUAL", "STYLISH", "HOARDER", "NOMAD", "PACIFIST", "TABLEMANNERS", "WAYFARER" ]
+    "forbidden_traits": [ "GOURMAND", "PARKOUR", "SPIRITUAL", "STYLISH", "HOARDER", "NOMAD", "PACIFIST", "TABLEMANNERS", "WAYFARER" ],
+    "bionics": [
+      "bio_laser_armgun",
+      "bio_sword",
+      "bio_flamethrower",
+      "bio_plasma_cell",
+      "bio_atomic_battery",
+      "bio_hazard_shield",
+      "bio_cutting_torch",
+      "bio_animal_empathy",
+      "bio_power_storage_sentinel"
+    ]
   },
   {
     "type": "scenario",
@@ -116,7 +138,8 @@
       "LARGE",
       "MARTIAL_ARTS_MUT_COM"
     ],
-    "professions": [ "sf_blade", "sf_claw", "sf_shock", "sf_weapon" ]
+    "professions": [ "sf_blade", "sf_claw", "sf_shock", "sf_weapon" ],
+    "bionics": [ "bio_laser_armgun", "bio_sword", "bio_flamethrower", "bio_hazard_shield" ]
   },
   {
     "type": "scenario",
@@ -145,7 +168,18 @@
       "bio_knight",
       "bio_tool"
     ],
-    "traits": [ "MARTIAL_ARTS_BIOJUTSU" ]
+    "traits": [ "MARTIAL_ARTS_BIOJUTSU" ],
+    "bionics": [
+      "bio_laser_armgun",
+      "bio_sword",
+      "bio_flamethrower",
+      "bio_plasma_cell",
+      "bio_atomic_battery",
+      "bio_hazard_shield",
+      "bio_cutting_torch",
+      "bio_animal_empathy",
+      "bio_power_storage_sentinel"
+    ]
   },
   {
     "copy-from": "alone",
@@ -199,7 +233,11 @@
     "copy-from": "cyberpunk",
     "type": "scenario",
     "id": "cyberpunk",
-    "extend": { "traits": [ "MARTIAL_ARTS_BIOJUTSU" ], "professions": [ "bionic_silencer" ] }
+    "extend": {
+      "traits": [ "MARTIAL_ARTS_BIOJUTSU" ],
+      "professions": [ "bionic_silencer" ],
+      "bionics": [ "bio_flamethrower", "bio_atomic_battery", "bio_hazard_shield", "bio_cutting_torch", "bio_animal_empathy" ]
+    }
   },
   {
     "copy-from": "wilderness",
@@ -236,7 +274,20 @@
     "copy-from": "lab_staff",
     "type": "scenario",
     "id": "lab_staff",
-    "extend": { "professions": [ "bio_infantry", "bio_scout", "bio_knight", "bio_tool", "bionic_silencer" ] }
+    "extend": {
+      "professions": [ "bio_infantry", "bio_scout", "bio_knight", "bio_tool", "bionic_silencer" ],
+      "bionics": [
+        "bio_laser_armgun",
+        "bio_sword",
+        "bio_flamethrower",
+        "bio_plasma_cell",
+        "bio_atomic_battery",
+        "bio_hazard_shield",
+        "bio_cutting_torch",
+        "bio_animal_empathy",
+        "bio_power_storage_sentinel"
+      ]
+    }
   },
   {
     "copy-from": "heli_crash",

--- a/nocts_cata_mod_BN/Surv_help/c_bionics.json
+++ b/nocts_cata_mod_BN/Surv_help/c_bionics.json
@@ -29,7 +29,8 @@
     "act_cost": "40 kJ",
     "fake_item": "bio_laser_minigun",
     "description": "Your left arm has been outfitted with a complex array of rotating laser projectors.  Or in layman's terms, a laser gatling gun!  You may use your energy banks to fire a barrage of lasers.",
-    "flags": [ "BIONIC_GUN", "BIONIC_NPC_USABLE" ]
+    "flags": [ "BIONIC_GUN", "BIONIC_NPC_USABLE" ],
+    "points": 4
   },
   {
     "id": "bio_laser_armgun",
@@ -66,7 +67,8 @@
     "act_cost": "150 J",
     "fake_item": "bio_sword_weapon",
     "description": "A deadly yard-long blade made of advanced material now resides inside your forearm, capable of being extended through the back of your wrist at the cost of a small amount of power.  Though exceptionally sharp, it will prevent you from holding anything else while extended.",
-    "flags": [ "BIONIC_TOGGLED", "BIONIC_WEAPON", "BIONIC_NPC_USABLE" ]
+    "flags": [ "BIONIC_TOGGLED", "BIONIC_WEAPON", "BIONIC_NPC_USABLE" ],
+    "points": 3
   },
   {
     "id": "bio_sword",
@@ -106,7 +108,8 @@
     "act_cost": "50 kJ",
     "fake_item": "bio_flamethrower_gun",
     "description": "Implanted in the palms of your hands lie a compact flamethrower system that uses bionic power and oxygen in the air as ignition, use as any other gun.",
-    "flags": [ "BIONIC_GUN", "BIONIC_NPC_USABLE" ]
+    "flags": [ "BIONIC_GUN", "BIONIC_NPC_USABLE" ],
+    "points": 2
   },
   {
     "id": "bio_flamethrower",
@@ -129,7 +132,8 @@
     "fuel_efficiency": 0.5,
     "exothermic_power_gen": true,
     "time": 1,
-    "flags": [ "BIONIC_TOGGLED", "BIONIC_POWER_SOURCE", "BIONIC_NPC_USABLE" ]
+    "flags": [ "BIONIC_TOGGLED", "BIONIC_POWER_SOURCE", "BIONIC_NPC_USABLE" ],
+    "points": 2
   },
   {
     "id": "bio_plasma_cell",
@@ -164,7 +168,8 @@
     "fuel_efficiency": 0.005,
     "time": 1,
     "occupied_bodyparts": [ [ "torso", 10 ] ],
-    "flags": [ "BIONIC_TOGGLED", "BIONIC_POWER_SOURCE", "BIONIC_NPC_USABLE", "BIONIC_SHOCKPROOF", "INITIALLY_ACTIVATE" ]
+    "flags": [ "BIONIC_TOGGLED", "BIONIC_POWER_SOURCE", "BIONIC_NPC_USABLE", "BIONIC_SHOCKPROOF", "INITIALLY_ACTIVATE" ],
+    "points": 2
   },
   {
     "id": "bio_atomic_battery",
@@ -207,7 +212,8 @@
     "enchantments": [ "C_ENCH_HAZARD_SHIELD" ],
     "act_cost": "1 kJ",
     "react_cost": "1 kJ",
-    "time": 1
+    "time": 1,
+    "points": 1
   },
   {
     "type": "enchantment",
@@ -233,7 +239,8 @@
     "occupied_bodyparts": [ [ "arm_r", 5 ] ],
     "act_cost": "50 J",
     "fake_item": "bio_cutting_torch_item",
-    "flags": [ "BIONIC_TOGGLED", "BIONIC_WEAPON" ]
+    "flags": [ "BIONIC_TOGGLED", "BIONIC_WEAPON" ],
+    "points": 2
   },
   {
     "id": "bio_cutting_torch",
@@ -282,7 +289,8 @@
     "enchantments": [ "C_ENCH_BIOPATTERN_DISTORTION" ],
     "act_cost": "1250 J",
     "react_cost": "1250 J",
-    "time": 1
+    "time": 1,
+    "points": 1
   },
   {
     "type": "enchantment",
@@ -317,7 +325,8 @@
     "name": { "str": "Sentinel Power Storage" },
     "capacity": "1000 kJ",
     "description": "An experimental and rare Compact Bionics Module that increases your power capacity by 1000 kJ.",
-    "flags": [ "BIONIC_NPC_USABLE", "MULTIINSTALL" ]
+    "flags": [ "BIONIC_NPC_USABLE", "MULTIINSTALL" ],
+    "points": 4
   },
   {
     "id": "bio_power_storage_sentinel",


### PR DESCRIPTION
Set aside for when https://github.com/cataclysmbn/Cataclysm-BN/pull/7651 is merged.
1. Allowed selecting all Cata++ bionics in Bio-Weapon Lab and Mycus bio-weapon scenario, and added smatterings of the new bionics to certain other scenarios too.
2. Added point costs to bionics, still not clear on good balance for CBM points but hopefully a good start.