### PR TITLE
Pending BN Update: changes to bionic weapons

### DIFF
--- a/nocts_cata_mod_BN/Surv_help/c_bionics.json
+++ b/nocts_cata_mod_BN/Surv_help/c_bionics.json
@@ -57,6 +57,15 @@
     "techniques": [ "RAPID", "WBLOCK_2" ],
     "volume": "2250 ml",
     "cutting": 48,
+    "attacks": [
+      {
+        "id": "STRIKE",
+        "to_hit": 3,
+        "damage": {
+          "values": [ { "damage_type": "cut", "amount": 48, "armor_penetration": 34 } ]
+        }
+      }
+    ],
     "flags": [ "NO_UNWIELD", "NO_DROP", "UNBREAKABLE_MELEE", "TRADER_AVOID" ],
     "qualities": [ [ "CUT", 1 ], [ "BUTCHER", 20 ] ]
   },

--- a/nocts_cata_mod_BN/Weapons/c_melee.json
+++ b/nocts_cata_mod_BN/Weapons/c_melee.json
@@ -15,9 +15,15 @@
     "looks_like": "bio_blade_weapon",
     "material": [ "superalloy", "steel" ],
     "techniques": [ "WBLOCK_2" ],
-    "bashing": 4,
-    "cutting": 32,
-    "to_hit": 2,
+    "attacks": [
+      {
+        "id": "STRIKE",
+        "to_hit": 2,
+        "damage": {
+          "values": [ { "damage_type": "bash", "amount": 4 }, { "damage_type": "cut", "amount": 32, "armor_penetration": 16 } ]
+        }
+      }
+    ],
     "flags": [ "UNBREAKABLE_MELEE", "SHEATH_KNIFE" ],
     "qualities": [ [ "CUT", 1 ], [ "BUTCHER", 22 ] ],
     "gunmod_data": {
@@ -43,9 +49,15 @@
     "looks_like": "bio_sword_weapon",
     "material": [ "superalloy", "steel" ],
     "techniques": [ "RAPID", "WBLOCK_2" ],
-    "bashing": 4,
-    "cutting": 44,
-    "to_hit": 2,
+    "attacks": [
+      {
+        "id": "STRIKE",
+        "to_hit": 2,
+        "damage": {
+          "values": [ { "damage_type": "bash", "amount": 4 }, { "damage_type": "cut", "amount": 44, "armor_penetration": 32 } ]
+        }
+      }
+    ],
     "flags": [ "UNBREAKABLE_MELEE", "SHEATH_SWORD" ],
     "qualities": [ [ "CUT", 1 ], [ "BUTCHER", 20 ] ],
     "gunmod_data": {
@@ -62,7 +74,6 @@
     "weapon_category": [ "BIONIC_WEAPONRY", "FIST_WEAPONS" ],
     "name": { "str_sp": "repurposed bionic claws" },
     "description": "Short and sharp claws made from a high-tech metal edged with bonded nanocrystals, salvaged from a CBM and welded to metal knuckles.  Lightweight and fast, wielding them feels as if you were bare-handed.",
-    "to_hit": 2,
     "weight": "200 g",
     "volume": "500 ml",
     "price": "400 USD",
@@ -71,8 +82,15 @@
     "symbol": "{",
     "looks_like": "bio_claws_weapon",
     "material": [ "superalloy", "steel" ],
-    "bashing": 14,
-    "cutting": 18,
+    "attacks": [
+      {
+        "id": "STRIKE",
+        "to_hit": 2,
+        "damage": {
+          "values": [ { "damage_type": "bash", "amount": 4 }, { "damage_type": "stab", "amount": 18, "armor_penetration": 19 } ]
+        }
+      }
+    ],
     "flags": [ "STAB", "UNARMED_WEAPON", "UNBREAKABLE_MELEE" ],
     "qualities": [ [ "CUT", 1 ], [ "BUTCHER", 12 ] ]
   },
@@ -82,7 +100,16 @@
     "type": "GENERIC",
     "name": { "str": "repurposed bionic whip" },
     "description": "A long, sharp thread of high-tech material with a small counterweight at the end, salvaged from a CBM.  A metal handle has been welded on to make it actually feasible to use without being more of a danger to the wielder.",
-    "relative": { "weight": "150 g", "to_hit": -1, "bashing": 4, "cutting": -4 },
+    "relative": { "weight": "150 g" },
+    "attacks": [
+      {
+        "id": "STRIKE",
+        "to_hit": 2,
+        "damage": {
+          "values": [ { "damage_type": "bash", "amount": 4 }, { "damage_type": "cut", "amount": 24, "armor_penetration": 22 } ]
+        }
+      }
+    ],
     "price": "60 USD",
     "price_postapoc": "20 USD",
     "extend": { "flags": [ "BELT_CLIP" ] },


### PR DESCRIPTION
Set aside for when https://github.com/cataclysmbn/Cataclysm-BN/pull/9206 is merged, updates bionic sword and repurposed bionic melee weapons to get the standard "10 plus 50% of total cut/stab damage" they get as of that PR. Needed also to fix repurposed whip so it doesn't error from trying to drive legacy values below zero.