### PR TITLE
Pending BN Update: Carry Permit trait

### DIFF
--- a/nocts_cata_mod_BN/Char_creation/c_scenarios.json
+++ b/nocts_cata_mod_BN/Char_creation/c_scenarios.json
@@ -11,7 +11,7 @@
     "allowed_locs": [ "Bio_Weapon_Lab_l" ],
     "professions": [ "bio_weapon_a", "bio_weapon_b", "bio_weapon_g", "bio_weapon_d", "failed_weapon_scen" ],
     "traits": [ "MARTIAL_ARTS_MUT_COM", "MARTIAL_ARTS_BIOJUTSU" ],
-    "forbidden_traits": [ "GOURMAND", "PARKOUR", "SPIRITUAL", "STYLISH", "HOARDER", "NOMAD", "PACIFIST", "WAYFARER" ],
+    "forbidden_traits": [ "GOURMAND", "PARKOUR", "SPIRITUAL", "STYLISH", "HOARDER", "NOMAD", "PACIFIST", "WAYFARER", "CARRY_PERMIT" ],
     "bionics": [
       "bio_laser_armgun",
       "bio_sword",
@@ -35,7 +35,7 @@
     "allowed_locs": [ "sloc_forest", "sloc_field" ],
     "professions": [ "mycus_weapon" ],
     "traits": [ "MARTIAL_ARTS_MUT_COM", "MARTIAL_ARTS_BIOJUTSU" ],
-    "forbidden_traits": [ "GOURMAND", "PARKOUR", "SPIRITUAL", "STYLISH", "HOARDER", "NOMAD", "PACIFIST", "TABLEMANNERS", "WAYFARER" ],
+    "forbidden_traits": [ "GOURMAND", "PARKOUR", "SPIRITUAL", "STYLISH", "HOARDER", "NOMAD", "PACIFIST", "TABLEMANNERS", "WAYFARER", "CARRY_PERMIT" ],
     "bionics": [
       "bio_laser_armgun",
       "bio_sword",
@@ -136,6 +136,8 @@
       "LARGE",
       "MARTIAL_ARTS_MUT_COM"
     ],
+    "//": "You'll to scramble for a half-loaded gun off the arena floor like a good little gladiator.",
+    "forbidden_traits": [ "CARRY_PERMIT" ],
     "professions": [ "sf_blade", "sf_claw", "sf_shock", "sf_weapon" ],
     "bionics": [ "bio_laser_armgun", "bio_sword", "bio_flamethrower", "bio_hazard_shield" ]
   },

--- a/nocts_cata_mod_BN/Char_creation/c_scenarios.json
+++ b/nocts_cata_mod_BN/Char_creation/c_scenarios.json
@@ -35,7 +35,18 @@
     "allowed_locs": [ "sloc_forest", "sloc_field" ],
     "professions": [ "mycus_weapon" ],
     "traits": [ "MARTIAL_ARTS_MUT_COM", "MARTIAL_ARTS_BIOJUTSU" ],
-    "forbidden_traits": [ "GOURMAND", "PARKOUR", "SPIRITUAL", "STYLISH", "HOARDER", "NOMAD", "PACIFIST", "TABLEMANNERS", "WAYFARER", "CARRY_PERMIT" ],
+    "forbidden_traits": [
+      "GOURMAND",
+      "PARKOUR",
+      "SPIRITUAL",
+      "STYLISH",
+      "HOARDER",
+      "NOMAD",
+      "PACIFIST",
+      "TABLEMANNERS",
+      "WAYFARER",
+      "CARRY_PERMIT"
+    ],
     "bionics": [
       "bio_laser_armgun",
       "bio_sword",


### PR DESCRIPTION
Set aside for when https://github.com/cataclysmbn/Cataclysm-BN/pull/9312 is merged. Locks you out of the Carry Permit trait when doing the Bio-Weapon Lab or Mycus BWMD scenarios. Bio-weapons who show up in non-restricted vanilla scenarios are free to pretend they earned their license and didn't just loot their gun off a dead guy sometime before game start, however. Also locked Slave Fighter's Freedom out of the trait since the gladiators are typically given makeshift melee weapons with the hope of scrounging a cheap zip gun littered around the arena, not walking around with an EDC piece just waiting to be a pain in the ass for their handlers.