### PR TITLE
Remove Shot_HE from loot pool

### DIFF
--- a/nocts_cata_mod_DDA/Terrain/Mapgen_Variants.json
+++ b/nocts_cata_mod_DDA/Terrain/Mapgen_Variants.json
@@ -148,7 +148,6 @@
         { "item": "shot_00", "x": 22, "y": 10, "chance": 75, "repeat": 10 },
         { "item": "shot_slug", "x": 22, "y": 10, "chance": 75, "repeat": 5 },
         { "item": "shot_beanbag", "x": 22, "y": 10, "chance": 75, "repeat": 3 },
-        { "item": "shot_he", "x": 22, "y": 10, "chance": 75, "repeat": 5 },
         { "item": "shot_flechette", "x": 22, "y": 10, "chance": 75, "repeat": 5 },
         { "item": "762_51_incendiary", "x": 22, "y": 11, "chance": 75, "repeat": 5 },
         { "item": "762_51", "x": 22, "y": [ 11, 12 ], "chance": 75, "repeat": 30 },


### PR DESCRIPTION
Recent CDDA Experimental has removed the SHOT_HE completely. Since it is no longer available, SHOT_HE throws a json error due to existing in the CATA++ loot pool for a mapgen location.

This PR is to remove it from the LootPool