### PR TITLE
Pending BN Feature: self-charging plutonium batteries using relic data

### DIFF
--- a/nocts_cata_mod_BN/Char_creation/c_classes_bw.json
+++ b/nocts_cata_mod_BN/Char_creation/c_classes_bw.json
@@ -3,19 +3,19 @@
     "type": "item_group",
     "subtype": "collection",
     "id": "c_plut_light",
-    "entries": [ { "item": "light_atomic_battery_cell_rechargeable", "ammo-item": "battery", "charges": [ 500, 1000 ] } ]
+    "entries": [ { "item": "light_atomic_battery_cell", "ammo-item": "battery", "charges": [ 500, 1000 ] } ]
   },
   {
     "type": "item_group",
     "subtype": "collection",
     "id": "c_plut_medium",
-    "entries": [ { "item": "medium_atomic_battery_cell_rechargeable", "ammo-item": "battery", "charges": [ 2500, 5000 ] } ]
+    "entries": [ { "item": "medium_atomic_battery_cell", "ammo-item": "battery", "charges": [ 2500, 5000 ] } ]
   },
   {
     "type": "item_group",
     "subtype": "collection",
     "id": "c_plut_heavy",
-    "entries": [ { "item": "heavy_atomic_battery_cell_rechargeable", "ammo-item": "battery", "charges": [ 5000, 10000 ] } ]
+    "entries": [ { "item": "heavy_atomic_battery_cell", "ammo-item": "battery", "charges": [ 5000, 10000 ] } ]
   },
   {
     "type": "profession",

--- a/nocts_cata_mod_BN/Monsters/c_monster_drops.json
+++ b/nocts_cata_mod_BN/Monsters/c_monster_drops.json
@@ -124,13 +124,7 @@
           {
             "collection": [
               { "item": "arc_laser_rifle", "damage": [ 0, 3 ], "charges": [ 0, 2500 ] },
-              {
-                "distribution": [
-                  { "item": "medium_atomic_battery_cell_rechargeable", "damage": [ 0, 1 ], "charges": [ 0, 5000 ], "prob": 50 },
-                  { "item": "medium_atomic_battery_cell", "damage": [ 0, 1 ], "charges": [ 0, 5000 ], "prob": 50 }
-                ],
-                "prob": 25
-              }
+              { "item": "medium_atomic_battery_cell", "damage": [ 0, 1 ], "charges": [ 0, 5000 ], "prob": 25 }
             ],
             "prob": 80
           },
@@ -178,13 +172,7 @@
           {
             "collection": [
               { "item": "xarm_laser_shotgun", "damage": [ 0, 3 ], "charges": [ 0, 2500 ] },
-              {
-                "distribution": [
-                  { "item": "medium_atomic_battery_cell_rechargeable", "damage": [ 0, 1 ], "charges": [ 0, 5000 ], "prob": 50 },
-                  { "item": "medium_atomic_battery_cell", "damage": [ 0, 1 ], "charges": [ 0, 5000 ], "prob": 50 }
-                ],
-                "prob": 25
-              }
+              { "item": "medium_atomic_battery_cell", "damage": [ 0, 1 ], "charges": [ 0, 5000 ], "prob": 25 }
             ],
             "prob": 80
           },
@@ -235,13 +223,7 @@
           {
             "collection": [
               { "item": "mx_laser_sniper", "damage": [ 0, 3 ], "charges": [ 0, 2500 ] },
-              {
-                "distribution": [
-                  { "item": "medium_atomic_battery_cell_rechargeable", "damage": [ 0, 1 ], "charges": [ 0, 5000 ], "prob": 50 },
-                  { "item": "medium_atomic_battery_cell", "damage": [ 0, 1 ], "charges": [ 0, 5000 ], "prob": 50 }
-                ],
-                "prob": 25
-              }
+              { "item": "medium_atomic_battery_cell", "damage": [ 0, 1 ], "charges": [ 0, 5000 ], "prob": 25 }
             ],
             "prob": 75
           },
@@ -293,13 +275,7 @@
           {
             "collection": [
               { "item": "krx_laser_lmg", "damage": [ 0, 3 ], "charges": [ 0, 5000 ] },
-              {
-                "distribution": [
-                  { "item": "heavy_atomic_battery_cell_rechargeable", "damage": [ 0, 1 ], "charges": [ 0, 10000 ], "prob": 50 },
-                  { "item": "heavy_atomic_battery_cell", "damage": [ 0, 1 ], "charges": [ 0, 10000 ], "prob": 50 }
-                ],
-                "prob": 25
-              }
+              { "item": "heavy_atomic_battery_cell", "damage": [ 0, 1 ], "charges": [ 0, 5000 ], "prob": 25 }
             ],
             "prob": 95
           },
@@ -381,9 +357,8 @@
               { "item": "neo_laser_pistol", "damage": [ 0, 3 ], "charges": [ 0, 250 ] },
               {
                 "distribution": [
-                  { "item": "light_atomic_battery_cell_rechargeable", "damage": [ 0, 1 ], "charges": [ 0, 1000 ], "prob": 50 },
-                  { "item": "light_atomic_battery_cell", "damage": [ 0, 1 ], "charges": [ 0, 1000 ], "prob": 25 },
-                  { "item": "light_minus_atomic_battery_cell", "damage": [ 0, 1 ], "charges": [ 0, 500 ], "prob": 25 }
+                  { "item": "light_atomic_battery_cell", "damage": [ 0, 1 ], "charges": [ 0, 1000 ], "prob": 50 },
+                  { "item": "light_minus_atomic_battery_cell", "damage": [ 0, 1 ], "charges": [ 0, 500 ], "prob": 50 }
                 ],
                 "prob": 25
               }
@@ -441,9 +416,8 @@
               { "item": "akro_laser_smg", "damage": [ 0, 3 ], "charges": [ 0, 500 ] },
               {
                 "distribution": [
-                  { "item": "light_atomic_battery_cell_rechargeable", "damage": [ 0, 1 ], "charges": [ 0, 1000 ], "prob": 50 },
-                  { "item": "light_atomic_battery_cell", "damage": [ 0, 1 ], "charges": [ 0, 1000 ], "prob": 25 },
-                  { "item": "light_minus_atomic_battery_cell", "damage": [ 0, 1 ], "charges": [ 0, 500 ], "prob": 25 }
+                  { "item": "light_atomic_battery_cell", "damage": [ 0, 1 ], "charges": [ 0, 1000 ], "prob": 50 },
+                  { "item": "light_minus_atomic_battery_cell", "damage": [ 0, 1 ], "charges": [ 0, 500 ], "prob": 50 }
                 ],
                 "prob": 25
               }
@@ -532,12 +506,7 @@
                 "distribution": [ { "item": "molle_pack", "damage": [ 1, 4 ], "prob": 50 }, { "item": "rucksack", "damage": [ 1, 4 ], "prob": 50 } ],
                 "prob": 50
               },
