### PR TITLE
Pending BN Update: microreactor reflavored as atomic battery

### DIFF
--- a/nocts_cata_mod_BN/Char_creation/c_classes_bw.json
+++ b/nocts_cata_mod_BN/Char_creation/c_classes_bw.json
@@ -289,7 +289,7 @@
       { "level": 3, "name": "speech" }
     ],
     "CBMs": [
-      "bio_reactor",
+      "bio_atomic_battery",
       "bio_int_enhancer",
       "bio_eye_enhancer",
       "bio_animal_empathy",

--- a/nocts_cata_mod_BN/Char_creation/c_classes_r.json
+++ b/nocts_cata_mod_BN/Char_creation/c_classes_r.json
@@ -190,7 +190,7 @@
       "bio_ads",
       "bio_alarm",
       "bio_cloak",
-      "bio_reactor",
+      "bio_atomic_battery",
       "bio_fingerhack",
       "bio_lockpick",
       "bio_metabolics",

--- a/nocts_cata_mod_BN/legacy.json
+++ b/nocts_cata_mod_BN/legacy.json
@@ -1030,39 +1030,5 @@
     "id": "heavy_atomic_battery_cell_rechargeable",
     "type": "MIGRATION",
     "replace": "heavy_atomic_battery_cell"
-  },
-  {
-    "type": "GENERIC",
-    "//": "pseudo item, used as fuel type for atomic battery CBM",
-    "id": "c_atomic_battery_power",
-    "symbol": "?",
-    "color": "white",
-    "name": { "str": "Alphavoltaic Power", "str_pl": "none" },
-    "description": "seeing this is a bug",
-    "stackable": true,
-    "volume": "0 ml",
-    "flags": [ "PSEUDO", "PERPETUAL" ],
-    "fuel": { "energy": 1 }
-  },
-  {
-    "id": "bio_atomic_battery",
-    "type": "bionic",
-    "name": { "str": "Atomic Battery" },
-    "description": "Your body has been implanted with a compact, advanced plutonium-cell generator for military use.  A true atomic battery, using advanced materials to create a practical alphavoltaic power source.  While its power output is still very low, it's also consistent with negligible waste heat, making it a useful backup to another power generation method.",
-    "fuel_options": [ "c_atomic_battery_power" ],
-    "fuel_efficiency": 0.005,
-    "time": 1,
-    "occupied_bodyparts": [ [ "torso", 10 ] ],
-    "flags": [ "BIONIC_TOGGLED", "BIONIC_POWER_SOURCE", "BIONIC_NPC_USABLE", "BIONIC_SHOCKPROOF", "INITIALLY_ACTIVATE" ],
-    "points": 2
-  },
-  {
-    "id": "bio_atomic_battery",
-    "copy-from": "bionic_general_npc_usable",
-    "type": "BIONIC_ITEM",
-    "name": { "str": "Atomic Battery CBM" },
-    "description": "An old form of non-thermal radioisotope generator, given new life and military applications using cutting-edge plutonium-catalyst developments.  Effectively a plutonium fuel cell converted into an alphavoltaic battery, with greater power output and longevity than older implants.  Its output is still very low at only 5 watts, but it also provides a continuous source of power, making it a good supplement to a more intensive power generation method.",
-    "price": "8000 USD",
-    "difficulty": 8
   }
 ]


### PR DESCRIPTION
Set aside for when https://github.com/cataclysmbn/Cataclysm-BN/pull/7954 is merged, phases out the atomic battery CBM since it's being mainlined in that PR.