### PR TITLE
Pending BN Update: changes to CVD machine

### DIFF
--- a/nocts_cata_mod_BN/Terrain/Unknown_Lab.json
+++ b/nocts_cata_mod_BN/Terrain/Unknown_Lab.json
@@ -686,7 +686,7 @@
         "6": "t_console_broken",
         "C": "t_metal_floor",
         "D": "t_cvdbody",
-        "E": "t_cvdmachine",
+        "E": "t_metal_floor",
         "F": "t_metal_floor",
         "I": "t_reinforced_glass",
         "P": "t_plut_generator",
@@ -703,6 +703,7 @@
       "furniture": {
         "{": "f_locker",
         "C": "f_counter",
+        "E": "t_cvdmachine",
         "F": "f_fridge",
         "T": "f_trashcan",
         "c": "f_chair",


### PR DESCRIPTION
Set aside for when https://github.com/cataclysmbn/Cataclysm-BN/pull/9896 is merged, for now just updates the CVD machine in the Unknown Lab to use the new furniture variant.