-              {
-                "item": "medium_atomic_battery_cell_rechargeable",
-                "damage": [ 0, 1 ],
-                "charges": [ 0, 5000 ],
-                "prob": 20
-              }
+              { "item": "medium_atomic_battery_cell", "damage": [ 0, 1 ], "charges": [ 0, 5000 ], "prob": 20 }
             ],
             "prob": 40
           },
@@ -552,7 +521,7 @@
               },
               {
                 "distribution": [
-                  { "item": "heavy_atomic_battery_cell_rechargeable", "damage": [ 0, 1 ], "charges": [ 0, 10000 ], "prob": 15 },
+                  { "item": "heavy_atomic_battery_cell", "damage": [ 0, 1 ], "charges": [ 0, 10000 ], "prob": 15 },
                   { "item": "plasma", "damage": [ 0, 1 ], "charges": [ 1, 2 ], "prob": 5 }
                 ],
                 "prob": 20
@@ -572,12 +541,7 @@
                 "distribution": [ { "item": "legrig", "damage": [ 1, 4 ], "prob": 50 }, { "item": "dump_pouch", "damage": [ 1, 4 ], "prob": 50 } ],
                 "prob": 50
               },
-              {
-                "item": "medium_atomic_battery_cell_rechargeable",
-                "damage": [ 0, 1 ],
-                "charges": [ 0, 5000 ],
-                "prob": 20
-              },
+              { "item": "medium_atomic_battery_cell", "damage": [ 0, 1 ], "charges": [ 0, 5000 ], "prob": 20 },
               { "item": "e_tool", "damage": [ 0, 3 ], "prob": 50 },
               { "item": "mre_beef_box", "damage": [ 0, 3 ], "prob": 75 },
               { "item": "large_tent_kit", "damage": [ 0, 3 ], "prob": 25 },
