### PR TITLE
Pending BN Update: `absolute_spawn_loc` usage

### DIFF
--- a/nocts_cata_mod_BN/Char_creation/c_start_locations.json
+++ b/nocts_cata_mod_BN/Char_creation/c_start_locations.json
@@ -24,7 +24,8 @@
     "type": "start_location",
     "id": "Bio_Weapon_Lab_l",
     "name": "Bio Weapon Lab",
-    "terrain": [ "Bio_Weapon_Lab_b" ]
+    "terrain": [ "Bio_Weapon_Lab_b" ],
+    "absolute_place_location": { "x": 0, "y": 1 }
   },
   {
     "type": "start_location",
@@ -44,7 +45,8 @@
     "id": "makeshift_command_center_1",
     "name": "Makeshift Command Center",
     "terrain": [ "makeshift_command_center_1" ],
-    "flags": [ "ALLOW_OUTSIDE" ]
+    "flags": [ "ALLOW_OUTSIDE" ],
+    "absolute_place_location": { "x": -1, "y": 1 }
   },
   {
     "type": "start_location",
@@ -52,7 +54,8 @@
     "//": "This versions is for the super soldier start, places them in the outdoors section.",
     "name": "Bio Weapon Lab",
     "terrain": [ "Bio_Weapon_Lab_1" ],
-    "flags": [ "ALLOW_OUTSIDE" ]
+    "flags": [ "ALLOW_OUTSIDE" ],
+    "absolute_place_location": { "x": 0, "y": 1 }
   },
   {
     "type": "start_location",

--- a/nocts_cata_mod_BN/Terrain/overmap_special.json
+++ b/nocts_cata_mod_BN/Terrain/overmap_special.json
@@ -106,7 +106,8 @@
     "locations": [ "wilderness" ],
     "city_distance": [ 20, -1 ],
     "city_sizes": [ 0, 16 ],
-    "occurrences": [ 75, 100 ],
+    "occurrences": [ 1, 1 ],
+    "absolute_spawn_loc": { "x": 0, "y": 1 },
     "flags": [ "CLASSIC", "GLOBALLY_UNIQUE", "ELECTRIC_GRID", "FLUID_GRID" ]
   },
   {
@@ -129,7 +130,8 @@
     "locations": [ "wilderness", "swamp" ],
     "city_distance": [ 20, -1 ],
     "city_sizes": [ 0, 16 ],
-    "occurrences": [ 75, 100 ],
+    "occurrences": [ 1, 1 ],
+    "absolute_spawn_loc": { "x": 1, "y": 1 },
     "flags": [ "CLASSIC", "GLOBALLY_UNIQUE", "ELECTRIC_GRID", "FLUID_GRID" ]
   },
   {
@@ -145,7 +147,8 @@
     "locations": [ "wilderness" ],
     "city_distance": [ 20, -1 ],
     "city_sizes": [ 0, 16 ],
-    "occurrences": [ 75, 100 ],
+    "occurrences": [ 1, 1 ],
+    "absolute_spawn_loc": { "x": -1, "y": 1 },
     "flags": [ "CLASSIC", "GLOBALLY_UNIQUE", "ELECTRIC_GRID", "FLUID_GRID" ]
   },
   {


### PR DESCRIPTION
Draft PR that follows up on https://github.com/cataclysmbn/Cataclysm-BN/pull/10133, set aside for after https://github.com/cataclysmbn/Cataclysm-BN/pull/10157 is merged.

1. Gave the bio-weapon lab `absolute_spawn_loc` of [0, 1], placing it south of the refugee center.
2. Gave the makeshift command center `absolute_spawn_loc` of [-1, 1], placing it southwest of the refugee center.
3. Gave the unknown lab `absolute_spawn_loc` of [1, 1], placing it southeast of the refugee center.
4. Added `absolute_place_location` to relevant starting locations.