### PR TITLE
fix: move ARMOR_ELEC to ARMOR_ELECTRIC for #9450

### DIFF
--- a/nocts_cata_mod_BN/Surv_help/c_armor.json
+++ b/nocts_cata_mod_BN/Surv_help/c_armor.json
@@ -831,7 +831,7 @@
             { "value": "STRENGTH", "add": 2 },
             { "value": "DEXTERITY", "add": 1 },
             { "value": "ATTACK_COST", "multiply": -0.25 },
-            { "value": "ARMOR_ELEC", "multiply": 0.5 }
+            { "value": "ARMOR_ELECTRIC", "multiply": 0.5 }
           ],
           "ench_effects": [ { "effect": "c_mi_go_carapace_stamina", "intensity": 1 } ],
           "mutations": [ "C_MIGO_HEAT_BONUS" ]


### PR DESCRIPTION
Fix for issues caused by https://github.com/cataclysmbn/Cataclysm-BN/pull/9450