@@ -596,13 +560,8 @@
               },
               {
                 "distribution": [
-                  { "item": "light_atomic_battery_cell_rechargeable", "damage": [ 0, 1 ], "charges": [ 0, 500 ], "prob": 20 },
-                  {
-                    "item": "light_atomic_battery_cell_rechargeable",
-                    "damage": [ 0, 1 ],
-                    "charges": [ 500, 1000 ],
-                    "prob": 10
-                  }
+                  { "item": "light_atomic_battery_cell", "damage": [ 0, 1 ], "charges": [ 0, 1000 ], "prob": 50 },
+                  { "item": "light_minus_atomic_battery_cell", "damage": [ 0, 1 ], "charges": [ 0, 500 ], "prob": 50 }
                 ],
                 "prob": 20
               },

--- a/nocts_cata_mod_BN/Npc/NC_BIO_WEAPONS.json
+++ b/nocts_cata_mod_BN/Npc/NC_BIO_WEAPONS.json
@@ -44,12 +44,7 @@
     "subtype": "collection",
     "ammo": 100,
     "entries": [
-      {
-        "distribution": [
-          { "item": "medium_atomic_battery_cell", "prob": 50 },
-          { "item": "medium_atomic_battery_cell_rechargeable", "prob": 50 }
-        ]
-      },
+      { "item": "medium_atomic_battery_cell" },
       { "item": "mre_veggy_box" },
       { "group": "everyday_gear" },
       { "group": "drugs_soldier", "prob": 50 },

--- a/nocts_cata_mod_BN/Npc/NC_SUPER_SOLDIERS.json
+++ b/nocts_cata_mod_BN/Npc/NC_SUPER_SOLDIERS.json
@@ -31,19 +31,7 @@
     "entries": [
       { "item": "protein_bar_evac", "count": [ 4, 8 ] },
       { "item": "id_military" },
-      {
-        "distribution": [
-          { "item": "medium_atomic_battery_cell", "prob": 50 },
-          { "item": "medium_atomic_battery_cell_rechargeable", "prob": 50 }
-        ]
-      },
-      {
-        "distribution": [
-          { "item": "medium_atomic_battery_cell", "prob": 50 },
-          { "item": "medium_atomic_battery_cell_rechargeable", "prob": 50 }
-        ],
-        "prob": 50
-      }
+      { "item": "medium_atomic_battery_cell", "count": [ 1, 2 ] }
     ]
   },
   {
@@ -91,19 +79,10 @@
       { "item": "badge_bio_weapon_evy" },
       { "item": "mre_veggy_box" },
       { "item": "militarymap" },
-      { "group": "NC_BIO_HUNTER_E_battery", "count": [ 5, 10 ] },
+      { "item": "light_atomic_battery_cell", "count": [ 3, 6 ] },
       { "group": "everyday_gear" },
       { "group": "drugs_soldier", "prob": 50 },
       { "group": "supplies_electronics", "prob": 50, "count": [ 1, 3 ] }
-    ]
-  },
-  {
-    "id": "NC_BIO_HUNTER_E_battery",
-    "type": "item_group",
-    "subtype": "distribution",
-    "entries": [
-      { "item": "light_atomic_battery_cell", "prob": 50 },
-      { "item": "light_atomic_battery_cell_rechargeable", "prob": 50 }
     ]
   },
   {

--- a/nocts_cata_mod_BN/Recipe/c_uncraft.json
+++ b/nocts_cata_mod_BN/Recipe/c_uncraft.json
@@ -333,7 +333,7 @@
     "time": "50 m",
     "qualities": [ { "id": "SCREW_FINE", "level": 1 }, { "id": "SAW_M_FINE", "level": 1 }, { "id": "WRENCH_FINE", "level": 1 } ],
     "components": [
-      [ [ "light_atomic_battery_cell_rechargeable", 1 ] ],
+      [ [ "light_atomic_battery_cell", 1 ] ],
       [ [ "circuit", 4 ] ],
       [ [ "cable", 4 ] ],
       [ [ "plut_cell", 3 ] ],

--- a/nocts_cata_mod_BN/Weapons/c_magazines.json
+++ b/nocts_cata_mod_BN/Weapons/c_magazines.json
@@ -286,29 +286,5 @@
     "reliability": 5,
     "looks_like": "battery",
     "flags": [ "NO_SALVAGE", "NO_UNLOAD", "RECHARGE", "MAG_COMPACT" ]
-  },
-  {
-    "id": "light_atomic_battery_cell_rechargeable",
-    "copy-from": "light_atomic_battery_cell",
-    "type": "MAGAZINE",
-    "name": { "str": "light rechargeable plutonium cell" },
-    "description": "This battery uses a thin plutonium-244 rod to stabilize multiple proprietary exotic compounds.  Designed by Omnitech for a military contract, this modified plutonium battery is rechargeable, but as it made for military purposes there is very little this is compatible with.",
-    "extend": { "flags": [ "RECHARGE" ] }
-  },
-  {
-    "id": "medium_atomic_battery_cell_rechargeable",
-    "copy-from": "medium_atomic_battery_cell",
-    "type": "MAGAZINE",
-    "name": { "str": "medium rechargeable plutonium cell" },
-    "description": "This battery uses a thin plutonium-244 rod to stabilize multiple proprietary exotic compounds.  Designed by Omnitech for a military contract, this modified plutonium battery is rechargeable, but as it made for military purposes there is very little this is compatible with.",
-    "extend": { "flags": [ "RECHARGE" ] }
-  },
-  {
-    "id": "heavy_atomic_battery_cell_rechargeable",
-    "copy-from": "heavy_atomic_battery_cell",
-    "type": "MAGAZINE",
-    "name": { "str": "heavy rechargeable plutonium cell" },
-    "description": "This battery uses a thin plutonium-244 rod to stabilize multiple proprietary exotic compounds.  Designed by Omnitech for a military contract, this modified plutonium battery is rechargeable, but as it made for military purposes there is very little this is compatible with.",
-    "extend": { "flags": [ "RECHARGE" ] }
   }
 ]

