### PR TITLE
BN Update: plutonium batteries start empty but can be uncrafted

### DIFF
--- a/nocts_cata_mod_BN/Npc/NC_BIO_WEAPONS.json
+++ b/nocts_cata_mod_BN/Npc/NC_BIO_WEAPONS.json
@@ -44,7 +44,7 @@
     "subtype": "collection",
     "ammo": 100,
     "entries": [
-      { "item": "medium_atomic_battery_cell" },
+      { "item": "medium_atomic_battery_cell", "charges": 5000 },
       { "item": "mre_veggy_box" },
       { "group": "everyday_gear" },
       { "group": "drugs_soldier", "prob": 50 },

--- a/nocts_cata_mod_BN/Npc/NC_SUPER_SOLDIERS.json
+++ b/nocts_cata_mod_BN/Npc/NC_SUPER_SOLDIERS.json
@@ -31,7 +31,7 @@
     "entries": [
       { "item": "protein_bar_evac", "count": [ 4, 8 ] },
       { "item": "id_military" },
-      { "item": "medium_atomic_battery_cell", "count": [ 1, 2 ] }
+      { "item": "medium_atomic_battery_cell", "count": [ 1, 2 ], "charges": 5000 }
     ]
   },
   {
@@ -79,7 +79,7 @@
       { "item": "badge_bio_weapon_evy" },
       { "item": "mre_veggy_box" },
       { "item": "militarymap" },
-      { "item": "light_atomic_battery_cell", "count": [ 3, 6 ] },
+      { "item": "light_atomic_battery_cell", "count": [ 3, 6 ], "charges": 1000 },
       { "group": "everyday_gear" },
       { "group": "drugs_soldier", "prob": 50 },
       { "group": "supplies_electronics", "prob": 50, "count": [ 1, 3 ] }


### PR DESCRIPTION
Update warranted by https://github.com/cataclysmbn/Cataclysm-BN/pull/7944 which makes plutonium batteries default to not starting full (so they can be disassembled), so sets spawns where relevant to specify charges as needed. Simple change that doesn't hinge on the PR and really change anything beyond some slight redundancy if the PR gets rejected, so can be merged early.