--- a/nocts_cata_mod_BN/Weapons/c_ranged.json
+++ b/nocts_cata_mod_BN/Weapons/c_ranged.json
@@ -826,7 +826,7 @@
     "color": "dark_gray",
     "weapon_category": [ "PISTOLS", "ENERGY_WEAPONS" ],
     "name": { "str": "NEO-33 laser pistol" },
-    "description": "A relatively small laser pistol, boxy design having just enough concessions to ergonomics to fit well in the hand.  Its manufacturer is listed as Omnitech Labs.  Powered by atomic power cells or an experimental rechargeable version, for heavy use where a UPS would not be sustainable in the short term.",
+    "description": "A relatively small laser pistol, boxy design having just enough concessions to ergonomics to fit well in the hand.  Its manufacturer is listed as Omnitech Labs.  Powered by self-charging atomic power cells, for heavy use where a UPS would not be sustainable in the short term.",
     "price": "18000 USD",
     "price_postapoc": "60 USD",
     "material": [ "superalloy", "steel" ],
@@ -857,12 +857,7 @@
       [ "lens", 1 ]
     ],
     "magazine_well": "50 ml",
-    "magazines": [
-      [
-        "battery",
-        [ "light_minus_atomic_battery_cell", "light_atomic_battery_cell", "light_atomic_battery_cell_rechargeable" ]
-      ]
-    ]
+    "magazines": [ [ "battery", [ "light_minus_atomic_battery_cell", "light_atomic_battery_cell" ] ] ]
   },
   {
     "id": "neo_laser_pistol_ups",
@@ -909,7 +904,7 @@
     "color": "dark_gray",
     "weapon_category": [ "SUBMACHINE_GUNS", "ENERGY_WEAPONS" ],
     "name": { "str": "AKRO-388 laser SMG" },
-    "description": "Based on the design of the NEO-33, the AKRO-388 balances energy efficiency with rate of fire, offering decent firepower and handling like common submachineguns in active service.  Its manufacturer is listed as Omnitech Labs.  Powered by atomic power cells or an experimental rechargeable version, for heavy use where a UPS would not be sustainable in the short term.",
+    "description": "Based on the design of the NEO-33, the AKRO-388 balances energy efficiency with rate of fire, offering decent firepower and handling like common submachineguns in active service.  Its manufacturer is listed as Omnitech Labs.  Powered by self-charging atomic power cells, for heavy use where a UPS would not be sustainable in the short term.",
     "price": "18000 USD",
     "price_postapoc": "60 USD",
     "material": [ "superalloy", "steel" ],
@@ -942,12 +937,7 @@
       [ "lens", 1 ]
     ],
     "magazine_well": "50 ml",
-    "magazines": [
-      [
-        "battery",
-        [ "light_atomic_battery_cell", "light_minus_atomic_battery_cell", "light_atomic_battery_cell_rechargeable" ]
-      ]
-    ]
+    "magazines": [ [ "battery", [ "light_atomic_battery_cell", "light_minus_atomic_battery_cell" ] ] ]
   },
   {
     "id": "akro_laser_smg_ups",
@@ -996,7 +986,7 @@
     "looks_like": "laser_rifle",
     "weapon_category": [ "RIFLES", "ENERGY_WEAPONS" ],
     "name": { "str": "ARC-314 laser rifle" },
-    "description": "An experimental laser rifle based on the A7 and AKRO-388, offering the handling of a modern combat rifle with the efficiency of a laser weapon, in a relatively compact package.  The manufacturer is listed as Omnitech Labs.  Powered by atomic power cells or an experimental rechargeable version, for heavy use where a UPS would not be sustainable in the short term.",
+    "description": "An experimental laser rifle based on the A7 and AKRO-388, offering the handling of a modern combat rifle with the efficiency of a laser weapon, in a relatively compact package.  The manufacturer is listed as Omnitech Labs.  Powered by self-charging atomic power cells, for heavy use where a UPS would not be sustainable in the short term.",
     "price": "18000 USD",
     "price_postapoc": "60 USD",
     "material": [ "superalloy", "steel" ],
@@ -1029,7 +1019,7 @@
       [ "lens", 1 ]
     ],
     "magazine_well": "300 ml",
-    "magazines": [ [ "battery", [ "medium_atomic_battery_cell", "medium_atomic_battery_cell_rechargeable" ] ] ]
+    "magazines": [ [ "battery", [ "medium_atomic_battery_cell" ] ] ]
   },
   {
     "id": "arc_laser_rifle_ups",
@@ -1078,7 +1068,7 @@
     "color": "dark_gray",
     "weapon_category": [ "MACHINE_GUNS", "ENERGY_WEAPONS" ],
     "name": { "str": "KRX-108 laser LMG" },
-    "description": "With the power per shot of the ARC and the firerate of the AKRO, Omnitech Labs' KRX-108 was made to overwhelm enemies with supreme firepower.  While not very energy-efficient, this behemoth can deal a devastating blow to large groups of enemies.  The manufacturer is listed as Omnitech Labs.  Powered by atomic power cells or an experimental rechargeable version, for heavy use where a UPS would not be sustainable in the short term.",
+    "description": "With the power per shot of the ARC and the firerate of the AKRO, Omnitech Labs' KRX-108 was made to overwhelm enemies with supreme firepower.  While not very energy-efficient, this behemoth can deal a devastating blow to large groups of enemies.  The manufacturer is listed as Omnitech Labs.  Powered by self-charging atomic power cells, for heavy use where a UPS would not be sustainable in the short term.",
     "price": "18000 USD",
     "price_postapoc": "60 USD",
     "material": [ "superalloy", "steel" ],
@@ -1110,7 +1100,7 @@
       [ "lens", 1 ]
     ],
     "magazine_well": "600 ml",
-    "magazines": [ [ "battery", [ "heavy_atomic_battery_cell", "heavy_atomic_battery_cell_rechargeable" ] ] ]
+    "magazines": [ [ "battery", [ "heavy_atomic_battery_cell" ] ] ]
   },
   {
     "id": "krx_laser_lmg_ups",
@@ -1157,7 +1147,7 @@
     "color": "dark_gray",
     "weapon_category": [ "RIFLES", "ENERGY_WEAPONS" ],
     "name": { "str": "MX-84 laser sniper" },
-    "description": "An accurized, long-range laser rifle, designed to deal massive damage to a single target.  Intended to be used as a long-range support weapon by modern special forces.  Requires an insane amount of energy to fire a single powerful laser, additionally providing EMP effects.  The manufacturer is listed as Omnitech Labs.  Powered by atomic power cells or an experimental rechargeable version, for heavy use where a UPS would not be sustainable in the short term.",
+    "description": "An accurized, long-range laser rifle, designed to deal massive damage to a single target.  Intended to be used as a long-range support weapon by modern special forces.  Requires an insane amount of energy to fire a single powerful laser, additionally providing EMP effects.  The manufacturer is listed as Omnitech Labs.  Powered by self-charging atomic power cells, for heavy use where a UPS would not be sustainable in the short term.",
     "price": "18000 USD",
     "price_postapoc": "60 USD",
     "material": [ "superalloy", "steel" ],
@@ -1189,17 +1179,7 @@
       [ "lens", 1 ]
     ],
     "magazine_well": "300 ml",
-    "magazines": [
-      [
-        "battery",
-        [
-          "medium_atomic_battery_cell",
-          "heavy_atomic_battery_cell",
-          "medium_atomic_battery_cell_rechargeable",
-          "heavy_atomic_battery_cell_rechargeable"
-        ]
-      ]
-    ]
+    "magazines": [ [ "battery", [ "medium_atomic_battery_cell", "heavy_atomic_battery_cell" ] ] ]
   },
   {
     "id": "mx_laser_sniper_ups",
@@ -1247,7 +1227,7 @@
     "color": "dark_gray",
     "weapon_category": [ "SHOTGUNS", "ENERGY_WEAPONS" ],
     "name": { "str": "XARM-37 pulse scattergun" },
-    "description": "This is an ARC rifle modified into something resembling a double-barrel shotgun.  It fires short-range EMP pulses; still decent against conventional threats but best against electronics.  The manufacturer is listed as Omnitech Labs.  Powered by atomic power cells or an experimental rechargeable version, for heavy use where a UPS would not be sustainable in the short term.",
+    "description": "This is an ARC rifle modified into something resembling a double-barrel shotgun.  It fires short-range EMP pulses; still decent against conventional threats but best against electronics.  The manufacturer is listed as Omnitech Labs.  Powered by self-charging atomic power cells, for heavy use where a UPS would not be sustainable in the short term.",
     "price": "18000 USD",
     "price_postapoc": "60 USD",
     "material": [ "superalloy", "steel" ],
@@ -1281,7 +1261,7 @@
       [ "lens", 1 ]
     ],
     "magazine_well": "300 ml",
-    "magazines": [ [ "battery", [ "medium_atomic_battery_cell", "medium_atomic_battery_cell_rechargeable" ] ] ]
+    "magazines": [ [ "battery", [ "medium_atomic_battery_cell" ] ] ]
   },
   {
     "id": "xarm_laser_shotgun_ups",

--- a/nocts_cata_mod_BN/legacy.json
+++ b/nocts_cata_mod_BN/legacy.json
@@ -1015,5 +1015,20 @@
     "extra_effects": [ { "id": "c_biostim_pain", "hit_self": true }, { "id": "c_hemo_damage", "hit_self": true } ],
     "min_duration": 1,
     "max_duration": 1
+  },
+  {
+    "id": "light_atomic_battery_cell_rechargeable",
+    "type": "MIGRATION",
+    "replace": "light_atomic_battery_cell"
+  },
+  {
+    "id": "medium_atomic_battery_cell_rechargeable",
+    "type": "MIGRATION",
+    "replace": "medium_atomic_battery_cell"
+  },
+  {
+    "id": "heavy_atomic_battery_cell_rechargeable",
+    "type": "MIGRATION",
+    "replace": "heavy_atomic_battery_cell"
   }
 ]


### PR DESCRIPTION
Lil thing set aside for when https://github.com/cataclysmbn/Cataclysm-BN/pull/7934 is merged. Now that regular plutonium batteries are going to be self-charging via relic data, the rechargeable batteries in the mod have served their purpose and can be phased out in favor of exclusively using the relevant vanilla ones.

<img width="859" height="326" alt="image" src="https://github.com/user-attachments/assets/e865371d-371a-4adb-bab5-53b91d0b2ad8" />